### PR TITLE
Update to Flecs 4.0.4

### DIFF
--- a/libs/flecs/flecs.c
+++ b/libs/flecs/flecs.c
@@ -295,11 +295,15 @@ void flecs_bitset_swap(
 typedef struct ecs_table_diff_builder_t {
     ecs_vec_t added;
     ecs_vec_t removed;
+    ecs_flags32_t added_flags;
+    ecs_flags32_t removed_flags;
 } ecs_table_diff_builder_t;
 
 typedef struct ecs_table_diff_t {
     ecs_type_t added;                /* Components added between tables */
     ecs_type_t removed;              /* Components removed between tables */
+    ecs_flags32_t added_flags;
+    ecs_flags32_t removed_flags;
 } ecs_table_diff_t;
 
 /** Edge linked list (used to keep track of incoming edges) */
@@ -313,7 +317,7 @@ typedef struct ecs_graph_edge_t {
     ecs_graph_edge_hdr_t hdr;
     ecs_table_t *from;               /* Edge source table */
     ecs_table_t *to;                 /* Edge destination table */
-    ecs_table_diff_t *diff;          /* Index into diff vector, if non trivial edge */
+    ecs_table_diff_t *diff;          /* Added/removed components for edge */
     ecs_id_t id;                     /* Id associated with edge */
 } ecs_graph_edge_t;
 
@@ -380,6 +384,12 @@ void flecs_table_diff_build(
 void flecs_table_diff_build_noalloc(
     ecs_table_diff_builder_t *builder,
     ecs_table_diff_t *diff);
+
+void flecs_table_edges_add_flags(
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_id_t id,
+    ecs_flags32_t flags);
 
 #endif
 
@@ -630,6 +640,7 @@ void flecs_table_mark_dirty(
 void flecs_table_notify(
     ecs_world_t *world,
     ecs_table_t *table,
+    ecs_id_t id,
     ecs_table_event_t *event);
 
 void flecs_table_delete_entities(
@@ -1243,7 +1254,9 @@ void flecs_init_id_records(
 void flecs_fini_id_records(
     ecs_world_t *world);
 
-ecs_id_t flecs_id_record_hash(
+/* Return flags for matching id records */
+ecs_flags32_t flecs_id_flags_get(
+    ecs_world_t *world,
     ecs_id_t id);
 
 #endif
@@ -1303,16 +1316,13 @@ extern char *flecs_this_name_array;
 /* -- Instruction kinds -- */
 typedef enum {
     EcsQueryAnd,            /* And operator: find or match id against variable source */
-    EcsQueryAndId,          /* And operator for fixed id (no wildcards/variables) */
     EcsQueryAndAny,         /* And operator with support for matching Any src/id */
     EcsQueryOnlyAny,        /* Dedicated instruction for _ queries where the src is unknown */
     EcsQueryTriv,           /* Trivial search (batches multiple terms) */
     EcsQueryCache,          /* Cached search */
     EcsQueryIsCache,        /* Cached search for queries that are entirely cached */
     EcsQueryUp,             /* Up traversal */
-    EcsQueryUpId,           /* Up traversal for fixed id (like AndId) */
     EcsQuerySelfUp,         /* Self|up traversal */
-    EcsQuerySelfUpId,       /* Self|up traversal for fixed id (like AndId) */
     EcsQueryWith,           /* Match id against fixed or variable source */
     EcsQueryTrav,           /* Support for transitive/reflexive queries */
     EcsQueryAndFrom,        /* AndFrom operator */
@@ -2174,41 +2184,28 @@ bool flecs_query_select(
     bool redo,
     const ecs_query_run_ctx_t *ctx);
 
+bool flecs_query_select_id(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    ecs_flags32_t table_filter);
+
+bool flecs_query_with(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx);
+
+bool flecs_query_with_id(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx);
+
 bool flecs_query_select_w_id(
     const ecs_query_op_t *op,
     bool redo,
     const ecs_query_run_ctx_t *ctx,
     ecs_id_t id,
     ecs_flags32_t filter_mask);
-
-typedef enum ecs_query_up_select_trav_kind_t {
-    FlecsQueryUpSelectUp,
-    FlecsQueryUpSelectSelfUp
-} ecs_query_up_select_trav_kind_t;
-
-typedef enum ecs_query_up_select_kind_t {
-    FlecsQueryUpSelectDefault,
-    FlecsQueryUpSelectId,
-    FlecsQueryUpSelectUnion
-} ecs_query_up_select_kind_t;
-
-bool flecs_query_up_select(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx,
-    ecs_query_up_select_trav_kind_t trav_kind,
-    ecs_query_up_select_kind_t kind);
-
-bool flecs_query_up_with(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx);
-
-bool flecs_query_self_up_with(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx,
-    bool id_only);
 
 
 /* Union evaluation */
@@ -2308,6 +2305,38 @@ bool flecs_query_member_neq(
     const ecs_query_op_t *op,
     bool redo,
     ecs_query_run_ctx_t *ctx);
+
+
+/* Up traversal */
+
+typedef enum ecs_query_up_select_trav_kind_t {
+    FlecsQueryUpSelectUp,
+    FlecsQueryUpSelectSelfUp
+} ecs_query_up_select_trav_kind_t;
+
+typedef enum ecs_query_up_select_kind_t {
+    FlecsQueryUpSelectDefault,
+    FlecsQueryUpSelectId,
+    FlecsQueryUpSelectUnion
+} ecs_query_up_select_kind_t;
+
+bool flecs_query_up_select(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    ecs_query_up_select_trav_kind_t trav_kind,
+    ecs_query_up_select_kind_t kind);
+
+bool flecs_query_up_with(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx);
+
+bool flecs_query_self_up_with(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    bool id_only);
 
 
 /* Transitive relationship traversal */
@@ -3022,7 +3051,7 @@ void flecs_notify_on_remove(
     ecs_table_t *other_table,
     int32_t row,
     int32_t count,
-    const ecs_type_t *diff);
+    const ecs_table_diff_t *diff);
 
 void flecs_notify_on_set(
     ecs_world_t *world,
@@ -3037,12 +3066,18 @@ int32_t flecs_relation_depth(
     ecs_entity_t r,
     const ecs_table_t *table);
 
+typedef struct ecs_instantiate_ctx_t {
+    ecs_entity_t root_prefab;
+    ecs_entity_t root_instance;
+} ecs_instantiate_ctx_t;
+
 void flecs_instantiate(
     ecs_world_t *world,
     ecs_entity_t base,
     ecs_table_t *table,
     int32_t row,
-    int32_t count);
+    int32_t count,
+    const ecs_instantiate_ctx_t *ctx);
 
 void* flecs_get_base_component(
     const ecs_world_t *world,
@@ -4087,6 +4122,7 @@ void flecs_bootstrap(
     ecs_add_id(world, EcsThis, EcsNotQueryable);
     ecs_add_id(world, EcsWildcard, EcsNotQueryable);
     ecs_add_id(world, EcsAny, EcsNotQueryable);
+    ecs_add_id(world, EcsVariable, EcsNotQueryable);
 
     /* Tag relationships (relationships that should never have data) */
     ecs_add_id(world, EcsIsA, EcsPairIsTag);
@@ -5259,7 +5295,8 @@ void flecs_instantiate_children(
     ecs_table_t *table,
     int32_t row,
     int32_t count,
-    ecs_table_t *child_table)
+    ecs_table_t *child_table,
+    const ecs_instantiate_ctx_t *ctx)
 {
     if (!ecs_table_count(child_table)) {
         return;
@@ -5318,6 +5355,16 @@ void flecs_instantiate_children(
             childof_base_index = diff.added.count;
         }
 
+        /* If this is a pure override, make sure we have a concrete version of the
+         * component. This relies on the fact that overrides always come after
+         * concrete components in the table type so we can check the components
+         * that have already been added to the child table type. */
+        if (ECS_HAS_ID_FLAG(id, AUTO_OVERRIDE)) {
+            ecs_id_t concreteId = id & ~ECS_AUTO_OVERRIDE;
+            flecs_child_type_insert(&diff.added, component_data, concreteId);
+            continue;
+        }
+
         int32_t storage_index = ecs_table_type_to_column_index(child_table, i);
         if (storage_index != -1) {
             component_data[diff.added.count] = 
@@ -5328,6 +5375,7 @@ void flecs_instantiate_children(
 
         diff.added.array[diff.added.count] = id;
         diff.added.count ++;
+        diff.added_flags |= flecs_id_flags_get(world, id);
     }
 
     /* Table must contain children of base */
@@ -5345,6 +5393,7 @@ void flecs_instantiate_children(
     /* Instantiate the prefab child table for each new instance */
     const ecs_entity_t *instances = ecs_table_entities(table);
     int32_t child_count = ecs_table_count(child_table);
+    ecs_entity_t *child_ids = flecs_walloc_n(world, ecs_entity_t, child_count);
 
     for (i = row; i < count + row; i ++) {
         ecs_entity_t instance = instances[i];
@@ -5377,9 +5426,46 @@ void flecs_instantiate_children(
         ecs_check(true, ECS_INVALID_OPERATION, NULL);
 #endif
 
+        /* Attempt to reserve ids for children that have the same offset from
+         * the instance as from the base prefab. This ensures stable ids for
+         * instance children, even across networked applications. */
+        ecs_instantiate_ctx_t ctx_cur = {base, instance};
+        if (ctx) {
+            ctx_cur = *ctx;
+        }
+
+        for (j = 0; j < child_count; j ++) {
+            if ((uint32_t)children[j] < (uint32_t)ctx_cur.root_prefab) {
+                /* Child id is smaller than root prefab id, can't use offset */
+                child_ids[j] = ecs_new(world);
+                continue;
+            }
+
+            /* Get prefab offset, ignore lifecycle generation count */
+            ecs_entity_t prefab_offset =
+                (uint32_t)children[j] - (uint32_t)ctx_cur.root_prefab;
+            ecs_assert(prefab_offset != 0, ECS_INTERNAL_ERROR, NULL);
+
+            /* First check if any entity with the desired id exists */
+            ecs_entity_t instance_child = (uint32_t)ctx_cur.root_instance + prefab_offset;
+            ecs_entity_t alive_id = flecs_entities_get_alive(world, instance_child);
+            if (alive_id && flecs_entities_is_alive(world, alive_id)) {
+                /* Alive entity with requested id exists, can't use offset id */
+                child_ids[j] = ecs_new(world);
+                continue;
+            }
+
+            /* Id is not in use. Make it alive & match the generation of the instance. */
+            instance_child = ctx_cur.root_instance + prefab_offset;
+            flecs_entities_make_alive(world, instance_child);
+            flecs_entities_ensure(world, instance_child);
+            ecs_assert(ecs_is_alive(world, instance_child), ECS_INTERNAL_ERROR, NULL);
+            child_ids[j] = instance_child;
+        }
+
         /* Create children */
         int32_t child_row;
-        const ecs_entity_t *i_children = flecs_bulk_new(world, i_table, NULL, 
+        const ecs_entity_t *i_children = flecs_bulk_new(world, i_table, child_ids,
             &diff.added, child_count, component_data, false, &child_row, &diff);
 
         /* If children are slots, add slot relationships to parent */
@@ -5395,9 +5481,11 @@ void flecs_instantiate_children(
         /* If prefab child table has children itself, recursively instantiate */
         for (j = 0; j < child_count; j ++) {
             ecs_entity_t child = children[j];
-            flecs_instantiate(world, child, i_table, child_row + j, 1);
+            flecs_instantiate(world, child, i_table, child_row + j, 1, &ctx_cur);
         }
-    }   
+    }
+
+    flecs_wfree_n(world, ecs_entity_t, child_count, child_ids);
 error:
     return;    
 }
@@ -5407,7 +5495,8 @@ void flecs_instantiate(
     ecs_entity_t base,
     ecs_table_t *table,
     int32_t row,
-    int32_t count)
+    int32_t count,
+    const ecs_instantiate_ctx_t *ctx)
 {
     ecs_record_t *record = flecs_entities_get_any(world, base);
     ecs_table_t *base_table = record->table;
@@ -5419,11 +5508,13 @@ void flecs_instantiate(
     ecs_id_record_t *idr = flecs_id_record_get(world, ecs_childof(base));
     ecs_table_cache_iter_t it;
     if (idr && flecs_table_cache_all_iter((ecs_table_cache_t*)idr, &it)) {
+        ecs_os_perf_trace_push("flecs.instantiate");
         const ecs_table_record_t *tr;
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
             flecs_instantiate_children(
-                world, base, table, row, count, tr->hdr.table);
+                world, base, table, row, count, tr->hdr.table, ctx);
         }
+        ecs_os_perf_trace_pop("flecs.instantiate");
     }
 }
 
@@ -5557,26 +5648,31 @@ void flecs_notify_on_add(
     ecs_table_t *other_table,
     int32_t row,
     int32_t count,
-    const ecs_type_t *added,
+    const ecs_table_diff_t *diff,
     ecs_flags32_t flags,
     ecs_flags64_t set_mask,
     bool construct,
     bool sparse)
 {
-    ecs_assert(added != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(diff != NULL, ECS_INTERNAL_ERROR, NULL);
+    const ecs_type_t *added = &diff->added;
 
     if (added->count) {
-        ecs_flags32_t table_flags = table->flags;
+        ecs_flags32_t diff_flags = 
+            diff->added_flags|(table->flags & EcsTableHasTraversable);
+        if (!diff_flags) {
+            return;
+        }
 
-        if (sparse && (table_flags & EcsTableHasSparse)) {
+        if (sparse && (diff_flags & EcsTableHasSparse)) {
             flecs_sparse_on_add(world, table, row, count, added, construct);
         }
 
-        if (table_flags & EcsTableHasUnion) {
+        if (diff_flags & EcsTableHasUnion) {
             flecs_union_on_add(world, table, row, count, added);
         }
 
-        if (table_flags & (EcsTableHasOnAdd|EcsTableHasIsA|EcsTableHasTraversable)) {
+        if (diff_flags & (EcsTableHasOnAdd|EcsTableHasTraversable)) {
             flecs_emit(world, world, set_mask, &(ecs_event_desc_t){
                 .event = EcsOnAdd,
                 .ids = added,
@@ -5597,25 +5693,24 @@ void flecs_notify_on_remove(
     ecs_table_t *other_table,
     int32_t row,
     int32_t count,
-    const ecs_type_t *removed)
+    const ecs_table_diff_t *diff)
 {
-    ecs_assert(removed != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(diff != NULL, ECS_INTERNAL_ERROR, NULL);
+    const ecs_type_t *removed = &diff->removed;
     ecs_assert(count != 0, ECS_INTERNAL_ERROR, NULL);
 
     if (removed->count) {
-        ecs_flags32_t table_flags = table->flags;
-
-        if (table_flags & EcsTableHasSparse) {
-            flecs_sparse_on_remove(world, table, row, count, removed);
+        ecs_flags32_t diff_flags = 
+            diff->removed_flags|(table->flags & EcsTableHasTraversable);
+        if (!diff_flags) {
+            return;
         }
-    
-        if (table_flags & EcsTableHasUnion) {
+
+        if (diff_flags & EcsTableHasUnion) {
             flecs_union_on_remove(world, table, row, count, removed);
         }
 
-        if (table_flags & (EcsTableHasOnRemove|EcsTableHasIsA|
-            EcsTableHasTraversable))
-        {
+        if (diff_flags & (EcsTableHasOnRemove|EcsTableHasTraversable)) {
             flecs_emit(world, world, 0, &(ecs_event_desc_t) {
                 .event = EcsOnRemove,
                 .ids = removed,
@@ -5625,6 +5720,10 @@ void flecs_notify_on_remove(
                 .count = count,
                 .observable = world
             });
+        }
+
+        if (diff_flags & EcsTableHasSparse) {
+            flecs_sparse_on_remove(world, table, row, count, removed);
         }
     }
 }
@@ -5696,7 +5795,7 @@ ecs_record_t* flecs_new_entity(
 
     ecs_assert(ecs_table_count(table) > row, ECS_INTERNAL_ERROR, NULL);
     flecs_notify_on_add(
-        world, table, NULL, row, 1, &diff->added, evt_flags, 0, ctor, true);
+        world, table, NULL, row, 1, diff, evt_flags, 0, ctor, true);
     ecs_assert(table == record->table, ECS_INTERNAL_ERROR, NULL);
 
     return record;
@@ -5731,8 +5830,7 @@ void flecs_move_entity(
         false, false);
 
     /* Invoke remove actions for removed components */
-    flecs_notify_on_remove(
-        world, src_table, dst_table, src_row, 1, &diff->removed);
+    flecs_notify_on_remove(world, src_table, dst_table, src_row, 1, diff);
 
     /* Copy entity & components from src_table to dst_table */
     flecs_table_move(world, entity, entity, dst_table, dst_row, 
@@ -5744,7 +5842,7 @@ void flecs_move_entity(
     record->row = ECS_ROW_TO_RECORD(dst_row, record->row & ECS_ROW_FLAGS_MASK);
     
     flecs_table_delete(world, src_table, src_row, false);
-    flecs_notify_on_add(world, dst_table, src_table, dst_row, 1, &diff->added, 
+    flecs_notify_on_add(world, dst_table, src_table, dst_row, 1, diff, 
         evt_flags, 0, ctor, true);
 
     flecs_update_name_index(world, src_table, dst_table, dst_row, 1);
@@ -5764,7 +5862,7 @@ void flecs_delete_entity(
     int32_t row = ECS_RECORD_TO_ROW(record->row);
 
     /* Invoke remove actions before deleting */
-    flecs_notify_on_remove(world, table, NULL, row, 1, &diff->removed);
+    flecs_notify_on_remove(world, table, NULL, row, 1, diff);
     flecs_table_delete(world, table, row, true);
 }
 
@@ -5830,14 +5928,17 @@ void flecs_commit(
         /* If source and destination table are the same no action is needed *
          * However, if a component was added in the process of traversing a
          * table, this suggests that a union relationship could have changed. */
-        if (src_table) {
+        if (src_table && src_table->flags & EcsTableHasUnion) {
+            diff->added_flags |= EcsIdIsUnion;
             flecs_notify_on_add(world, src_table, src_table, 
-                ECS_RECORD_TO_ROW(record->row), 1, &diff->added, evt_flags, 0, 
+                ECS_RECORD_TO_ROW(record->row), 1, diff, evt_flags, 0, 
                     construct, true);
         }
         flecs_journal_end();
         return;
     }
+
+    ecs_os_perf_trace_push("flecs.commit");
 
     if (src_table) {
         ecs_assert(dst_table != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -5874,7 +5975,9 @@ void flecs_commit(
             ECS_OUT_OF_RANGE, 0);
         ecs_check(entity >= world->info.min_id, 
             ECS_OUT_OF_RANGE, 0);
-    } 
+    }
+
+    ecs_os_perf_trace_pop("flecs.commit");
 
 error:
     flecs_journal_end();
@@ -5927,7 +6030,7 @@ const ecs_entity_t* flecs_bulk_new(
 
     flecs_defer_begin(world, world->stages[0]);
 
-    flecs_notify_on_add(world, table, NULL, row, count, &diff->added, 
+    flecs_notify_on_add(world, table, NULL, row, count, diff,
         (component_data == NULL) ? 0 : EcsEventNoOnSet, 0, true, true);
 
     if (component_data) {
@@ -6149,6 +6252,7 @@ void flecs_invoke_hook(
     it.table = table;
     it.trs[0] = tr;
     it.row_fields = !!(((ecs_id_record_t*)tr->hdr.cache)->flags & EcsIdIsSparse);
+    it.ref_fields = it.row_fields;
     it.sizes = ECS_CONST_CAST(ecs_size_t*, &ti->size);
     it.ids[0] = id;
     it.event = event;
@@ -6158,6 +6262,7 @@ void flecs_invoke_hook(
     it.count = count;
     it.offset = row;
     it.flags = EcsIterIsValid;
+
     hook(&it);
     ecs_iter_fini(&it);
 
@@ -6273,9 +6378,13 @@ bool ecs_commit(
 
     if (added) {
         diff.added = *added;
+        diff.added_flags = table->flags & EcsTableAddEdgeFlags;
     }
     if (removed) {
         diff.removed = *removed;
+        if (src_table) {
+            diff.removed_flags = src_table->flags & EcsTableRemoveEdgeFlags;
+        }
     }
 
     ecs_defer_begin(world);
@@ -6425,13 +6534,23 @@ ecs_entity_t ecs_new_w_table(
     ecs_table_t *table)
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(table != NULL, ECS_INVALID_PARAMETER, NULL);
 
     flecs_stage_from_world(&world);    
     ecs_entity_t entity = ecs_new(world);
     ecs_record_t *r = flecs_entities_get(world, entity);
+    ecs_flags32_t flags = table->flags & EcsTableAddEdgeFlags;
+    if (table->flags & EcsTableHasIsA) {
+        flags |= EcsTableHasOnAdd;
+    }
 
-    ecs_table_diff_t table_diff = { .added = table->type };
+    ecs_table_diff_t table_diff = { 
+        .added = table->type,
+        .added_flags = flags
+    };
+
     flecs_new_entity(world, entity, r, table, &table_diff, true, 0);
+
     return entity;
 error:
     return 0;
@@ -6486,6 +6605,15 @@ int flecs_traverse_from_expr(
             if (!id) {
                 break;
             }
+
+            if (!ecs_id_is_valid(world, id)) {
+                char *idstr = ecs_id_str(world, id);
+                ecs_parser_error(name, expr, (ptr - expr), 
+                    "id %s is invalid for add expression", idstr);
+                ecs_os_free(idstr);
+                goto error;
+            }
+
             ecs_vec_append_t(&world->allocator, ids, ecs_id_t)[0] = id;
         }
 
@@ -7150,7 +7278,8 @@ void ecs_clear(
     ecs_table_t *table = r->table;
     if (table) {
         ecs_table_diff_t diff = {
-            .removed = table->type
+            .removed = table->type,
+            .removed_flags = table->flags & EcsTableRemoveEdgeFlags
         };
 
         flecs_delete_entity(world, r, &diff);
@@ -7473,8 +7602,7 @@ void flecs_remove_from_table(
                 ecs_log_push_3();
                 ecs_table_diff_t td;
                 flecs_table_diff_build_noalloc(&diff, &td);
-                flecs_notify_on_remove(world, table, NULL, 0, table_count, 
-                    &td.removed);
+                flecs_notify_on_remove(world, table, NULL, 0, table_count, &td);
                 ecs_log_pop_3();
             }
 
@@ -7693,6 +7821,8 @@ void ecs_delete(
         return;
     }
 
+    ecs_os_perf_trace_push("flecs.delete");
+
     ecs_record_t *r = flecs_entities_try(world, entity);
     if (r) {
         flecs_journal_begin(world, EcsJournalDelete, entity, NULL, NULL);
@@ -7724,7 +7854,8 @@ void ecs_delete(
 
         if (table) {
             ecs_table_diff_t diff = {
-                .removed = table->type
+                .removed = table->type,
+                .removed_flags = table->flags & EcsTableRemoveEdgeFlags
             };
 
             flecs_delete_entity(world, r, &diff);
@@ -7740,6 +7871,7 @@ void ecs_delete(
 
     flecs_defer_end(world, stage);
 error:
+    ecs_os_perf_trace_pop("flecs.delete");
     return;
 }
 
@@ -7815,9 +7947,14 @@ ecs_entity_t ecs_clone(
     }
 
     ecs_type_t dst_type = dst_table->type;
-    ecs_table_diff_t diff = { .added = dst_type };
+    ecs_table_diff_t diff = {
+        .added = dst_type,
+        .added_flags = dst_table->flags & EcsTableAddEdgeFlags
+    };
     ecs_record_t *dst_r = flecs_entities_get(world, dst);
-    flecs_new_entity(world, dst, dst_r, dst_table, &diff, true, 0);
+    /* Note 'ctor' parameter below is set to 'false' if the value will be copied, since flecs_table_move
+       will call a copy constructor */
+    flecs_new_entity(world, dst, dst_r, dst_table, &diff, !copy_value, 0);
     int32_t row = ECS_RECORD_TO_ROW(dst_r->row);
 
     if (copy_value) {
@@ -9742,6 +9879,7 @@ void flecs_cmd_batch_for_entity(
                     &diff->removed, ecs_id_t, table->type.count);
                 ecs_os_memcpy_n(ids, table->type.array, ecs_id_t, 
                     table->type.count);
+                diff->removed_flags |= table->flags & EcsTableRemoveEdgeFlags;
             }
             table = &world->store.root;
             world->info.cmd.batched_command_count ++;
@@ -9869,10 +10007,14 @@ void flecs_cmd_batch_for_entity(
         } while ((cur = next_for_entity));
     }
 
-    if (added.count) {
+    if (added.count && r->table) {
+        ecs_table_diff_t add_diff = ECS_TABLE_DIFF_INIT;
+        add_diff.added = added;
+        add_diff.added_flags = diff->added_flags;
+
         flecs_defer_begin(world, world->stages[0]);
-        flecs_notify_on_add(world, table, start_table, 
-            ECS_RECORD_TO_ROW(r->row), 1, &added, 0, set_mask, true, false);
+        flecs_notify_on_add(world, r->table, start_table,
+            ECS_RECORD_TO_ROW(r->row), 1, &add_diff, 0, set_mask, true, false);
         flecs_defer_end(world, world->stages[0]);
         if (r->row & EcsEntityIsTraversable) {
             /* Update monitors since we didn't do this in flecs_commit. */
@@ -9903,6 +10045,8 @@ bool flecs_defer_end(
     ecs_assert(stage->defer > 0, ECS_INTERNAL_ERROR, NULL);
 
     if (!--stage->defer) {
+        ecs_os_perf_trace_push("flecs.commands.merge");
+
         /* Test whether we're flushing to another queue or whether we're 
          * flushing to the storage */
         bool merge_to_world = false;
@@ -10096,6 +10240,8 @@ bool flecs_defer_end(
                     world->on_commands_ctx_active);
             }
         }
+
+        ecs_os_perf_trace_pop("flecs.commands.merge");
 
         return true;
     }
@@ -10760,7 +10906,7 @@ ecs_entity_t ecs_add_path_w_sep(
      * immediately updated. Without this, we could create multiple entities for
      * the same name in a single command queue. */
     bool suspend_defer = ecs_is_deferred(world) &&
-        (ecs_get_stage_count(world) <= 1);
+        !(world->flags & EcsWorldMultiThreaded);
         
     ecs_entity_t cur = parent;
     char *name = NULL;
@@ -10837,6 +10983,9 @@ ecs_entity_t ecs_new_from_path_w_sep(
  * @brief Id utilities.
  */
 
+
+#ifdef FLECS_SCRIPT
+#endif
 
 bool ecs_id_match(
     ecs_id_t id,
@@ -10962,6 +11111,29 @@ ecs_flags32_t ecs_id_get_flags(
     } else {
         return 0;
     }
+}
+
+ecs_id_t ecs_id_from_str(
+    const ecs_world_t *world,
+    const char *expr)
+{
+#ifdef FLECS_SCRIPT
+    ecs_id_t result;
+
+    /* Temporarily disable parser logging */
+    int prev_level = ecs_log_set_level(-3);
+    if (!flecs_id_parse(world, NULL, expr, &result)) {
+        /* Invalid expression */
+        ecs_log_set_level(prev_level);
+        return 0;
+    }
+    ecs_log_set_level(prev_level);
+    return result;
+#else
+    (void)world;
+    (void)expr;
+    ecs_abort(ECS_UNSUPPORTED, "ecs_id_from_str requires FLECS_SCRIPT addon");
+#endif
 }
 
 /**
@@ -11149,7 +11321,7 @@ void* ecs_field_at_w_size(
 
     ecs_entity_t src = it->sources[index];
     if (!src) {
-        src = ecs_table_entities(it->table)[row];
+        src = ecs_table_entities(it->table)[row + it->offset];
     }
 
     return flecs_sparse_get_any(idr->sparse, flecs_uto(int32_t, size), src);
@@ -12539,13 +12711,19 @@ int32_t flecs_event_observers_get(
             ecs_id_t id_fwc = ecs_pair(EcsWildcard, ECS_PAIR_SECOND(id));
             ecs_id_t id_swc = ecs_pair(ECS_PAIR_FIRST(id), EcsWildcard);
             ecs_id_t id_pwc = ecs_pair(EcsWildcard, EcsWildcard);
-            iders[count] = flecs_event_id_record_get_if(er, id_fwc);
-            count += iders[count] != 0;
-            iders[count] = flecs_event_id_record_get_if(er, id_swc);
-            count += iders[count] != 0;
-            iders[count] = flecs_event_id_record_get_if(er, id_pwc);
-            count += iders[count] != 0;
-        } else {
+            if (id_fwc != id) {
+                iders[count] = flecs_event_id_record_get_if(er, id_fwc);
+                count += iders[count] != 0;
+            }
+            if (id_swc != id) {
+                iders[count] = flecs_event_id_record_get_if(er, id_swc);
+                count += iders[count] != 0;
+            }
+            if (id_pwc != id) {
+                iders[count] = flecs_event_id_record_get_if(er, id_pwc);
+                count += iders[count] != 0;
+            }
+        } else if (id != EcsWildcard) {
             iders[count] = flecs_event_id_record_get_if(er, EcsWildcard);
             count += iders[count] != 0;
         }
@@ -12607,6 +12785,7 @@ void flecs_emit_propagate_id(
         it->other_table = NULL;
         it->offset = 0;
         it->count = entity_count;
+        it->up_fields = 1;
         if (entity_count) {
             it->entities = ecs_table_entities(table);
         }
@@ -12645,6 +12824,7 @@ void flecs_emit_propagate_id(
     }
 
     it->event_cur = event_cur;
+    it->up_fields = 0;
 }
 
 static
@@ -12939,6 +13119,7 @@ void flecs_emit_forward_id(
     it->sources[0] = tgt;
     it->event_id = id;
     ECS_CONST_CAST(int32_t*, it->sizes)[0] = 0; /* safe, owned by observer */
+    it->up_fields = 1;
 
     int32_t storage_i = ecs_table_type_to_column_index(tgt_table, column);
     if (storage_i != -1) {
@@ -12999,6 +13180,8 @@ void flecs_emit_forward_id(
             it->trs[0] = base_tr;
         }
     }
+
+    it->up_fields = 0;
 }
 
 static
@@ -13431,6 +13614,8 @@ void flecs_emit(
     ecs_check(desc->table != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(desc->observable != NULL, ECS_INVALID_PARAMETER, NULL);
 
+    ecs_os_perf_trace_push("flecs.emit");
+
     ecs_time_t t = {0};
     bool measure_time = world->flags & EcsWorldMeasureSystemTime;
     if (measure_time) {
@@ -13550,6 +13735,8 @@ repeat_event:
         ecs_id_record_t *idr = NULL;
         const ecs_type_info_t *ti = NULL;
         ecs_id_t id = id_array[i];
+        ecs_assert(id == EcsAny || !ecs_id_is_wildcard(id), 
+            ECS_INVALID_PARAMETER, "cannot emit wildcard ids");
         int32_t ider_i, ider_count = 0;
         bool is_pair = ECS_IS_PAIR(id);
         void *override_ptr = NULL;
@@ -13587,7 +13774,7 @@ repeat_event:
                              * from being called recursively, in case prefab
                              * children also have IsA relationships. */
                             world->stages[0]->base = tgt;
-                            flecs_instantiate(world, tgt, table, offset, count);
+                            flecs_instantiate(world, tgt, table, offset, count, NULL);
                             world->stages[0]->base = 0;
                         }
 
@@ -13655,7 +13842,6 @@ repeat_event:
 
         int32_t storage_i;
         it.trs[0] = tr;
-        // it.ptrs[0] = NULL;
         ECS_CONST_CAST(int32_t*, it.sizes)[0] = 0; /* safe, owned by observer */
         it.event_id = id;
         it.ids[0] = id;
@@ -13701,7 +13887,6 @@ repeat_event:
                             /* Set the source temporarily to the base and base
                              * component pointer. */
                             it.sources[0] = base;
-                            // it.ptrs[0] = ptr;
                             for (ider_set_i = 0; ider_set_i < ider_set_count; ider_set_i ++) {
                                 ecs_event_id_record_t *ider = iders_set[ider_set_i];
                                 flecs_observers_invoke(
@@ -13718,8 +13903,6 @@ repeat_event:
                         }
                     }
                 }
-
-                // it.ptrs[0] = ptr;
             }
         }
 
@@ -13756,6 +13939,8 @@ repeat_event:
 
 error:
     world->stages[0]->defer = defer;
+
+    ecs_os_perf_trace_pop("flecs.emit");
 
     if (measure_time) {
         world->info.emit_time_total += (ecs_ftime_t)ecs_time_measure(&t);
@@ -14138,13 +14323,13 @@ void flecs_observer_invoke(
             ECS_INTERNAL_ERROR, NULL);
     }
 
-    ecs_termset_t set_fields = it->set_fields;
-    // it->set_fields = 1; /* Field 0 is set otherwise we wouldn't be triggering */
+    ecs_termset_t row_fields = it->row_fields;
+    it->row_fields = query->row_fields;
 
     bool match_this = query->flags & EcsQueryMatchThis;
     if (match_this) {
         callback(it);
-        query->eval_count ++;
+        ecs_os_inc(&query->eval_count);
     } else {
         ecs_entity_t observer_src = ECS_TERM_REF_ID(&term->src);
         if (observer_src && !(term->src.id & EcsIsEntity)) {
@@ -14160,7 +14345,7 @@ void flecs_observer_invoke(
             it->entities = &e;
             if (!observer_src) {
                 callback(it);
-                query->eval_count ++;
+                ecs_os_inc(&query->eval_count);
             } else if (observer_src == e) {
                 ecs_entity_t dummy = 0;
                 it->entities = &dummy;
@@ -14169,7 +14354,7 @@ void flecs_observer_invoke(
                 }
 
                 callback(it);
-                query->eval_count ++;
+                ecs_os_inc(&query->eval_count);
                 it->sources[0] = src;
                 break;
             }
@@ -14179,7 +14364,7 @@ void flecs_observer_invoke(
         it->count = count;
     }
 
-    it->set_fields = set_fields;
+    it->row_fields = row_fields;
 
     flecs_stage_set_system(world->stages[0], old_system);
 
@@ -14429,7 +14614,8 @@ void flecs_multi_observer_builtin_run(ecs_iter_t *it) {
 static
 void flecs_observer_yield_existing(
     ecs_world_t *world,
-    ecs_observer_t *o)
+    ecs_observer_t *o,
+    bool yield_on_remove)
 {
     ecs_run_action_t run = o->run;
     if (!run) {
@@ -14444,6 +14630,19 @@ void flecs_observer_yield_existing(
      * the event, if the event is iterable. */
     int i, count = o->event_count;
     for (i = 0; i < count; i ++) {
+        ecs_entity_t event = o->events[i];
+
+        /* We only yield for OnRemove events if the observer is deleted. */
+        if (event == EcsOnRemove) {
+            if (!yield_on_remove) {
+                continue;
+            }
+        } else {
+            if (yield_on_remove) {
+                continue;
+            }
+        }
+
         ecs_iter_t it = ecs_query_iter(world, o->query);
         it.system = o->entity;
         it.ctx = o;
@@ -14777,6 +14976,8 @@ ecs_observer_t* flecs_observer_init(
     impl->term_index = desc->term_index_;
     impl->flags = desc->flags_;
 
+    bool yield_on_create = false;
+
     /* Check if observer is monitor. Monitors are created as multi observers
      * since they require pre/post checking of the filter to test if the
      * entity is entering/leaving the monitor. */
@@ -14795,8 +14996,19 @@ ecs_observer_t* flecs_observer_init(
             o->events[1] = EcsOnRemove;
             o->event_count ++;
             impl->flags |= EcsObserverIsMonitor;
+            if (desc->yield_existing) {
+                impl->flags |= EcsObserverYieldOnDelete;
+                yield_on_create = true;
+            }
         } else {
             o->events[i] = event;
+            if (desc->yield_existing) {
+                if (event == EcsOnRemove) {
+                    impl->flags |= EcsObserverYieldOnDelete;
+                } else {
+                    yield_on_create = true;
+                }
+            }
         }
 
         o->event_count ++;
@@ -14830,8 +15042,8 @@ ecs_observer_t* flecs_observer_init(
         }
     }
 
-    if (desc->yield_existing) {
-        flecs_observer_yield_existing(world, o);
+    if (yield_on_create) {
+        flecs_observer_yield_existing(world, o, false);
     }
 
     return o;
@@ -14955,6 +15167,10 @@ void flecs_observer_fini(
     ecs_assert(o->query != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_world_t *world = o->query->world;
     ecs_observer_impl_t *impl = flecs_observer_impl(o);
+
+    if (impl->flags & EcsObserverYieldOnDelete) {
+        flecs_observer_yield_existing(world, o, true);
+    }
 
     if (impl->flags & EcsObserverIsMulti) {
         ecs_observer_t **children = ecs_vec_first(&impl->children);
@@ -15375,6 +15591,26 @@ void ecs_os_strset(char **str, const char *value) {
     char *old = str[0];
     str[0] = ecs_os_strdup(value);
     ecs_os_free(old);
+}
+
+void ecs_os_perf_trace_push_(
+    const char *file,
+    size_t line,
+    const char *name)
+{
+    if (ecs_os_api.perf_trace_push_) {
+        ecs_os_api.perf_trace_push_(file, line, name);
+    }
+}
+
+void ecs_os_perf_trace_pop_(
+    const char *file,
+    size_t line,
+    const char *name)
+{
+    if (ecs_os_api.perf_trace_pop_) {
+        ecs_os_api.perf_trace_pop_(file, line, name);
+    }
 }
 
 /* Replace dots with underscores */
@@ -17499,142 +17735,142 @@ ECS_TAG_DECLARE(EcsAlertError);
 ECS_TAG_DECLARE(EcsAlertCritical);
 #endif
 #ifdef FLECS_UNITS
-ECS_DECLARE(EcsUnitPrefixes);
+ecs_entity_t EcsUnitPrefixes;
 
-ECS_DECLARE(EcsYocto);
-ECS_DECLARE(EcsZepto);
-ECS_DECLARE(EcsAtto);
-ECS_DECLARE(EcsFemto);
-ECS_DECLARE(EcsPico);
-ECS_DECLARE(EcsNano);
-ECS_DECLARE(EcsMicro);
-ECS_DECLARE(EcsMilli);
-ECS_DECLARE(EcsCenti);
-ECS_DECLARE(EcsDeci);
-ECS_DECLARE(EcsDeca);
-ECS_DECLARE(EcsHecto);
-ECS_DECLARE(EcsKilo);
-ECS_DECLARE(EcsMega);
-ECS_DECLARE(EcsGiga);
-ECS_DECLARE(EcsTera);
-ECS_DECLARE(EcsPeta);
-ECS_DECLARE(EcsExa);
-ECS_DECLARE(EcsZetta);
-ECS_DECLARE(EcsYotta);
+ecs_entity_t EcsYocto;
+ecs_entity_t EcsZepto;
+ecs_entity_t EcsAtto;
+ecs_entity_t EcsFemto;
+ecs_entity_t EcsPico;
+ecs_entity_t EcsNano;
+ecs_entity_t EcsMicro;
+ecs_entity_t EcsMilli;
+ecs_entity_t EcsCenti;
+ecs_entity_t EcsDeci;
+ecs_entity_t EcsDeca;
+ecs_entity_t EcsHecto;
+ecs_entity_t EcsKilo;
+ecs_entity_t EcsMega;
+ecs_entity_t EcsGiga;
+ecs_entity_t EcsTera;
+ecs_entity_t EcsPeta;
+ecs_entity_t EcsExa;
+ecs_entity_t EcsZetta;
+ecs_entity_t EcsYotta;
 
-ECS_DECLARE(EcsKibi);
-ECS_DECLARE(EcsMebi);
-ECS_DECLARE(EcsGibi);
-ECS_DECLARE(EcsTebi);
-ECS_DECLARE(EcsPebi);
-ECS_DECLARE(EcsExbi);
-ECS_DECLARE(EcsZebi);
-ECS_DECLARE(EcsYobi);
+ecs_entity_t EcsKibi;
+ecs_entity_t EcsMebi;
+ecs_entity_t EcsGibi;
+ecs_entity_t EcsTebi;
+ecs_entity_t EcsPebi;
+ecs_entity_t EcsExbi;
+ecs_entity_t EcsZebi;
+ecs_entity_t EcsYobi;
 
-ECS_DECLARE(EcsDuration);
-    ECS_DECLARE(EcsPicoSeconds);
-    ECS_DECLARE(EcsNanoSeconds);
-    ECS_DECLARE(EcsMicroSeconds);
-    ECS_DECLARE(EcsMilliSeconds);
-    ECS_DECLARE(EcsSeconds);
-    ECS_DECLARE(EcsMinutes);
-    ECS_DECLARE(EcsHours);
-    ECS_DECLARE(EcsDays);
+ecs_entity_t EcsDuration;
+    ecs_entity_t EcsPicoSeconds;
+    ecs_entity_t EcsNanoSeconds;
+    ecs_entity_t EcsMicroSeconds;
+    ecs_entity_t EcsMilliSeconds;
+    ecs_entity_t EcsSeconds;
+    ecs_entity_t EcsMinutes;
+    ecs_entity_t EcsHours;
+    ecs_entity_t EcsDays;
 
-ECS_DECLARE(EcsTime);
-    ECS_DECLARE(EcsDate);
+ecs_entity_t EcsTime;
+    ecs_entity_t EcsDate;
 
-ECS_DECLARE(EcsMass);
-    ECS_DECLARE(EcsGrams);
-    ECS_DECLARE(EcsKiloGrams);
+ecs_entity_t EcsMass;
+    ecs_entity_t EcsGrams;
+    ecs_entity_t EcsKiloGrams;
 
-ECS_DECLARE(EcsElectricCurrent);
-    ECS_DECLARE(EcsAmpere);
+ecs_entity_t EcsElectricCurrent;
+    ecs_entity_t EcsAmpere;
 
-ECS_DECLARE(EcsAmount);
-    ECS_DECLARE(EcsMole);
+ecs_entity_t EcsAmount;
+    ecs_entity_t EcsMole;
 
-ECS_DECLARE(EcsLuminousIntensity);
-    ECS_DECLARE(EcsCandela);
+ecs_entity_t EcsLuminousIntensity;
+    ecs_entity_t EcsCandela;
 
-ECS_DECLARE(EcsForce);
-    ECS_DECLARE(EcsNewton);
+ecs_entity_t EcsForce;
+    ecs_entity_t EcsNewton;
 
-ECS_DECLARE(EcsLength);
-    ECS_DECLARE(EcsMeters);
-        ECS_DECLARE(EcsPicoMeters);
-        ECS_DECLARE(EcsNanoMeters);
-        ECS_DECLARE(EcsMicroMeters);
-        ECS_DECLARE(EcsMilliMeters);
-        ECS_DECLARE(EcsCentiMeters);
-        ECS_DECLARE(EcsKiloMeters);
-    ECS_DECLARE(EcsMiles);
-    ECS_DECLARE(EcsPixels);
+ecs_entity_t EcsLength;
+    ecs_entity_t EcsMeters;
+        ecs_entity_t EcsPicoMeters;
+        ecs_entity_t EcsNanoMeters;
+        ecs_entity_t EcsMicroMeters;
+        ecs_entity_t EcsMilliMeters;
+        ecs_entity_t EcsCentiMeters;
+        ecs_entity_t EcsKiloMeters;
+    ecs_entity_t EcsMiles;
+    ecs_entity_t EcsPixels;
 
-ECS_DECLARE(EcsPressure);
-    ECS_DECLARE(EcsPascal);
-    ECS_DECLARE(EcsBar);
+ecs_entity_t EcsPressure;
+    ecs_entity_t EcsPascal;
+    ecs_entity_t EcsBar;
 
-ECS_DECLARE(EcsSpeed);
-    ECS_DECLARE(EcsMetersPerSecond);
-    ECS_DECLARE(EcsKiloMetersPerSecond);
-    ECS_DECLARE(EcsKiloMetersPerHour);
-    ECS_DECLARE(EcsMilesPerHour);
+ecs_entity_t EcsSpeed;
+    ecs_entity_t EcsMetersPerSecond;
+    ecs_entity_t EcsKiloMetersPerSecond;
+    ecs_entity_t EcsKiloMetersPerHour;
+    ecs_entity_t EcsMilesPerHour;
 
-ECS_DECLARE(EcsAcceleration);
+ecs_entity_t EcsAcceleration;
 
-ECS_DECLARE(EcsTemperature);
-    ECS_DECLARE(EcsKelvin);
-    ECS_DECLARE(EcsCelsius);
-    ECS_DECLARE(EcsFahrenheit);
+ecs_entity_t EcsTemperature;
+    ecs_entity_t EcsKelvin;
+    ecs_entity_t EcsCelsius;
+    ecs_entity_t EcsFahrenheit;
 
-ECS_DECLARE(EcsData);
-    ECS_DECLARE(EcsBits);
-        ECS_DECLARE(EcsKiloBits);
-        ECS_DECLARE(EcsMegaBits);
-        ECS_DECLARE(EcsGigaBits);
-    ECS_DECLARE(EcsBytes);
-        ECS_DECLARE(EcsKiloBytes);
-        ECS_DECLARE(EcsMegaBytes);
-        ECS_DECLARE(EcsGigaBytes);
-        ECS_DECLARE(EcsKibiBytes);
-        ECS_DECLARE(EcsGibiBytes);
-        ECS_DECLARE(EcsMebiBytes);
+ecs_entity_t EcsData;
+    ecs_entity_t EcsBits;
+        ecs_entity_t EcsKiloBits;
+        ecs_entity_t EcsMegaBits;
+        ecs_entity_t EcsGigaBits;
+    ecs_entity_t EcsBytes;
+        ecs_entity_t EcsKiloBytes;
+        ecs_entity_t EcsMegaBytes;
+        ecs_entity_t EcsGigaBytes;
+        ecs_entity_t EcsKibiBytes;
+        ecs_entity_t EcsGibiBytes;
+        ecs_entity_t EcsMebiBytes;
 
-ECS_DECLARE(EcsDataRate);
-    ECS_DECLARE(EcsBitsPerSecond);
-    ECS_DECLARE(EcsKiloBitsPerSecond);
-    ECS_DECLARE(EcsMegaBitsPerSecond);
-    ECS_DECLARE(EcsGigaBitsPerSecond);
-    ECS_DECLARE(EcsBytesPerSecond);
-    ECS_DECLARE(EcsKiloBytesPerSecond);
-    ECS_DECLARE(EcsMegaBytesPerSecond);
-    ECS_DECLARE(EcsGigaBytesPerSecond);
+ecs_entity_t EcsDataRate;
+    ecs_entity_t EcsBitsPerSecond;
+    ecs_entity_t EcsKiloBitsPerSecond;
+    ecs_entity_t EcsMegaBitsPerSecond;
+    ecs_entity_t EcsGigaBitsPerSecond;
+    ecs_entity_t EcsBytesPerSecond;
+    ecs_entity_t EcsKiloBytesPerSecond;
+    ecs_entity_t EcsMegaBytesPerSecond;
+    ecs_entity_t EcsGigaBytesPerSecond;
 
-ECS_DECLARE(EcsPercentage);
+ecs_entity_t EcsPercentage;
 
-ECS_DECLARE(EcsAngle);
-    ECS_DECLARE(EcsRadians);
-    ECS_DECLARE(EcsDegrees);
+ecs_entity_t EcsAngle;
+    ecs_entity_t EcsRadians;
+    ecs_entity_t EcsDegrees;
 
-ECS_DECLARE(EcsColor);
-    ECS_DECLARE(EcsColorRgb);
-    ECS_DECLARE(EcsColorHsl);
-    ECS_DECLARE(EcsColorCss);
+ecs_entity_t EcsColor;
+    ecs_entity_t EcsColorRgb;
+    ecs_entity_t EcsColorHsl;
+    ecs_entity_t EcsColorCss;
 
-ECS_DECLARE(EcsBel);
-ECS_DECLARE(EcsDeciBel);
+ecs_entity_t EcsBel;
+ecs_entity_t EcsDeciBel;
 
-ECS_DECLARE(EcsFrequency);
-    ECS_DECLARE(EcsHertz);
-    ECS_DECLARE(EcsKiloHertz);
-    ECS_DECLARE(EcsMegaHertz);
-    ECS_DECLARE(EcsGigaHertz);
+ecs_entity_t EcsFrequency;
+    ecs_entity_t EcsHertz;
+    ecs_entity_t EcsKiloHertz;
+    ecs_entity_t EcsMegaHertz;
+    ecs_entity_t EcsGigaHertz;
 
-ECS_DECLARE(EcsUri);
-    ECS_DECLARE(EcsUriHyperlink);
-    ECS_DECLARE(EcsUriImage);
-    ECS_DECLARE(EcsUriFile);
+ecs_entity_t EcsUri;
+    ecs_entity_t EcsUriHyperlink;
+    ecs_entity_t EcsUriImage;
+    ecs_entity_t EcsUriFile;
 #endif
 
 /* -- Private functions -- */
@@ -17699,7 +17935,7 @@ ecs_world_t* flecs_suspend_readonly(
 
     /* Cannot suspend when running with multiple threads */
     ecs_assert(!(world->flags & EcsWorldReadonly) ||
-        (ecs_get_stage_count(world) <= 1), ECS_INVALID_WHILE_READONLY, NULL);
+        !(world->flags & EcsWorldMultiThreaded), ECS_INVALID_WHILE_READONLY, NULL);
 
     state->is_readonly = is_readonly;
     state->is_deferred = stage->defer != 0;
@@ -17761,6 +17997,10 @@ void flecs_eval_component_monitor(
         return;
     }
 
+    world->info.eval_comp_monitors_total ++;
+
+    ecs_os_perf_trace_push("flecs.component_monitor.eval");
+
     world->monitors.is_dirty = false;
 
     ecs_map_iter_t it = ecs_map_iter(&world->monitors.monitors);
@@ -17782,6 +18022,8 @@ void flecs_eval_component_monitor(
             });
         }
     }
+
+    ecs_os_perf_trace_pop("flecs.component_monitor.eval");
 }
 
 void flecs_monitor_mark_dirty(
@@ -18367,7 +18609,7 @@ void flecs_notify_tables(
         int32_t i, count = flecs_sparse_count(tables);
         for (i = 0; i < count; i ++) {
             ecs_table_t *table = flecs_sparse_get_dense_t(tables, ecs_table_t, i);
-            flecs_table_notify(world, table, event);
+            flecs_table_notify(world, table, id, event);
         }
 
     /* If id is specified, only broadcast to tables with id */
@@ -18382,7 +18624,7 @@ void flecs_notify_tables(
 
         flecs_table_cache_all_iter(&idr->cache, &it);
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {
-            flecs_table_notify(world, tr->hdr.table, event);
+            flecs_table_notify(world, tr->hdr.table, id, event);
         }
     }
 }
@@ -18514,8 +18756,10 @@ void ecs_set_hooks_id(
 
     if (h->ctx) ti->hooks.ctx = h->ctx;
     if (h->binding_ctx) ti->hooks.binding_ctx = h->binding_ctx;
+    if (h->lifecycle_ctx) ti->hooks.lifecycle_ctx = h->lifecycle_ctx;
     if (h->ctx_free) ti->hooks.ctx_free = h->ctx_free;
     if (h->binding_ctx_free) ti->hooks.binding_ctx_free = h->binding_ctx_free;
+    if (h->lifecycle_ctx_free) ti->hooks.lifecycle_ctx_free = h->lifecycle_ctx_free;
 
     /* If no constructor is set, invoking any of the other lifecycle actions
      * is not safe as they will potentially access uninitialized memory. For
@@ -18619,6 +18863,9 @@ void ecs_run_post_frame(
     ecs_check(action != NULL, ECS_INVALID_PARAMETER, NULL);
 
     ecs_stage_t *stage = flecs_stage_from_world(&world);
+    ecs_check((world->flags & EcsWorldFrameInProgress), ECS_INVALID_OPERATION, 
+        "cannot register post frame action while frame is not in progress");
+
     ecs_action_elem_t *elem = ecs_vec_append_t(&stage->allocator,
         &stage->post_frame_actions, ecs_action_elem_t);
     ecs_assert(elem != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -18898,15 +19145,15 @@ void ecs_set_entity_range(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(!id_end || id_end > id_start, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(!id_end || id_end > flecs_entities_max_id(world),
-        ECS_INVALID_PARAMETER, NULL);
+
+    if (id_start == 0) {
+      id_start = flecs_entities_max_id(world) + 1;
+    }
 
     uint32_t start = (uint32_t)id_start;
     uint32_t end = (uint32_t)id_end;
 
-    if (flecs_entities_max_id(world) < start) {
-        flecs_entities_max_id(world) = start - 1;
-    }
+    flecs_entities_max_id(world) = start - 1;
 
     world->info.min_id = start;
     world->info.max_id = end;
@@ -19052,6 +19299,9 @@ void flecs_type_info_fini(
     if (ti->hooks.binding_ctx_free) {
         ti->hooks.binding_ctx_free(ti->hooks.binding_ctx);
     }
+    if (ti->hooks.lifecycle_ctx_free) {
+        ti->hooks.lifecycle_ctx_free(ti->hooks.lifecycle_ctx);
+    }
     if (ti->name) {
         /* Safe to cast away const, world has ownership over string */
         ecs_os_free(ECS_CONST_CAST(char*, ti->name));
@@ -19093,6 +19343,8 @@ ecs_ftime_t flecs_insert_sleep(
         return delta_time;
     }
 
+    ecs_os_perf_trace_push("flecs.insert_sleep");
+
     ecs_ftime_t target_delta_time =
         ((ecs_ftime_t)1.0 / (ecs_ftime_t)world->info.target_fps);
 
@@ -19115,6 +19367,8 @@ ecs_ftime_t flecs_insert_sleep(
         delta_time = (ecs_ftime_t)ecs_time_measure(&now);
     } while ((target_delta_time - delta_time) >
         (sleep_time / (ecs_ftime_t)2.0));
+
+    ecs_os_perf_trace_pop("flecs.insert_sleep");
 
     *stop = now;
     return delta_time;
@@ -19182,6 +19436,8 @@ ecs_ftime_t ecs_frame_begin(
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(!(world->flags & EcsWorldReadonly), ECS_INVALID_OPERATION, 
         "cannot begin frame while world is in readonly mode");
+    ecs_check(!(world->flags & EcsWorldFrameInProgress), ECS_INVALID_OPERATION, 
+        "cannot begin frame while frame is already in progress");
     ecs_check(ECS_NEQZERO(user_delta_time) || ecs_os_has_time(), 
         ECS_MISSING_OS_API, "get_time");
 
@@ -19206,6 +19462,8 @@ ecs_ftime_t ecs_frame_begin(
 
     ecs_run_aperiodic(world, 0);
 
+    world->flags |= EcsWorldFrameInProgress;
+
     return world->info.delta_time;
 error:
     return (ecs_ftime_t)0;
@@ -19217,6 +19475,8 @@ void ecs_frame_end(
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(!(world->flags & EcsWorldReadonly), ECS_INVALID_OPERATION, 
         "cannot end frame while world is in readonly mode");
+    ecs_check((world->flags & EcsWorldFrameInProgress), ECS_INVALID_OPERATION, 
+        "cannot end frame while frame is not in progress");
 
     world->info.frame_count_total ++;
     
@@ -19230,6 +19490,9 @@ void ecs_frame_end(
     /* Reset command handler each frame */
     world->on_commands_active = NULL;
     world->on_commands_ctx_active = NULL;
+
+    world->flags &= ~EcsWorldFrameInProgress;
+    
 error:
     return;
 }
@@ -19318,6 +19581,8 @@ void flecs_process_pending_tables(
         return;
     }
 
+    ecs_os_perf_trace_push("flecs.process_pending_tables");
+
     flecs_journal_begin(world, EcsJournalTableEvents, 0, 0, 0);
 
     do {
@@ -19372,6 +19637,8 @@ void flecs_process_pending_tables(
     } while ((count = flecs_sparse_count(world->pending_tables)));
 
     flecs_journal_end();
+
+    ecs_os_perf_trace_pop("flecs.process_pending_tables");
 }
 
 void flecs_table_set_empty(
@@ -19431,11 +19698,13 @@ int32_t ecs_delete_empty_tables(
 {
     flecs_poly_assert(world, ecs_world_t);
 
+    ecs_os_perf_trace_push("flecs.delete_empty_tables");
+
     /* Make sure empty tables are in the empty table lists */
     ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
 
     ecs_time_t start = {0}, cur = {0};
-    int32_t delete_count = 0, clear_count = 0;
+    int32_t delete_count = 0;
     bool time_budget = false;
 
     if (ECS_NEQZERO(time_budget_seconds) || (ecs_should_log_1() && ecs_os_has_time())) {
@@ -19474,24 +19743,13 @@ int32_t ecs_delete_empty_tables(
                 flecs_table_fini(world, table);
                 delete_count ++;
             } else if (clear_generation && (gen > clear_generation)) {
-                if (flecs_table_shrink(world, table)) {
-                    clear_count ++;
-                }
+                flecs_table_shrink(world, table);
             }
         }
     }
 
 done:
-    if (ecs_should_log_1() && ecs_os_has_time()) {
-        if (delete_count) {
-            ecs_dbg_1("#[red]deleted#[normal] %d empty tables in %.2fs",
-                delete_count, ecs_time_measure(&start));
-        }
-        if (clear_count) {
-            ecs_dbg_1("#[red]cleared#[normal] %d empty tables in %.2fs",
-                clear_count, ecs_time_measure(&start));
-        }
-    }
+    ecs_os_perf_trace_pop("flecs.delete_empty_tables");
 
     return delete_count;
 }
@@ -31743,13 +32001,13 @@ int flecs_query_set_caching_policy(
     const ecs_query_desc_t *desc)
 {
     ecs_query_cache_kind_t kind = desc->cache_kind;
+    bool group_order_by = desc->group_by || desc->group_by_callback || 
+            desc->order_by || desc->order_by_callback;
 
     /* If caching policy is default, try to pick a policy that does the right
      * thing in most cases. */
     if (kind == EcsQueryCacheDefault) {
-        if (desc->entity || desc->group_by || desc->group_by_callback || 
-            desc->order_by || desc->order_by_callback)
-        {
+        if (desc->entity || group_order_by) {
             /* If the query is created with an entity handle (typically 
              * indicating that the query is named or belongs to a system) the
              * chance is very high that the query will be reused, so enable
@@ -31797,8 +32055,29 @@ int flecs_query_set_caching_policy(
             /* Same for when the query has no cacheable terms */
             impl->pub.cache_kind = EcsQueryCacheNone;
         } else {
-            /* Part of the query is cacheable */
-            impl->pub.cache_kind = EcsQueryCacheAuto;
+            /* Part of the query is cacheable. Make sure to only create a cache
+             * if the cacheable part of the query contains not just not/optional
+             * terms, as this would build a cache that contains all tables. */
+            int32_t not_optional_terms = 0, cacheable_terms = 0;
+            if (!group_order_by) {
+                int32_t i, term_count = impl->pub.term_count;
+                const ecs_term_t *terms = impl->pub.terms;
+                for (i = 0; i < term_count; i ++) {
+                    const ecs_term_t *term = &terms[i];
+                    if (term->flags_ & EcsTermIsCacheable) {
+                        cacheable_terms ++;
+                        if (term->oper == EcsNot || term->oper == EcsOptional) {
+                            not_optional_terms ++;
+                        }
+                    }
+                }
+            }
+
+            if (group_order_by || cacheable_terms != not_optional_terms) {
+                impl->pub.cache_kind = EcsQueryCacheAuto;
+            } else {
+                impl->pub.cache_kind = EcsQueryCacheNone;
+            }
         }
     }
 
@@ -32335,16 +32614,13 @@ const char* flecs_query_op_str(
 {
     switch(kind) {
     case EcsQueryAnd:            return "and       ";
-    case EcsQueryAndId:          return "andid     ";
     case EcsQueryAndAny:         return "andany    ";
     case EcsQueryTriv:           return "triv      ";
     case EcsQueryCache:          return "cache     ";
     case EcsQueryIsCache:        return "xcache    ";
     case EcsQueryOnlyAny:        return "any       ";
     case EcsQueryUp:             return "up        ";
-    case EcsQueryUpId:           return "upid      ";
     case EcsQuerySelfUp:         return "selfup    ";
-    case EcsQuerySelfUpId:       return "selfupid  ";
     case EcsQueryWith:           return "with      ";
     case EcsQueryTrav:           return "trav      ";
     case EcsQueryAndFrom:        return "andfrom   ";
@@ -33736,29 +34012,29 @@ int flecs_term_finalize(
         ecs_record_t *first_record = flecs_entities_get(world, first_entity);
         ecs_table_t *first_table = first_record ? first_record->table : NULL;
         if (first_table) {
-            /* Add traversal flags for transitive relationships */
-            if (ecs_term_ref_is_set(second) && !((second_flags & EcsTraverseFlags) == EcsSelf)) {
-                if (!((src->id & EcsIsVariable) && (src_id == EcsAny))) {
-                    if (!((second->id & EcsIsVariable) && (second_id == EcsAny))) {
-                        if (ecs_table_has_id(world, first_table, EcsTransitive)) {
-                            term->flags_ |= EcsTermTransitive;
+            if (ecs_term_ref_is_set(second)) {
+                /* Add traversal flags for transitive relationships */
+                if (!((second_flags & EcsTraverseFlags) == EcsSelf)) {
+                    if (!((src->id & EcsIsVariable) && (src_id == EcsAny))) {
+                        if (!((second->id & EcsIsVariable) && (second_id == EcsAny))) {
+                            if (ecs_table_has_id(world, first_table, EcsTransitive)) {
+                                term->flags_ |= EcsTermTransitive;
+                            }
+
+                            if (ecs_table_has_id(world, first_table, EcsReflexive)) {
+                                term->flags_ |= EcsTermReflexive;
+                            }
                         }
                     }
                 }
-            }
 
-            if (ECS_IS_PAIR(term->id)) {
-                if (ecs_table_has_id(world, first_table, EcsReflexive)) {
-                    term->flags_ |= EcsTermReflexive;
-                }
-            }
-
-            /* Check if term is union */
-            if (ecs_table_has_id(world, first_table, EcsUnion)) {
-                /* Any wildcards don't need special handling as they just return
-                 * (Rel, *). */
-                if (ECS_IS_PAIR(term->id) && ECS_PAIR_SECOND(term->id) != EcsAny) {
-                    term->flags_ |= EcsTermIsUnion;
+                /* Check if term is union */
+                if (ecs_table_has_id(world, first_table, EcsUnion)) {
+                    /* Any wildcards don't need special handling as they just return
+                    * (Rel, *). */
+                    if (ECS_IS_PAIR(term->id) && ECS_PAIR_SECOND(term->id) != EcsAny) {
+                        term->flags_ |= EcsTermIsUnion;
+                    }
                 }
             }
         }
@@ -33830,7 +34106,7 @@ int flecs_term_finalize(
 
     if (term->flags_ & EcsTermTransitive) {
         trivial_term = false;
-        cacheable_term = false;
+        cacheable_term = false; 
     }
 
     if (term->flags_ & EcsTermIdInherited) {
@@ -34006,6 +34282,7 @@ int flecs_query_finalize_terms(
     }
 
     bool cacheable = true;
+    bool match_nothing = true;
     for (i = 0; i < term_count; i ++) {
         ecs_term_t *term = &terms[i];
         bool prev_is_or = i && term[-1].oper == EcsOr;
@@ -34014,6 +34291,11 @@ int flecs_query_finalize_terms(
 
         if (flecs_term_finalize(world, term, &ctx)) {
             return -1;
+        }
+
+        if (term->src.id != EcsIsEntity) {
+            /* If term doesn't match 0 entity, query doesn't match nothing */
+            match_nothing = false;
         }
 
         if (scope_nesting) {
@@ -34180,6 +34462,12 @@ int flecs_query_finalize_terms(
             ECS_TERMSET_SET(q->fixed_fields, 1u << term->field_index);
         }
 
+        if ((term->src.id & EcsIsVariable) && 
+            (ECS_TERM_REF_ID(&term->src) != EcsThis)) 
+        {
+            ECS_TERMSET_SET(q->var_fields, 1u << term->field_index);
+        }
+
         ecs_id_record_t *idr = flecs_id_record_get(world, term->id);
         if (idr) {
             if (ecs_os_has_threading()) {
@@ -34335,6 +34623,9 @@ int flecs_query_finalize_terms(
     ECS_BIT_COND(q->flags, EcsQueryIsCacheable, 
         cacheable && (cacheable_terms == term_count) &&
             !desc->order_by_callback);
+
+    /* If none of the terms match a source, the query matches nothing */
+    ECS_BIT_COND(q->flags, EcsQueryMatchNothing, match_nothing);
 
     for (i = 0; i < q->term_count; i ++) {
         ecs_term_t *term = &q->terms[i];
@@ -34529,17 +34820,20 @@ bool flecs_query_finalize_simple(
             if (idr->flags & EcsIdIsSparse) {
                 term->flags_ |= EcsTermIsSparse;
                 cacheable = false; trivial = false;
+                q->row_fields |= flecs_uto(uint32_t, 1llu << i);
             }
         }
 
         if (ECS_IS_PAIR(id)) {
             if (ecs_has_id(world, first, EcsTransitive)) {
                 term->flags_ |= EcsTermTransitive;
-                cacheable = false; trivial = false;
+                trivial = false;
+                cacheable = false; 
             }
             if (ecs_has_id(world, first, EcsReflexive)) {
                 term->flags_ |= EcsTermReflexive;
-                cacheable = false; trivial = false;
+                trivial = false;
+                cacheable = false; 
             }
         }
 
@@ -34943,6 +35237,11 @@ uint64_t flecs_entity_index_new_id(
 
     /* Create new id */
     uint32_t id = (uint32_t)++ index->max_id;
+
+    /* Make sure id hasn't been issued before */
+    ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION, 
+        "new entity %u id already in use (likely due to overlapping ranges)", (uint32_t)id);
+
     ecs_vec_append_t(index->allocator, &index->dense, uint64_t)[0] = id;
 
     ecs_entity_index_page_t *page = flecs_entity_index_ensure_page(index, id);
@@ -34974,6 +35273,11 @@ uint64_t* flecs_entity_index_new_ids(
     int32_t i, to_add = new_count - dense_count;
     for (i = 0; i < to_add; i ++) {
         uint32_t id = (uint32_t)++ index->max_id;
+
+        /* Make sure id hasn't been issued before */
+        ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION, 
+            "new entity %u id already in use (likely due to overlapping ranges)", (uint32_t)id);
+
         int32_t dense = dense_count + i;
         ecs_vec_get_t(&index->dense, uint64_t, dense)[0] = id;
         ecs_entity_index_page_t *page = flecs_entity_index_ensure_page(index, id);
@@ -35146,7 +35450,7 @@ void flecs_remove_id_elem(
     }
 }
 
-
+static
 ecs_id_t flecs_id_record_hash(
     ecs_id_t id)
 {
@@ -35204,6 +35508,23 @@ void flecs_id_record_fini_sparse(
             ecs_abort(ECS_INTERNAL_ERROR, "unknown sparse storage");
         }
     }
+}
+
+static
+ecs_flags32_t flecs_id_record_event_flags(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    ecs_observable_t *o = &world->observable;
+    ecs_flags32_t result = 0;
+    result |= flecs_observers_exist(o, id, EcsOnAdd) * EcsIdHasOnAdd;
+    result |= flecs_observers_exist(o, id, EcsOnRemove) * EcsIdHasOnRemove;
+    result |= flecs_observers_exist(o, id, EcsOnSet) * EcsIdHasOnSet;
+    result |= flecs_observers_exist(o, id, EcsOnTableFill) * EcsIdHasOnTableFill;
+    result |= flecs_observers_exist(o, id, EcsOnTableEmpty) * EcsIdHasOnTableEmpty;
+    result |= flecs_observers_exist(o, id, EcsOnTableCreate) * EcsIdHasOnTableCreate;
+    result |= flecs_observers_exist(o, id, EcsOnTableDelete) * EcsIdHasOnTableDelete;
+    return result;
 }
 
 static
@@ -35388,14 +35709,7 @@ ecs_id_record_t* flecs_id_record_new(
         }
     }
 
-    ecs_observable_t *o = &world->observable;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnAdd) * EcsIdHasOnAdd;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnRemove) * EcsIdHasOnRemove;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnSet) * EcsIdHasOnSet;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnTableFill) * EcsIdHasOnTableFill;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnTableEmpty) * EcsIdHasOnTableEmpty;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnTableCreate) * EcsIdHasOnTableCreate;
-    idr->flags |= flecs_observers_exist(o, id, EcsOnTableDelete) * EcsIdHasOnTableDelete;
+    idr->flags |= flecs_id_record_event_flags(world, id);
 
     if (idr->flags & EcsIdIsSparse) {
         flecs_id_record_init_sparse(world, idr);
@@ -35711,6 +36025,56 @@ void flecs_fini_id_records(
 
     ecs_map_fini(&world->id_index_hi);
     ecs_os_free(world->id_index_lo);
+}
+
+static
+ecs_flags32_t flecs_id_flags(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    const ecs_id_record_t *idr = flecs_id_record_get(world, id);
+    if (idr) {
+        ecs_flags32_t extra_flags = 0;
+        if (idr->flags & EcsIdOnInstantiateInherit) {
+            extra_flags |= EcsIdHasOnAdd|EcsIdHasOnRemove;
+        }
+        return idr->flags|extra_flags;
+    }
+    return flecs_id_record_event_flags(world, id);
+}
+
+ecs_flags32_t flecs_id_flags_get(
+    ecs_world_t *world,
+    ecs_id_t id)
+{
+    ecs_flags32_t result = flecs_id_flags(world, id);
+
+    if (id != EcsAny) {
+        result |= flecs_id_flags(world, EcsAny);
+    }
+
+    if (ECS_IS_PAIR(id)) {
+        ecs_entity_t first = ECS_PAIR_FIRST(id);
+        ecs_entity_t second = ECS_PAIR_SECOND(id);
+
+        if (id != ecs_pair(first, EcsWildcard)) {
+            result |= flecs_id_flags(world, ecs_pair(first, EcsWildcard));
+        }
+        if (id != ecs_pair(EcsWildcard, second)) {
+            result |= flecs_id_flags(world, ecs_pair(EcsWildcard, second));
+        }
+        if (id != ecs_pair(EcsWildcard, EcsWildcard)) {
+            result |= flecs_id_flags(world, ecs_pair(EcsWildcard, EcsWildcard));
+        }
+
+        if (first == EcsIsA) {
+            result |= EcsIdHasOnAdd|EcsIdHasOnRemove;
+        }
+    } else if (id != EcsWildcard) {
+        result |= flecs_id_flags(world, EcsWildcard);
+    }
+
+    return result;
 }
 
 /**
@@ -36339,24 +36703,34 @@ static
 void flecs_table_add_trigger_flags(
     ecs_world_t *world, 
     ecs_table_t *table, 
+    ecs_id_t id,
     ecs_entity_t event) 
 {
     (void)world;
 
+    ecs_flags32_t flags = 0;
+
     if (event == EcsOnAdd) {
-        table->flags |= EcsTableHasOnAdd;
+        flags = EcsTableHasOnAdd;
     } else if (event == EcsOnRemove) {
-        table->flags |= EcsTableHasOnRemove;
+        flags = EcsTableHasOnRemove;
     } else if (event == EcsOnSet) {
-        table->flags |= EcsTableHasOnSet;
+        flags = EcsTableHasOnSet;
     } else if (event == EcsOnTableFill) {
-        table->flags |= EcsTableHasOnTableFill;
+        flags = EcsTableHasOnTableFill;
     } else if (event == EcsOnTableEmpty) {
-        table->flags |= EcsTableHasOnTableEmpty;
+        flags = EcsTableHasOnTableEmpty;
     } else if (event == EcsWildcard) {
-        table->flags |= EcsTableHasOnAdd|EcsTableHasOnRemove|EcsTableHasOnSet|
+        flags = EcsTableHasOnAdd|EcsTableHasOnRemove|EcsTableHasOnSet|
             EcsTableHasOnTableFill|EcsTableHasOnTableEmpty|
             EcsTableHasOnTableCreate|EcsTableHasOnTableDelete;
+    }
+
+    table->flags |= flags;
+
+    /* Add observer flags to incoming edges for id */
+    if (id && ((flags == EcsTableHasOnAdd) || (flags == EcsTableHasOnRemove))) {
+        flecs_table_edges_add_flags(world, table, id, flags);
     }
 }
 
@@ -36369,7 +36743,10 @@ void flecs_table_notify_on_remove(
 {
     int32_t count = ecs_table_count(table);
     if (count) {
-        flecs_notify_on_remove(world, table, NULL, 0, count, &table->type);
+        ecs_table_diff_t diff = ECS_TABLE_DIFF_INIT;
+        diff.removed = table->type;
+        diff.removed_flags = table->flags & EcsTableRemoveEdgeFlags;
+        flecs_notify_on_remove(world, table, NULL, 0, count, &diff);
     }
 }
 
@@ -36688,6 +37065,8 @@ void flecs_table_fini(
         ECS_INTERNAL_ERROR, NULL);
     (void)world;
 
+    ecs_os_perf_trace_push("flecs.table.free");
+
     if (!is_root && !(world->flags & EcsWorldQuit)) {
         if (table->flags & EcsTableHasOnTableDelete) {
             flecs_table_emit(world, table, EcsOnTableDelete);
@@ -36738,6 +37117,8 @@ void flecs_table_fini(
     }
 
     ecs_log_pop_2();
+
+    ecs_os_perf_trace_pop("flecs.table.free");
 }
 
 /* Free table type. Do this separately from freeing the table as types can be
@@ -37133,6 +37514,12 @@ int32_t flecs_table_append(
     table->data.count = v_entities.count;
     table->data.size = v_entities.size;
 
+    /* If this is the first entity in this table, signal queries so that the
+     * table moves from an inactive table to an active table. */
+    if (!count) {
+        flecs_table_set_empty(world, table);
+    }
+
     /* Reobtain size to ensure that the columns have the same size as the 
      * entities and record vectors. This keeps reasoning about when allocations
      * occur easier. */
@@ -37167,12 +37554,6 @@ int32_t flecs_table_append(
         ecs_assert(bs_columns != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_bitset_t *bs = &bs_columns[i];
         flecs_bitset_addn(bs, 1);
-    }
-
-    /* If this is the first entity in this table, signal queries so that the
-     * table moves from an inactive table to an active table. */
-    if (!count) {
-        flecs_table_set_empty(world, table);
     }
 
     flecs_table_check_sanity(world, table);
@@ -37235,13 +37616,6 @@ void flecs_table_delete(
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);    
 
-    /* If table is empty, deactivate it */
-    if (!count) {
-        table->data.count --;
-        flecs_table_set_empty(world, table);
-        table->data.count ++;
-    }
-
     /* Destruct component data */
     ecs_column_t *columns = table->data.columns;
     int32_t column_count = table->column_count;
@@ -37255,6 +37629,9 @@ void flecs_table_delete(
         }
 
         table->data.count --;
+        if (!count) {
+            flecs_table_set_empty(world, table);
+        }
 
         flecs_table_check_sanity(world, table);
         return;
@@ -37318,6 +37695,9 @@ void flecs_table_delete(
     }
 
     table->data.count --;
+    if (!count) {
+        flecs_table_set_empty(world, table);
+    }
 
     flecs_table_check_sanity(world, table);
 }
@@ -37859,6 +38239,7 @@ void flecs_table_merge(
 void flecs_table_notify(
     ecs_world_t *world,
     ecs_table_t *table,
+    ecs_id_t id,
     ecs_table_event_t *event)
 {
     if (world->flags & EcsWorldFini) {
@@ -37867,10 +38248,10 @@ void flecs_table_notify(
 
     switch(event->kind) {
     case EcsTableTriggersForId:
-        flecs_table_add_trigger_flags(world, table, event->event);
+        flecs_table_add_trigger_flags(world, table, id, event->event);
         break;
     case EcsTableNoTriggersForId:
-        break;
+        break; /* TODO */
     }
 }
 
@@ -37956,7 +38337,6 @@ int32_t ecs_table_get_type_index(
 {
     flecs_poly_assert(world, ecs_world_t);
     ecs_check(table != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_check(ecs_id_is_valid(world, id), ECS_INVALID_PARAMETER, NULL);
 
     if (id < FLECS_HI_COMPONENT_ID) {
         int16_t res = table->component_map[id];
@@ -38786,6 +39166,8 @@ void flecs_table_diff_builder_init(
     ecs_allocator_t *a = &world->allocator;
     ecs_vec_init_t(a, &builder->added, ecs_id_t, 256);
     ecs_vec_init_t(a, &builder->removed, ecs_id_t, 256);
+    builder->added_flags = 0;
+    builder->removed_flags = 0;
 }
 
 void flecs_table_diff_builder_fini(
@@ -38832,6 +39214,8 @@ void flecs_table_diff_build(
         added_offset);
     flecs_table_diff_build_type(world, &builder->removed, &diff->removed, 
         removed_offset);
+    diff->added_flags = builder->added_flags;
+    diff->removed_flags = builder->removed_flags;
 }
 
 void flecs_table_diff_build_noalloc(
@@ -38842,6 +39226,8 @@ void flecs_table_diff_build_noalloc(
         .array = builder->added.array, .count = builder->added.count };
     diff->removed = (ecs_type_t){
         .array = builder->removed.array, .count = builder->removed.count };
+    diff->added_flags = builder->added_flags;
+    diff->removed_flags = builder->removed_flags;
 }
 
 static
@@ -38867,6 +39253,8 @@ void flecs_table_diff_build_append_table(
 {
     flecs_table_diff_build_add_type_to_vec(world, &dst->added, &src->added);
     flecs_table_diff_build_add_type_to_vec(world, &dst->removed, &src->removed);
+    dst->added_flags |= src->added_flags;
+    dst->removed_flags |= src->removed_flags;
 }
 
 static
@@ -39029,6 +39417,8 @@ ecs_table_t *flecs_table_new(
     flecs_hashmap_result_t table_elem,
     ecs_table_t *prev)
 {
+    ecs_os_perf_trace_push("flecs.table.create");
+
     ecs_table_t *result = flecs_sparse_add_t(&world->store.tables, ecs_table_t);
     ecs_assert(result != NULL, ECS_INTERNAL_ERROR, NULL);
     result->_ = flecs_calloc_t(&world->allocator, ecs_table__t);
@@ -39080,6 +39470,8 @@ ecs_table_t *flecs_table_new(
     world->info.table_create_total ++;
 
     ecs_log_pop_2();
+
+    ecs_os_perf_trace_pop("flecs.table.create");
 
     return result;
 }
@@ -39162,6 +39554,7 @@ void flecs_compute_table_diff(
                     &world->allocators.table_diff);
                 diff->added.count = 1;
                 diff->added.array = flecs_wdup_n(world, ecs_id_t, 1, &id);
+                diff->added_flags = EcsTableHasUnion;
                 edge->diff = diff;
                 return;
             }
@@ -39174,6 +39567,7 @@ void flecs_compute_table_diff(
     int32_t i_next = 0, next_count = next_type.count;
     int32_t added_count = 0;
     int32_t removed_count = 0;
+    ecs_flags32_t added_flags = 0, removed_flags = 0;
     bool trivial_edge = !ECS_HAS_RELATION(id, EcsIsA);
 
     /* First do a scan to see how big the diff is, so we don't have to realloc
@@ -39188,18 +39582,36 @@ void flecs_compute_table_diff(
         trivial_edge &= !added || id_next == id;
         trivial_edge &= !removed || id_node == id;
 
-        added_count += added;
-        removed_count += removed;
+        if (added) {
+            added_flags |= flecs_id_flags_get(world, id_next) & 
+                EcsTableAddEdgeFlags;
+            added_count ++;
+        }
+
+        if (removed) {
+            removed_flags |= flecs_id_flags_get(world, id_node) & 
+                EcsTableRemoveEdgeFlags;
+            removed_count ++;
+        }
 
         i_node += id_node <= id_next;
         i_next += id_next <= id_node;
     }
 
-    added_count += next_count - i_next;
-    removed_count += node_count - i_node;
+    for (; i_next < next_count; i_next ++) {
+        added_flags |= flecs_id_flags_get(world, ids_next[i_next]) & 
+            EcsTableAddEdgeFlags;
+        added_count ++;
+    }
+
+    for (; i_node < node_count; i_node ++) {
+        removed_flags |= flecs_id_flags_get(world, ids_node[i_node]) & 
+            EcsTableRemoveEdgeFlags;
+        removed_count ++;
+    }
 
     trivial_edge &= (added_count + removed_count) <= 1 && 
-        !ecs_id_is_wildcard(id);
+        !ecs_id_is_wildcard(id) && !(added_flags|removed_flags);
 
     if (trivial_edge) {
         /* If edge is trivial there's no need to create a diff element for it */
@@ -39234,6 +39646,8 @@ void flecs_compute_table_diff(
     ecs_table_diff_t *diff = flecs_bcalloc(&world->allocators.table_diff);
     edge->diff = diff;
     flecs_table_diff_build(world, builder, diff, added_offset, removed_offset);
+    diff->added_flags = added_flags;
+    diff->removed_flags = removed_flags;
 
     ecs_assert(diff->added.count == added_count, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(diff->removed.count == removed_count, ECS_INTERNAL_ERROR, NULL);
@@ -39596,6 +40010,11 @@ ecs_table_t* flecs_table_traverse_add(
     if (node != to || edge->diff) {
         if (edge->diff) {
             *diff = *edge->diff;
+            if (edge->diff->added_flags & EcsIdIsUnion) {
+                diff->added.array = id_ptr;
+                diff->added.count = 1;
+                diff->removed.count = 0;
+            }
         } else {
             diff->added.array = id_ptr;
             diff->added.count = 1;
@@ -39629,6 +40048,54 @@ void flecs_init_root_table(
     uint64_t new_id = flecs_sparse_new_id(&world->store.tables);
     ecs_assert(new_id == 0, ECS_INTERNAL_ERROR, NULL);
     (void)new_id;
+}
+
+void flecs_table_edges_add_flags(
+    ecs_world_t *world,
+    ecs_table_t *table,
+    ecs_id_t id,
+    ecs_flags32_t flags)
+{
+    ecs_graph_node_t *table_node = &table->node;
+    ecs_graph_edge_hdr_t *node_refs = &table_node->refs;
+
+    /* Add flags to incoming matching add edges */
+    if (flags == EcsTableHasOnAdd) {
+        ecs_graph_edge_hdr_t *next, *cur = node_refs->next;
+        if (cur) {
+            do {
+                ecs_graph_edge_t *edge = (ecs_graph_edge_t*)cur;
+                if ((id == EcsAny) || ecs_id_match(edge->id, id)) {
+                    if (!edge->diff) {
+                        edge->diff = flecs_bcalloc(&world->allocators.table_diff);
+                        edge->diff->added.array = flecs_walloc_t(world, ecs_id_t);
+                        edge->diff->added.count = 1;
+                        edge->diff->added.array[0] = edge->id;
+                    }
+                    edge->diff->added_flags |= EcsTableHasOnAdd;
+                }
+                next = cur->next;
+            } while ((cur = next));
+        }
+    }
+
+    /* Add flags to outgoing matching remove edges */
+    if (flags == EcsTableHasOnRemove) {
+        ecs_map_iter_t it = ecs_map_iter(table->node.remove.hi);
+        while (ecs_map_next(&it)) {
+            ecs_id_t edge_id = ecs_map_key(&it);
+            if ((id == EcsAny) || ecs_id_match(edge_id, id)) {
+                ecs_graph_edge_t *edge = ecs_map_ptr(&it);
+                if (!edge->diff) {
+                    edge->diff = flecs_bcalloc(&world->allocators.table_diff);
+                    edge->diff->removed.array = flecs_walloc_t(world, ecs_id_t);
+                    edge->diff->removed.count = 1;
+                    edge->diff->removed.array[0] = edge->id;
+                }
+                edge->diff->removed_flags |= EcsTableHasOnRemove;
+            }
+        }
+    }
 }
 
 void flecs_table_clear_edges(
@@ -40617,7 +41084,7 @@ const char* flecs_entity_from_json(
         return NULL;
     }
 
-    if (!ecs_os_strcmp(token, "alerts")) {
+    if (!ecs_os_strcmp(token, "has_alerts")) {
         json = flecs_json_expect(json, JsonBoolean, token, desc);
         if (!json) {
             goto error;
@@ -41752,6 +42219,9 @@ int flecs_expr_ser_primitive(
     ecs_strbuf_t *str,
     bool is_expr);
 
+void flecs_rtt_init_default_hooks(
+    ecs_iter_t *it);
+
 #endif
 
 #endif
@@ -42074,8 +42544,12 @@ void flecs_json_serialize_query_plan(
 
     bool prev_color = ecs_log_enable_colors(true);
     char *plan = ecs_query_plan(q);
-    flecs_json_string_escape(buf, plan);
-    ecs_os_free(plan);
+    if (plan) {
+        flecs_json_string_escape(buf, plan);
+        ecs_os_free(plan);
+    } else {
+        flecs_json_null(buf);
+    }
     ecs_log_enable_colors(prev_color);
 }
 
@@ -42676,7 +43150,7 @@ void flecs_json_serialize_iter_this(
 #endif
 
     if (this_data->has_alerts) {
-        flecs_json_memberl(buf, "alerts");
+        flecs_json_memberl(buf, "has_alerts");
         flecs_json_true(buf);
     }
 }
@@ -48331,6 +48805,29 @@ double ecs_meta_get_float(
     return flecs_meta_to_float(op->kind, ptr);
 }
 
+/* Handler to get string from opaque (see ecs_meta_get_string below) */
+static int ecs_meta_get_string_value_from_opaque(
+    const struct ecs_serializer_t *ser, ecs_entity_t type, const void *value)
+{
+    if(type != ecs_id(ecs_string_t)) {
+         ecs_err("Expected value call for opaque type to be a string");
+         return -1;
+    }
+    char*** ctx = (char ***) ser->ctx;
+    *ctx = ECS_CONST_CAST(char**, value);
+    return 0;
+}
+
+/* Handler to get string from opaque (see ecs_meta_get_string below) */
+static int ecs_meta_get_string_member_from_opaque(
+    const struct ecs_serializer_t* ser, const char* name)
+{
+    (void)ser;  // silence unused warning
+    (void)name; // silence unused warning
+    ecs_err("Unexpected member call when serializing string from opaque");
+    return -1;
+}
+
 const char* ecs_meta_get_string(
     const ecs_meta_cursor_t *cursor)
 {
@@ -48339,9 +48836,28 @@ const char* ecs_meta_get_string(
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
     switch(op->kind) {
     case EcsOpString: return *(const char**)ptr;
+    case EcsOpOpaque: {
+        /* If opaque type happens to map to a string, retrieve it. 
+         Otherwise, fallback to default case (error). */
+        const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
+        if(opaque && opaque->as_type == ecs_id(ecs_string_t) && opaque->serialize) {
+            char** str = NULL;
+            ecs_serializer_t ser = {
+                .world = cursor->world,
+                .value = ecs_meta_get_string_value_from_opaque,
+                .member = ecs_meta_get_string_member_from_opaque,
+                .ctx = &str
+            };
+            opaque->serialize(&ser, ptr);
+            if(str && *str)
+                return *str;
+            /* invalid string, so fall through */
+        }
+        /* Not a compatible opaque type, so fall through */
+    }
+    /* fall through */
     case EcsOpArray:
     case EcsOpVector:
-    case EcsOpOpaque:
     case EcsOpPush:
     case EcsOpPop:
     case EcsOpScope:
@@ -48496,6 +49012,13 @@ size_t flecs_addon_vec_count(const void *ptr) {
     return flecs_ito(size_t, count);
 }
 
+static
+int flecs_const_str_serialize(const ecs_serializer_t *ser, const void *ptr) {
+    char **data = ECS_CONST_CAST(char**, ptr);
+    ser->value(ser, ecs_id(ecs_string_t), data);
+    return 0;
+}
+
 /* Initialize reflection data for core components */
 static
 void flecs_meta_import_core_definitions(
@@ -48513,6 +49036,29 @@ void flecs_meta_import_core_definitions(
         .entity = ecs_id(EcsDefaultChildComponent),
         .members = {
             { .name = "component", .type = ecs_id(ecs_entity_t) }
+        }
+    });
+
+    /* Define const string as an opaque type that maps to string
+       This enables reflection for strings that are in .rodata,
+       (read-only) so that the meta add-on does not try to free them.
+       This opaque type defines how to serialize (read) the string,
+       but won't let users assign a new value.
+    */
+    ecs_entity_t const_string = ecs_opaque(world, {
+        .entity = ecs_component(world, {
+              .entity = ecs_entity(world, {
+                .name = "flecs.core.const_string_t",
+                .root_sep = ""
+            }),
+            .type = {
+                .size = ECS_SIZEOF(const char*),
+                .alignment = ECS_ALIGNOF(const char*)
+            }          
+        }),
+        .type = {
+            .as_type = ecs_id(ecs_string_t),
+            .serialize = flecs_const_str_serialize,       
         }
     });
 
@@ -48548,9 +49094,9 @@ void flecs_meta_import_core_definitions(
             .root_sep = ""
         }),
         .members = {
-            { .name = "compiler", .type = ecs_id(ecs_string_t) },
+            { .name = "compiler", .type = const_string },
             { .name = "addons", .type = addon_vec },
-            { .name = "version", .type = ecs_id(ecs_string_t) },
+            { .name = "version", .type = const_string },
             { .name = "version_major", .type = ecs_id(ecs_i16_t) },
             { .name = "version_minor", .type = ecs_id(ecs_i16_t) },
             { .name = "version_patch", .type = ecs_id(ecs_i16_t) },
@@ -49015,14 +49561,16 @@ int flecs_init_type(
 
     EcsType *meta_type = ecs_ensure(world, type, EcsType);
     if (meta_type->kind == 0) {
+        /* Determine if this is an existing type or a reflection-defined type (runtime type) */
         meta_type->existing = ecs_has(world, type, EcsComponent);
 
-        /* Ensure that component has a default constructor, to prevent crashing
-         * serializers on uninitialized values. */
+        /* For existing types, ensure that component has a default constructor, to prevent crashing
+         * serializers on uninitialized values. For runtime types (rtt), the default hooks are set
+         by flecs_meta_rtt_init_default_hooks */
         ecs_type_info_t *ti = flecs_type_info_ensure(world, type);
-        if (!ti->hooks.ctor) {
+        if (meta_type->existing && !ti->hooks.ctor) {
             ti->hooks.ctor = flecs_default_ctor;
-        }
+        } 
     } else {
         if (meta_type->kind != kind) {
             ecs_err("type '%s' reregistered as '%s' (was '%s')", 
@@ -49862,30 +50410,6 @@ void flecs_unit_quantity_monitor(ecs_iter_t *it) {
 }
 
 static
-void ecs_meta_type_init_default_ctor(ecs_iter_t *it) {
-    ecs_world_t *world = it->world;
-    EcsType *type = ecs_field(it, EcsType, 0);
-
-    int i;
-    for (i = 0; i < it->count; i ++) {
-        /* If a component is defined from reflection data, configure it with the
-         * default constructor. This ensures that a new component value does not
-         * contain uninitialized memory, which could cause serializers to crash
-         * when for example inspecting string fields. */
-        if (!type->existing) {
-            ecs_entity_t e = it->entities[i];
-            const ecs_type_info_t *ti = ecs_get_type_info(world, e);
-            if (!ti || !ti->hooks.ctor) {
-                ecs_set_hooks_id(world, e, 
-                    &(ecs_type_hooks_t){ 
-                        .ctor = flecs_default_ctor
-                    });
-            }
-        }
-    }
-}
-
-static
 void flecs_member_on_set(ecs_iter_t *it) {
     EcsMember *mbr = ecs_field(it, EcsMember, 0);
     if (!mbr->count) {
@@ -50147,7 +50671,7 @@ void FlecsMetaImport(
     ecs_observer(world, {
         .query.terms[0] = { .id = ecs_id(EcsType) },
         .events = {EcsOnSet},
-        .callback = ecs_meta_type_init_default_ctor
+        .callback = flecs_rtt_init_default_hooks
     });
 
     ecs_observer(world, {
@@ -50210,6 +50734,687 @@ void FlecsMetaImport(
 
     /* Import reflection definitions for builtin types */
     flecs_meta_import_definitions(world);
+}
+
+#endif
+
+/*
+ * @file addons/meta/rtt_lifecycle.c
+ * @brief Runtime components lifecycle management
+ */
+
+
+#ifdef FLECS_META
+
+/* Stores all the information necessary to forward a hook call to a
+ * struct's member type */
+typedef struct ecs_rtt_call_data_t {
+    union {
+        ecs_xtor_t xtor;
+        ecs_move_t move;
+        ecs_copy_t copy;
+    } hook;
+    const ecs_type_info_t *type_info;
+    int32_t offset;
+    int32_t count;
+} ecs_rtt_call_data_t;
+
+/* Lifecycle context for runtime structs */
+typedef struct ecs_rtt_struct_ctx_t {
+    ecs_vec_t vctor; /* vector<ecs_string_initializertt_call_data_t> */
+    ecs_vec_t vdtor; /* vector<ecs_rtt_call_data_t> */
+    ecs_vec_t vmove; /* vector<ecs_rtt_call_data_t> */
+    ecs_vec_t vcopy; /* vector<ecs_rtt_call_data_t> */
+} ecs_rtt_struct_ctx_t;
+
+/* Lifecycle context for runtime arrays */
+typedef struct ecs_rtt_array_ctx_t {
+    const ecs_type_info_t *type_info;
+    int32_t elem_count;
+} ecs_rtt_array_ctx_t;
+
+/* Lifecycle context for runtime vectors */
+typedef struct ecs_rtt_vector_ctx_t {
+    const ecs_type_info_t *type_info;
+} ecs_rtt_vector_ctx_t;
+
+/* Generic copy assign hook */
+static
+void flecs_rtt_default_copy(
+    void *dst_ptr,
+    const void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_os_memcpy(dst_ptr, src_ptr, count * type_info->size);
+}
+
+/* Generic move assign hook */
+static
+void flecs_rtt_default_move(
+    void *dst_ptr,
+    void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    flecs_rtt_default_copy(dst_ptr, src_ptr, count, type_info);
+}
+
+/*
+ *
+ * RTT struct support
+ *
+ */
+
+/* Invokes struct member type's constructor/destructor using saved information
+ * in the lifecycle context */
+static
+void flecs_rtt_struct_xtor(
+    ecs_vec_t *xtor_data_vec,
+    void *ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    int cb_count = ecs_vec_count(xtor_data_vec);
+    int i, j;
+    for (j = 0; j < count; j++) {
+        void *elem_ptr = ECS_ELEM(ptr, type_info->size, j);
+        for (i = 0; i < cb_count; i++) {
+            ecs_rtt_call_data_t *xtor_data =
+                ecs_vec_get_t(xtor_data_vec, ecs_rtt_call_data_t, i);
+            xtor_data->hook.xtor(
+                ECS_OFFSET(elem_ptr, xtor_data->offset),
+                xtor_data->count,
+                xtor_data->type_info);
+        }
+    }
+}
+
+/* Generic struct constructor. It will read hook information call data from
+ * the structs's lifecycle context and call the constructors configured when
+ * the type was created. */
+static
+void flecs_rtt_struct_ctor(
+    void *ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_struct_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_assert(rtt_ctx != NULL, ECS_INTERNAL_ERROR, NULL);
+    flecs_rtt_struct_xtor(&rtt_ctx->vctor, ptr, count, type_info);
+}
+
+/* Generic struct destructor. It will read hook information call data from
+ * the structs's lifecycle context and call the constructors configured when
+ * the type was created. */
+static
+void flecs_rtt_struct_dtor(
+    void *ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_struct_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_assert(rtt_ctx != NULL, ECS_INTERNAL_ERROR, NULL);
+    flecs_rtt_struct_xtor(&rtt_ctx->vdtor, ptr, count, type_info);
+}
+
+/* Generic move hook. It will read hook information call data from the
+ * structs's lifecycle context and call the move hooks configured when
+ * the type was created. */
+static
+void flecs_rtt_struct_move(
+    void *dst_ptr,
+    void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_struct_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_assert(rtt_ctx != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    int cb_count = ecs_vec_count(&rtt_ctx->vmove);
+    int i, j;
+    for (j = 0; j < count; j++) {
+        ecs_size_t elem_offset = type_info->size * j;
+        void *elem_dst_ptr = ECS_OFFSET(dst_ptr, elem_offset);
+        void *elem_src_ptr = ECS_OFFSET(src_ptr, elem_offset);
+        for (i = 0; i < cb_count; i++) {
+            ecs_rtt_call_data_t *move_data =
+                ecs_vec_get_t(&rtt_ctx->vmove, ecs_rtt_call_data_t, i);
+            move_data->hook.move(
+                ECS_OFFSET(elem_dst_ptr, move_data->offset),
+                ECS_OFFSET(elem_src_ptr, move_data->offset),
+                move_data->count,
+                move_data->type_info);
+        }
+    }
+}
+
+/* Generic copy hook. It will read hook information call data from the
+ * structs's lifecycle context and call the copy hooks configured when
+ * the type was created. */
+static
+void flecs_rtt_struct_copy(
+    void *dst_ptr,
+    const void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_struct_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_assert(rtt_ctx != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    int cb_count = ecs_vec_count(&rtt_ctx->vcopy);
+    int i, j;
+    for (j = 0; j < count; j++) {
+        ecs_size_t elem_offset = type_info->size * j;
+        void *elem_dst_ptr = ECS_OFFSET(dst_ptr, elem_offset);
+        const void *elem_src_ptr = ECS_OFFSET(src_ptr, elem_offset);
+        for (i = 0; i < cb_count; i++) {
+            ecs_rtt_call_data_t *copy_data =
+                ecs_vec_get_t(&rtt_ctx->vcopy, ecs_rtt_call_data_t, i);
+            copy_data->hook.copy(
+                ECS_OFFSET(elem_dst_ptr, copy_data->offset),
+                ECS_OFFSET(elem_src_ptr, copy_data->offset),
+                copy_data->count,
+                copy_data->type_info);
+        }
+    }
+}
+
+static
+void flecs_rtt_free_lifecycle_struct_ctx(
+    void *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    ecs_rtt_struct_ctx_t *lifecycle_ctx = ctx;
+
+    ecs_vec_fini_t(NULL, &lifecycle_ctx->vctor, ecs_rtt_call_data_t);
+    ecs_vec_fini_t(NULL, &lifecycle_ctx->vdtor, ecs_rtt_call_data_t);
+    ecs_vec_fini_t(NULL, &lifecycle_ctx->vmove, ecs_rtt_call_data_t);
+    ecs_vec_fini_t(NULL, &lifecycle_ctx->vcopy, ecs_rtt_call_data_t);
+
+    ecs_os_free(ctx);
+}
+
+static
+ecs_rtt_struct_ctx_t * flecs_rtt_configure_struct_hooks(
+    ecs_world_t *world,
+    const ecs_type_info_t *ti,
+    bool ctor,
+    bool dtor,
+    bool move,
+    bool copy)
+{
+    ecs_type_hooks_t hooks = ti->hooks;
+    if (hooks.lifecycle_ctx_free) {
+        hooks.lifecycle_ctx_free(hooks.lifecycle_ctx);
+    }
+
+    ecs_rtt_struct_ctx_t *rtt_ctx = NULL;
+    if (ctor || dtor || move || copy) {
+        rtt_ctx = ecs_os_malloc_t(ecs_rtt_struct_ctx_t);
+        ecs_vec_init_t(NULL, &rtt_ctx->vctor, ecs_rtt_call_data_t, 0);
+        ecs_vec_init_t(NULL, &rtt_ctx->vdtor, ecs_rtt_call_data_t, 0);
+        ecs_vec_init_t(NULL, &rtt_ctx->vmove, ecs_rtt_call_data_t, 0);
+        ecs_vec_init_t(NULL, &rtt_ctx->vcopy, ecs_rtt_call_data_t, 0);
+        hooks.lifecycle_ctx = rtt_ctx;
+        hooks.lifecycle_ctx_free = flecs_rtt_free_lifecycle_struct_ctx;
+
+        if (ctor) {
+            hooks.ctor = flecs_rtt_struct_ctor;
+        }
+        if (dtor) {
+            hooks.dtor = flecs_rtt_struct_dtor;
+        }
+        if (move) {
+            hooks.move = flecs_rtt_struct_move;
+        }
+        if (copy) {
+            hooks.copy = flecs_rtt_struct_copy;
+        }
+    } else {
+        hooks.lifecycle_ctx = NULL;
+        hooks.lifecycle_ctx_free = NULL;
+    }
+    ecs_set_hooks_id(world, ti->component, &hooks);
+    return rtt_ctx;
+}
+
+/* Checks if a struct member's types have hooks installed. If so, it generates
+ * and installs required hooks for the struct type itself. These hooks will
+ * invoke the member hooks when necessary  */
+static
+void flecs_rtt_init_default_hooks_struct(
+    ecs_world_t *world,
+    ecs_entity_t component,
+    const ecs_type_info_t *ti)
+{
+    /* Obtain struct information to figure out what members it contains: */
+    const EcsStruct *struct_info = ecs_get(world, component, EcsStruct);
+    ecs_assert(struct_info != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    /* These flags will be set to true if we determine we need to generate a
+     * hook of a particular type: */
+    bool ctor_hook_required = false;
+    bool dtor_hook_required = false;
+    bool move_hook_required = false;
+    bool copy_hook_required = false;
+
+    /* Iterate all struct members and see if any member type has hooks. If so,
+     * the struct itself will need to have that hook: */
+    int i, member_count = ecs_vec_count(&struct_info->members);
+    ecs_member_t *members = ecs_vec_first(&struct_info->members);
+    for (i = 0; i < member_count; i++) {
+        ecs_member_t *m = &members[i];
+        const ecs_type_info_t *member_ti = ecs_get_type_info(world, m->type);
+        ctor_hook_required |= member_ti->hooks.ctor &&
+                              member_ti->hooks.ctor != flecs_default_ctor;
+        dtor_hook_required |= member_ti->hooks.dtor != NULL;
+        move_hook_required |= member_ti->hooks.move != NULL;
+        copy_hook_required |= member_ti->hooks.copy != NULL;
+    }
+
+    /* If any hook is required, then create a lifecycle context and configure a
+     * generic hook that will interpret that context: */
+    ecs_rtt_struct_ctx_t *rtt_ctx = flecs_rtt_configure_struct_hooks(
+        world,
+        ti,
+        ctor_hook_required,
+        dtor_hook_required,
+        move_hook_required,
+        copy_hook_required);
+
+    if (!rtt_ctx) {
+        return; /* no hooks required */
+    }
+
+    /* At least a hook was configured, therefore examine each struct member to
+     * build the vector of calls that will then be executed by the generic hook
+     * handler: */
+    for (i = 0; i < member_count; i++) {
+        ecs_member_t *m = &members[i];
+        const ecs_type_info_t *member_ti = ecs_get_type_info(world, m->type);
+        if (ctor_hook_required) {
+            ecs_rtt_call_data_t *ctor_data =
+                ecs_vec_append_t(NULL, &rtt_ctx->vctor, ecs_rtt_call_data_t);
+            ctor_data->count = m->count;
+            ctor_data->offset = m->offset;
+            ctor_data->type_info = member_ti;
+            if (member_ti->hooks.ctor) {
+                ctor_data->hook.xtor = member_ti->hooks.ctor;
+            } else {
+                ctor_data->hook.xtor = flecs_default_ctor;
+            }
+        }
+        if (dtor_hook_required && member_ti->hooks.dtor) {
+            ecs_rtt_call_data_t *dtor_data =
+                ecs_vec_append_t(NULL, &rtt_ctx->vdtor, ecs_rtt_call_data_t);
+            dtor_data->count = m->count;
+            dtor_data->offset = m->offset;
+            dtor_data->type_info = member_ti;
+            dtor_data->hook.xtor = member_ti->hooks.dtor;
+        }
+        if (move_hook_required) {
+            ecs_rtt_call_data_t *move_data =
+                ecs_vec_append_t(NULL, &rtt_ctx->vmove, ecs_rtt_call_data_t);
+            move_data->offset = m->offset;
+            move_data->type_info = member_ti;
+            move_data->count = m->count;
+            if (member_ti->hooks.move) {
+                move_data->hook.move = member_ti->hooks.move;
+            } else {
+                move_data->hook.move = flecs_rtt_default_move;
+            }
+        }
+        if (copy_hook_required) {
+            ecs_rtt_call_data_t *copy_data =
+                ecs_vec_append_t(NULL, &rtt_ctx->vcopy, ecs_rtt_call_data_t);
+            copy_data->offset = m->offset;
+            copy_data->type_info = member_ti;
+            copy_data->count = m->count;
+            if (member_ti->hooks.copy) {
+                copy_data->hook.copy = member_ti->hooks.copy;
+            } else {
+                copy_data->hook.copy = flecs_rtt_default_copy;
+            }
+        }
+    }
+}
+
+/*
+ *
+ * RTT array support
+ *
+ */
+
+static
+void flecs_rtt_free_lifecycle_array_ctx(
+    void *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    ecs_os_free(ctx);
+}
+
+/* Generic array constructor. It will invoke the constructor of the underlying
+ * type for all the elements */
+static
+void flecs_rtt_array_ctor(
+    void *ptr,
+    int32_t count, /* note: "count" is how many arrays to initialize, not how
+                      many elements are in the array */
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_array_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_xtor_t ctor = rtt_ctx->type_info->hooks.ctor;
+    int i;
+    for (i = 0; i < count; i++) {
+        void *arr = ECS_ELEM(ptr, type_info->size, i);
+        ctor(arr, rtt_ctx->elem_count, rtt_ctx->type_info);
+    }
+}
+
+/* Generic array constructor. It will invoke the destructor of the underlying
+ * type for all the elements */
+static
+void flecs_rtt_array_dtor(
+    void *ptr,
+    int32_t count, /* note: "count" is how many arrays to destroy, not how
+                      many elements are in the array */
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_array_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_xtor_t dtor = rtt_ctx->type_info->hooks.dtor;
+    int i;
+    for (i = 0; i < count; i++) {
+        void *arr = ECS_ELEM(ptr, type_info->size, i);
+        dtor(arr, rtt_ctx->elem_count, rtt_ctx->type_info);
+    }
+}
+
+/* Generic array move hook. It will invoke the move hook of the underlying
+ * type for all the elements */
+static
+void flecs_rtt_array_move(
+    void *dst_ptr,
+    void *src_ptr,
+    int32_t count, /* note: "count" is how many arrays to move, not how
+                      many elements are in the array */
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_array_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_move_t move = rtt_ctx->type_info->hooks.move;
+    int i;
+    for (i = 0; i < count; i++) {
+        void *src_arr = ECS_ELEM(src_ptr, type_info->size, i);
+        void *dst_arr = ECS_ELEM(dst_ptr, type_info->size, i);
+        move(dst_arr, src_arr, rtt_ctx->elem_count, rtt_ctx->type_info);
+    }
+}
+
+/* Generic array copy hook. It will invoke the copy hook of the underlying
+ * type for all the elements */
+static
+void flecs_rtt_array_copy(
+    void *dst_ptr,
+    const void *src_ptr,
+    int32_t count, /* note: "count" is how many arrays to copy, not how
+                      many elements are in the array */
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_array_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_copy_t copy = rtt_ctx->type_info->hooks.copy;
+    int i;
+    for (i = 0; i < count; i++) {
+        const void *src_arr = ECS_ELEM(src_ptr, type_info->size, i);
+        void *dst_arr = ECS_ELEM(dst_ptr, type_info->size, i);
+        copy(dst_arr, src_arr, rtt_ctx->elem_count, rtt_ctx->type_info);
+    }
+}
+
+/* Checks if an array's underlying type has hooks installed. If so, it generates
+ * and installs required hooks for the array type itself. These hooks will
+ * invoke the underlying type's hook for each element in the array. */
+static
+void flecs_rtt_init_default_hooks_array(
+    ecs_world_t *world, 
+    ecs_entity_t component)
+{
+    const EcsArray *array_info = ecs_get(world, component, EcsArray);
+    ecs_assert(array_info != NULL, ECS_INTERNAL_ERROR, NULL);
+    const ecs_type_info_t *array_ti =
+        ecs_get_type_info(world, array_info->type);
+    bool ctor_hook_required =
+        array_ti->hooks.ctor && array_ti->hooks.ctor != flecs_default_ctor;
+    bool dtor_hook_required = array_ti->hooks.dtor != NULL;
+    bool move_hook_required = array_ti->hooks.move != NULL;
+    bool copy_hook_required = array_ti->hooks.copy != NULL;
+
+    if (!ctor_hook_required && !dtor_hook_required && !move_hook_required &&
+        !copy_hook_required) {
+        return; /* no hooks required */
+    }
+
+    ecs_rtt_array_ctx_t *rtt_ctx = ecs_os_malloc_t(ecs_rtt_array_ctx_t);
+    rtt_ctx->type_info = array_ti;
+    rtt_ctx->elem_count = array_info->count;
+    ecs_type_hooks_t hooks = *ecs_get_hooks_id(world, component);
+    if (hooks.lifecycle_ctx_free) {
+        hooks.lifecycle_ctx_free(hooks.lifecycle_ctx);
+    }
+
+    hooks.lifecycle_ctx = rtt_ctx;
+    hooks.lifecycle_ctx_free = flecs_rtt_free_lifecycle_array_ctx;
+
+    if (ctor_hook_required) {
+        hooks.ctor = flecs_rtt_array_ctor;
+    }
+
+    if (dtor_hook_required) {
+        hooks.dtor = flecs_rtt_array_dtor;
+    }
+
+    if (move_hook_required) {
+        hooks.move = flecs_rtt_array_move;
+    }
+
+    if (copy_hook_required) {
+        hooks.copy = flecs_rtt_array_copy;
+    }
+
+    ecs_set_hooks_id(world, component, &hooks);
+}
+
+/*
+ *
+ * RTT vector support
+ *
+ */
+
+static
+void flecs_rtt_free_lifecycle_vector_ctx(
+    void *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    ecs_os_free(ctx);
+}
+
+/* Generic vector constructor. Makes sure the vector structure is initialized to
+ * 0 elements */
+static
+void flecs_rtt_vector_ctor(
+    void *ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_vector_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    int i;
+    for (i = 0; i < count; i++) {
+        ecs_vec_t *vec = ECS_ELEM(ptr, type_info->size, i);
+        ecs_vec_init(NULL, vec, rtt_ctx->type_info->size, 0);
+    }
+}
+
+/* Generic vector destructor. It will invoke the destructor for each element of
+ * the vector and finalize resources associated to the vector itself. */
+static
+void flecs_rtt_vector_dtor(
+    void *ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_vector_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    ecs_xtor_t dtor = rtt_ctx->type_info->hooks.dtor;
+    int i;
+    for (i = 0; i < count; i++) {
+        ecs_vec_t *vec = ECS_ELEM(ptr, type_info->size, i);
+        int32_t num_elements = ecs_vec_count(vec);
+        if (dtor && num_elements) {
+            dtor(ecs_vec_first(vec), num_elements, rtt_ctx->type_info);
+        }
+        ecs_vec_fini(NULL, vec, rtt_ctx->type_info->size);
+    }
+}
+
+/* Generic vector move hook. */
+static
+void flecs_rtt_vector_move(
+    void *dst_ptr,
+    void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    flecs_rtt_vector_dtor(dst_ptr, count, type_info);
+    int i;
+    for (i = 0; i < count; i++) {
+        ecs_vec_t *src_vec = ECS_ELEM(src_ptr, type_info->size, i);
+        ecs_vec_t *dst_vec = ECS_ELEM(dst_ptr, type_info->size, i);
+        *dst_vec = *src_vec;
+        src_vec->array = NULL;
+        src_vec->count = 0;
+    }
+}
+
+/* Generic vector copy hook. It makes a deep copy of vector contents */
+static
+void flecs_rtt_vector_copy(
+    void *dst_ptr,
+    const void *src_ptr,
+    int32_t count,
+    const ecs_type_info_t *type_info)
+{
+    ecs_rtt_vector_ctx_t *rtt_ctx = type_info->hooks.lifecycle_ctx;
+    flecs_rtt_vector_dtor(dst_ptr, count, type_info);
+    ecs_copy_t copy = rtt_ctx->type_info->hooks.copy
+                          ? rtt_ctx->type_info->hooks.copy
+                          : flecs_rtt_default_copy;
+    ecs_xtor_t ctor = rtt_ctx->type_info->hooks.ctor
+                          ? rtt_ctx->type_info->hooks.ctor
+                          : flecs_default_ctor;
+    ecs_xtor_t dtor = rtt_ctx->type_info->hooks.dtor;
+    int i;
+    for (i = 0; i < count; i++) {
+        const ecs_vec_t *src_vec = ECS_ELEM(src_ptr, type_info->size, i);
+        ecs_vec_t *dst_vec = ECS_ELEM(dst_ptr, type_info->size, i);
+        int32_t src_count = ecs_vec_count(src_vec);
+        int32_t dst_count = ecs_vec_count(dst_vec);
+        if (dtor && dst_count) {
+            dtor(ecs_vec_first(dst_vec), dst_count, rtt_ctx->type_info);
+        }
+        ecs_vec_set_count(NULL, dst_vec, rtt_ctx->type_info->size, src_count);
+        ctor(ecs_vec_first(dst_vec), src_count, rtt_ctx->type_info);
+        copy(
+            ecs_vec_first(dst_vec),
+            ecs_vec_first(src_vec),
+            src_count,
+            rtt_ctx->type_info);
+    }
+}
+
+/* Generates and installs required hooks for managing the vector and underlying
+ * type lifecycle. Vectors always have hooks because at the very least the
+ * vector structure itself must be initialized/destroyed/copied/moved, even if
+ * empty. */
+static
+void flecs_rtt_init_default_hooks_vector(
+    ecs_world_t *world,
+    ecs_entity_t component)
+{
+    const EcsVector *vector_info = ecs_get(world, component, EcsVector);
+    ecs_assert(vector_info != NULL, ECS_INTERNAL_ERROR, NULL);
+    const ecs_type_info_t *vector_ti =
+        ecs_get_type_info(world, vector_info->type);
+    ecs_rtt_vector_ctx_t *rtt_ctx = ecs_os_malloc_t(ecs_rtt_vector_ctx_t);
+    rtt_ctx->type_info = vector_ti;
+    ecs_type_hooks_t hooks = *ecs_get_hooks_id(world, component);
+    if (hooks.lifecycle_ctx_free) {
+        hooks.lifecycle_ctx_free(hooks.lifecycle_ctx);
+    }
+    hooks.lifecycle_ctx = rtt_ctx;
+    hooks.lifecycle_ctx_free = flecs_rtt_free_lifecycle_vector_ctx;
+    hooks.ctor = flecs_rtt_vector_ctor;
+    hooks.dtor = flecs_rtt_vector_dtor;
+    hooks.move = flecs_rtt_vector_move;
+    hooks.copy = flecs_rtt_vector_copy;
+    ecs_set_hooks_id(world, component, &hooks);
+}
+
+void flecs_rtt_init_default_hooks(
+    ecs_iter_t *it)
+{
+    ecs_world_t *world = it->world;
+    EcsType *type_field = ecs_field(it, EcsType, 0);
+
+    int i;
+    for (i = 0; i < it->count; i++) {
+        EcsType *type = &type_field[i];
+        if (type->existing) {
+            continue; /* non-rtt type. Ignore. */
+        }
+
+        /* If a component is defined from reflection data, configure appropriate
+         * default hooks.
+         * - For trivial types, at least set a default constructor so memory is
+         * zero-initialized
+         * - For struct types, configure a hook that in turn calls hooks of
+         * member types, if those member types have hooks defined themselves.
+         * - For array types, configure a hook that in turn calls hooks for the
+         * underlying type, for each element in the array.
+         *  - For vector types, configure hooks to manage the vector structure
+         * itself, move the vector and deep-copy vector elements
+         * */
+
+        ecs_entity_t component = it->entities[i];
+        const ecs_type_info_t *ti = ecs_get_type_info(world, component);
+
+        if (ti) {
+            if (type->kind == EcsStructType) {
+                flecs_rtt_init_default_hooks_struct(world, component, ti);
+            } else if (type->kind == EcsArrayType) {
+                flecs_rtt_init_default_hooks_array(world, component);
+            } else if (type->kind == EcsVectorType) {
+                flecs_rtt_init_default_hooks_vector(world, component);
+            }
+        }
+
+        /* Make sure there is at least a default constructor. This ensures that
+         * a new component value does not contain uninitialized memory, which
+         * could cause serializers to crash when for example inspecting string
+         * fields. */
+        if (!ti || !ti->hooks.ctor) {
+            ecs_set_hooks_id(
+                world,
+                component,
+                &(ecs_type_hooks_t){.ctor = flecs_default_ctor});
+        }
+    }
 }
 
 #endif
@@ -51709,9 +52914,11 @@ int32_t flecs_run_pipeline_ops(
         ecs_system_t* sys = (ecs_system_t*)poly->poly;
 
         /* Keep track of the last frame for which the system has ran, so we
-        * know from where to resume the schedule in case the schedule
-        * changes during a merge. */
-        sys->last_frame = world->info.frame_count_total + 1;
+         * know from where to resume the schedule in case the schedule
+         * changes during a merge. */
+        if (stage_index == 0) {
+            sys->last_frame = world->info.frame_count_total + 1;
+        }
 
         ecs_stage_t* s = NULL;
         if (!op->immediate) {
@@ -51723,7 +52930,7 @@ int32_t flecs_run_pipeline_ops(
         flecs_run_intern(world, s, system, sys, stage_index,
             stage_count, delta_time, NULL);
 
-        world->info.systems_ran_frame++;
+        ecs_os_linc(&world->info.systems_ran_frame);
         ran_since_merge++;
 
         if (ran_since_merge == op->count) {
@@ -56381,12 +57588,6 @@ const char* flecs_id_parse(
         return NULL;
     }
 
-    if (!ecs_id_is_valid(world, term.id)) {
-        ecs_parser_error(name, expr, (result - expr), 
-            "invalid term for add expression");
-        return NULL;
-    }
-
     if (term.oper != EcsAnd) {
         ecs_parser_error(name, expr, (result - expr), 
             "invalid operator for add expression");
@@ -57527,11 +58728,13 @@ int flecs_script_template_preprocess(
     ecs_script_eval_visitor_t *v,
     ecs_script_template_t *template)
 {
+    ecs_visit_action_t prev_visit = v->base.visit;
     v->template = template;
     v->base.visit = (ecs_visit_action_t)flecs_script_template_eval;
     v->vars = flecs_script_vars_push(v->vars, &v->stack, v->allocator);
     int result = ecs_script_visit_scope(v, template->node->scope);
     v->vars = ecs_script_vars_pop(v->vars);
+    v->base.visit = prev_visit;
     v->template = NULL;
     return result;
 }
@@ -62011,39 +63214,47 @@ void FlecsWorldMonitorImport(
 
 ECS_COMPONENT_DECLARE(EcsWorldSummary);
 
+static 
+void flecs_copy_world_summary(
+    ecs_world_t *world,
+    EcsWorldSummary *dst)
+{
+    const ecs_world_info_t *info = ecs_get_world_info(world);
+
+    dst->target_fps = (double)info->target_fps;
+    dst->time_scale = (double)info->time_scale;
+
+    dst->frame_time_last = (double)info->frame_time_total - dst->frame_time_total;
+    dst->system_time_last = (double)info->system_time_total - dst->system_time_total;
+    dst->merge_time_last = (double)info->merge_time_total - dst->merge_time_total;
+
+    dst->frame_time_total = (double)info->frame_time_total;
+    dst->system_time_total = (double)info->system_time_total;
+    dst->merge_time_total = (double)info->merge_time_total;
+
+    dst->frame_count ++;
+    dst->command_count +=
+        info->cmd.add_count +
+        info->cmd.remove_count +
+        info->cmd.delete_count +
+        info->cmd.clear_count +
+        info->cmd.set_count +
+        info->cmd.ensure_count +
+        info->cmd.modified_count +
+        info->cmd.discard_count +
+        info->cmd.event_count +
+        info->cmd.other_count;
+
+    dst->build_info = *ecs_get_build_info();
+}
+
 static
 void UpdateWorldSummary(ecs_iter_t *it) {
     EcsWorldSummary *summary = ecs_field(it, EcsWorldSummary, 0);
 
-    const ecs_world_info_t *info = ecs_get_world_info(it->world);
-
     int32_t i, count = it->count;
     for (i = 0; i < count; i ++) {
-        summary[i].target_fps = (double)info->target_fps;
-        summary[i].time_scale = (double)info->time_scale;
-
-        summary[i].frame_time_last = (double)info->frame_time_total - summary[i].frame_time_total;
-        summary[i].system_time_last = (double)info->system_time_total - summary[i].system_time_total;
-        summary[i].merge_time_last = (double)info->merge_time_total - summary[i].merge_time_total;
-
-        summary[i].frame_time_total = (double)info->frame_time_total;
-        summary[i].system_time_total = (double)info->system_time_total;
-        summary[i].merge_time_total = (double)info->merge_time_total;
-
-        summary[i].frame_count ++;
-        summary[i].command_count +=
-            info->cmd.add_count +
-            info->cmd.remove_count +
-            info->cmd.delete_count +
-            info->cmd.clear_count +
-            info->cmd.set_count +
-            info->cmd.ensure_count +
-            info->cmd.modified_count +
-            info->cmd.discard_count +
-            info->cmd.event_count +
-            info->cmd.other_count;
-
-        summary[i].build_info = *ecs_get_build_info();
+        flecs_copy_world_summary(it->world, &summary[i]);
     }
 }
 
@@ -62106,6 +63317,10 @@ void FlecsWorldSummaryImport(
         .target_fps = (double)info->target_fps,
         .time_scale = (double)info->time_scale
     });
+
+    EcsWorldSummary *summary = ecs_ensure(world, EcsWorld, EcsWorldSummary);
+    flecs_copy_world_summary(world, summary);
+    ecs_modified(world, EcsWorld, EcsWorldSummary);    
 }
 
 #endif
@@ -62168,6 +63383,8 @@ ecs_entity_t flecs_run_intern(
         }
     }
 
+    ecs_os_perf_trace_push(system_data->name);
+
     if (ecs_should_log_3()) {
         char *path = ecs_get_path(world, system);
         ecs_dbg_3("worker %d: %s", stage_index, path);
@@ -62212,7 +63429,10 @@ ecs_entity_t flecs_run_intern(
 
     ecs_run_action_t run = system_data->run;
     if (run) {
-        if (!system_data->query->term_count) {
+        /* If system query matches nothing, the system run callback doesn't have
+         * anything to iterate, so the iterator resources don't get cleaned up
+         * automatically, so clean it up here. */
+        if (system_data->query->flags & EcsQueryMatchNothing) {
             it->next = flecs_default_next_callback; /* Return once */
             run(it);
             ecs_iter_fini(&qit);
@@ -62243,6 +63463,8 @@ ecs_entity_t flecs_run_intern(
     }
 
     flecs_defer_end(world, stage);
+
+    ecs_os_perf_trace_pop(system_data->name);
 
     return it->interrupted_by;
 }
@@ -62294,6 +63516,9 @@ void flecs_system_fini(ecs_system_t *sys) {
         sys->run_ctx_free(sys->run_ctx);
     }
 
+    /* Safe cast, type owns name */
+    ecs_os_free(ECS_CONST_CAST(char*, sys->name));
+
     flecs_poly_free(sys, ecs_system_t);
 }
 
@@ -62305,11 +63530,18 @@ void flecs_system_poly_fini(void *sys)
 }
 
 static
-void flecs_system_init_timer(
+int flecs_system_init_timer(
     ecs_world_t *world,
     ecs_entity_t entity,
     const ecs_system_desc_t *desc)
 {
+    if (ECS_NEQZERO(desc->interval) && ECS_NEQZERO(desc->rate)) {
+        char *name = ecs_get_path(world, entity);
+        ecs_err("system %s cannot have both interval and rate set", name);
+        ecs_os_free(name);
+        return -1;
+    }
+
     if (ECS_NEQZERO(desc->interval) || ECS_NEQZERO(desc->rate) || 
         ECS_NEQZERO(desc->tick_source)) 
     {
@@ -62320,9 +63552,6 @@ void flecs_system_init_timer(
 
         if (desc->rate) {
             ecs_entity_t tick_source = desc->tick_source;
-            if (!tick_source) {
-                tick_source = entity;
-            }
             ecs_set_rate(world, entity, desc->rate, tick_source);
         } else if (desc->tick_source) {
             ecs_set_tick_source(world, entity, desc->tick_source);
@@ -62333,6 +63562,8 @@ void flecs_system_init_timer(
         ecs_abort(ECS_UNSUPPORTED, "timer module not available");
 #endif
     }
+
+    return 0;
 }
 
 ecs_entity_t ecs_system_init(
@@ -62392,14 +63623,20 @@ ecs_entity_t ecs_system_init(
         system->multi_threaded = desc->multi_threaded;
         system->immediate = desc->immediate;
 
-        flecs_system_init_timer(world, entity, desc);
+        system->name = ecs_get_path(world, entity);
+
+        if (flecs_system_init_timer(world, entity, desc)) {
+            ecs_delete(world, entity);
+            ecs_defer_end(world);
+            goto error;
+        }
 
         if (ecs_get_name(world, entity)) {
             ecs_trace("#[green]system#[reset] %s created", 
                 ecs_get_name(world, entity));
         }
 
-        ecs_defer_end(world);            
+        ecs_defer_end(world);
     } else {
         flecs_poly_assert(poly->poly, ecs_system_t);
         ecs_system_t *system = (ecs_system_t*)poly->poly;
@@ -62472,7 +63709,9 @@ ecs_entity_t ecs_system_init(
             system->immediate = desc->immediate;
         }
 
-        flecs_system_init_timer(world, entity, desc);
+        if (flecs_system_init_timer(world, entity, desc)) {
+            return 0;
+        }
     }
 
     flecs_poly_modified(world, entity, ecs_system_t);
@@ -64423,7 +65662,29 @@ error:
 }
 
 static
+ecs_flags32_t flecs_query_to_table_flags(
+    const ecs_query_t *q)
+{
+    ecs_flags32_t query_flags = q->flags;
+    if (!(query_flags & EcsQueryMatchDisabled) || 
+        !(query_flags & EcsQueryMatchPrefab)) 
+    {
+        ecs_flags32_t table_flags = EcsTableNotQueryable;
+        if (!(query_flags & EcsQueryMatchDisabled)) {
+            table_flags |= EcsTableIsDisabled;
+        }
+        if (!(query_flags & EcsQueryMatchPrefab)) {
+            table_flags |= EcsTableIsPrefab;
+        }
+
+        return table_flags;
+    }
+    return 0;
+}
+
+static
 bool flecs_query_select_all(
+    const ecs_query_t *q,
     ecs_term_t *term,
     ecs_query_op_t *op,
     ecs_var_id_t src_var,
@@ -64451,6 +65712,7 @@ bool flecs_query_select_all(
             match_any.flags |= (EcsQueryIsEntity << EcsQuerySecond);
         }
         match_any.written = (1ull << src_var);
+        match_any.other = flecs_itolbl(flecs_query_to_table_flags(q));
         flecs_query_op_insert(&match_any, ctx);
         flecs_query_write_ctx(op->src.var, ctx, false);
 
@@ -64662,11 +65924,9 @@ void flecs_query_mark_last_or_op(
 
 static
 void flecs_query_set_op_kind(
-    ecs_query_t *q,
     ecs_query_op_t *op,
     ecs_term_t *term,
-    bool src_is_var,
-    bool member_term)
+    bool src_is_var)
 {
     /* Default instruction for And operators. If the source is fixed (like for
      * singletons or terms with an entity source), use With, which like And but
@@ -64719,18 +65979,6 @@ void flecs_query_set_op_kind(
             op->kind = EcsQuerySelfUp;
         } else if (term->flags_ & (EcsTermMatchAny|EcsTermMatchAnySrc)) {
             op->kind = EcsQueryAndAny;
-        }
-    }
-
-    /* If term has fixed id, insert simpler instruction that skips dealing with
-     * wildcard terms and variables */
-    if (flecs_term_is_fixed_id(q, term) && !member_term) {
-        if (op->kind == EcsQueryAnd) {
-            op->kind = EcsQueryAndId;
-        } else if (op->kind == EcsQuerySelfUp) {
-            op->kind = EcsQuerySelfUpId;
-        } else if (op->kind == EcsQueryUp) {
-            op->kind = EcsQueryUpId;
         }
     }
 }
@@ -64831,7 +66079,7 @@ int flecs_query_compile_term(
     op.field_index = flecs_ito(int8_t, term->field_index);
     op.term_index = flecs_ito(int8_t, term - q->terms);
 
-    flecs_query_set_op_kind(q, &op, term, src_is_var, member_term);
+    flecs_query_set_op_kind(&op, term, src_is_var);
 
     bool is_not = (term->oper == EcsNot) && !builtin_pred;
 
@@ -64878,7 +66126,7 @@ int flecs_query_compile_term(
      * written to yet, insert instruction that selects all entities so we have
      * something to match the optional/not against. */
     if (src_is_var && !src_written && !src_is_wildcard && !src_is_lookup) {
-        src_written = flecs_query_select_all(term, &op, op.src.var, ctx);
+        src_written = flecs_query_select_all(q, term, &op, op.src.var, ctx);
     }
 
     /* A bit of special logic for OR expressions and equality predicates. If the
@@ -65017,20 +66265,7 @@ int flecs_query_compile_term(
      * filtering out disabled/prefab entities is the default and this check is
      * cheap to perform on table flags, it's worth special casing. */
     if (!src_written && op.src.var == 0) {
-        ecs_flags32_t query_flags = q->flags;
-        if (!(query_flags & EcsQueryMatchDisabled) || 
-            !(query_flags & EcsQueryMatchPrefab)) 
-        {
-            ecs_flags32_t table_flags = EcsTableNotQueryable;
-            if (!(query_flags & EcsQueryMatchDisabled)) {
-                table_flags |= EcsTableIsDisabled;
-            }
-            if (!(query_flags & EcsQueryMatchPrefab)) {
-                table_flags |= EcsTableIsPrefab;
-            }
-
-            op.other = flecs_itolbl(table_flags);
-        }
+        op.other = flecs_itolbl(flecs_query_to_table_flags(q));
     }
 
     /* After evaluating a term, a used variable is always written */
@@ -65970,6 +67205,8 @@ void flecs_query_cache_rematch_tables(
         return;
     }
 
+    ecs_os_perf_trace_push("flecs.query.rematch");
+
     cache->monitor_generation = world->monitor_generation;
 
     it = ecs_query_iter(world, cache->query);
@@ -66039,6 +67276,8 @@ void flecs_query_cache_rematch_tables(
     if (world->flags & EcsWorldMeasureFrameTime) {
         world->info.rematch_time_total += (ecs_ftime_t)ecs_time_measure(&t);
     }
+
+    ecs_os_perf_trace_pop("flecs.query.rematch");
 }
 
 /* -- Private API -- */
@@ -67701,7 +68940,6 @@ bool flecs_query_select(
         (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled));
 }
 
-static
 bool flecs_query_with(
     const ecs_query_op_t *op,
     bool redo,
@@ -67762,7 +69000,6 @@ bool flecs_query_and(
     }
 }
 
-static
 bool flecs_query_select_id(
     const ecs_query_op_t *op,
     bool redo,
@@ -67812,7 +69049,6 @@ repeat: {}
     return true;
 }
 
-static
 bool flecs_query_with_id(
     const ecs_query_op_t *op,
     bool redo,
@@ -67851,275 +69087,6 @@ bool flecs_query_with_id(
 }
 
 static
-bool flecs_query_and_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (written & (1ull << op->src.var)) {
-        return flecs_query_with_id(op, redo, ctx);
-    } else {
-        return flecs_query_select_id(op, redo, ctx, 
-            (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled));
-    }
-}
-
-bool flecs_query_up_select(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx,
-    ecs_query_up_select_trav_kind_t trav_kind,
-    ecs_query_up_select_kind_t kind)
-{
-    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
-    ecs_world_t *world = ctx->world;
-    ecs_iter_t *it = ctx->it;
-    bool redo_select = redo;
-    const ecs_query_t *q = &ctx->query->pub;
-    bool self = trav_kind == FlecsQueryUpSelectSelfUp;
-
-    /* Early out if traversal relationship doesn't exist */
-    op_ctx->trav = q->terms[op->term_index].trav;
-    if (!op_ctx->idr_trav) {
-        op_ctx->idr_trav = flecs_id_record_get(ctx->world, 
-            ecs_pair(op_ctx->trav, EcsWildcard));
-    }
-
-    if (!op_ctx->idr_trav || !flecs_table_cache_all_count(&op_ctx->idr_trav->cache)){
-        if (!self) {
-            return false;
-        } else if (kind == FlecsQueryUpSelectId) {
-            return flecs_query_select_id(op, redo, ctx,
-                (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled));
-        } else if (kind == FlecsQueryUpSelectDefault) {
-            return flecs_query_select(op, redo, ctx);
-        } else if (kind == FlecsQueryUpSelectUnion) {
-            return flecs_query_union_select(op, redo, ctx);
-        } else {
-            /* Invalid select kind */
-            ecs_abort(ECS_INTERNAL_ERROR, NULL);
-        }
-    }
-
-    if (!redo) {
-        op_ctx->with = flecs_query_op_get_id(op, ctx);
-        op_ctx->idr_with = flecs_id_record_get(ctx->world, op_ctx->with);
-        if (!op_ctx->idr_with) {
-            return false;
-        }
-
-        op_ctx->down = NULL;
-        op_ctx->cache_elem = 0;
-    }
-
-    ecs_trav_down_t *down = op_ctx->down;
-
-    do {
-        while (!down) {
-            ecs_table_t *table = op_ctx->table;
-            if (!table) {
-                ecs_table_range_t range;
-                it->sources[op->field_index] = 0;
-                do {
-                    bool result;
-                    if (kind == FlecsQueryUpSelectId) {
-                        result = flecs_query_select_id(op, redo_select, ctx, 0);
-                    } else if (kind == FlecsQueryUpSelectDefault) {
-                        result = flecs_query_select_w_id(op, redo_select, ctx, 
-                            op_ctx->with, 0);
-                    } else if (kind == FlecsQueryUpSelectUnion) {
-                        result = flecs_query_union_select(op, redo_select, ctx);
-                    } else {
-                        ecs_abort(ECS_INTERNAL_ERROR, NULL);
-                    }
-
-                    if (!result) {
-                        return false;
-                    }
-
-                    redo_select = true;
-
-                    range = flecs_query_get_range(
-                        op, &op->src, EcsQuerySrc, ctx);
-                    ecs_assert(range.table != NULL, ECS_INTERNAL_ERROR, NULL);
-                } while (!self && range.table->_->traversable_count == 0);
-
-                if (!range.count) {
-                    range.count = ecs_table_count(range.table);
-                }
-
-                table = op_ctx->table = range.table;
-                op_ctx->row = range.offset;
-                op_ctx->end = range.offset + range.count;
-                op_ctx->matched = it->ids[op->field_index];
-
-                if (self) {
-                    if (!flecs_query_table_filter(table, op->other, 
-                        (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)))
-                    {
-                        flecs_reset_source_set_flag(it, op->field_index);
-                        op_ctx->row --;
-                        return true;
-                    }
-                }
-
-                redo_select = true;
-            } else {
-                op_ctx->row ++;
-            }
-
-            if (table->_->traversable_count == 0) {
-                op_ctx->table = NULL;
-                continue;
-            } else {
-                int32_t row;
-                ecs_entity_t entity = 0;
-                const ecs_entity_t *entities = ecs_table_entities(table);
-
-                for (row = op_ctx->row; row < op_ctx->end; row ++) {
-                    entity = entities[row];
-                    ecs_record_t *record = flecs_entities_get(world, entity);
-                    if (record->row & EcsEntityIsTraversable) {
-                        it->sources[op->field_index] = entity;
-                        break;
-                    }
-                }
-
-                if (row == op_ctx->end) {
-                    op_ctx->table = NULL;
-                    continue;
-                }
-
-                op_ctx->row = row;
-
-                bool match_empty = (q->flags & EcsQueryMatchEmptyTables) != 0;
-                down = op_ctx->down = flecs_query_get_down_cache(ctx, &op_ctx->cache, 
-                    op_ctx->trav, entity, op_ctx->idr_with, self, match_empty);
-                op_ctx->cache_elem = -1;
-            }
-        }
-
-next_elem:
-        if ((++ op_ctx->cache_elem) >= ecs_vec_count(&down->elems)) {
-            down = NULL;
-            continue;
-        }
-
-        ecs_trav_down_elem_t *elem = ecs_vec_get_t(
-            &down->elems, ecs_trav_down_elem_t, op_ctx->cache_elem);
-        flecs_query_var_set_range(op, op->src.var, elem->table, 0, 0, ctx);
-        flecs_query_set_vars(op, op_ctx->matched, ctx);
-
-        if (flecs_query_table_filter(elem->table, op->other, 
-            (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)))
-        {
-            goto next_elem;
-        }
-
-        break;
-    } while (true);
-
-    flecs_set_source_set_flag(it, op->field_index);
-
-    return true;
-}
-
-bool flecs_query_up_with(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    const ecs_query_t *q = &ctx->query->pub;
-    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
-    ecs_iter_t *it = ctx->it;
-
-    /* Early out if traversal relationship doesn't exist */
-    op_ctx->trav = q->terms[op->term_index].trav;
-    if (!op_ctx->idr_trav) {
-        op_ctx->idr_trav = flecs_id_record_get(ctx->world, 
-            ecs_pair(op_ctx->trav, EcsWildcard));
-    }
-
-    if (!op_ctx->idr_trav || !flecs_table_cache_all_count(&op_ctx->idr_trav->cache)){
-        return false;
-    }
-
-    if (!redo) {
-        op_ctx->trav = q->terms[op->term_index].trav;
-        op_ctx->with = flecs_query_op_get_id(op, ctx);
-        op_ctx->idr_with = flecs_id_record_get(ctx->world, op_ctx->with);
-
-        if (!op_ctx->idr_with) {
-            return false;
-        }
-
-        ecs_table_range_t range = flecs_query_get_range(
-            op, &op->src, EcsQuerySrc, ctx);
-        if (!range.table) {
-            return false;
-        }
-
-        ecs_trav_up_t *up = flecs_query_get_up_cache(ctx, &op_ctx->cache, 
-            range.table, op_ctx->with, op_ctx->trav, op_ctx->idr_with,
-            op_ctx->idr_trav);
-
-        if (!up) {
-            return false;
-        }
-
-        it->sources[op->field_index] = flecs_entities_get_alive(
-            ctx->world, up->src);
-        it->trs[op->field_index] = up->tr;
-        it->ids[op->field_index] = up->id;
-        flecs_query_set_vars(op, up->id, ctx);
-        flecs_set_source_set_flag(it, op->field_index);
-        return true;
-    } else {
-        return false;
-    }
-}
-
-bool flecs_query_self_up_with(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx,
-    bool id_only)
-{
-    if (!redo) {
-        bool result;
-        if (id_only) {
-            result = flecs_query_with_id(op, redo, ctx);
-            ecs_query_and_ctx_t *op_ctx = flecs_op_ctx(ctx, and);
-            op_ctx->remaining = 1;
-        } else {
-            result = flecs_query_with(op, redo, ctx);
-        }
-
-        flecs_reset_source_set_flag(ctx->it, op->field_index);
-
-        if (result) {
-            ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
-            op_ctx->trav = 0;
-            if (flecs_query_ref_flags(op->flags, EcsQuerySrc) & EcsQueryIsVar) {
-                ecs_iter_t *it = ctx->it;
-                it->sources[op->field_index] = 0;
-            }
-            return true;
-        }
-
-        return flecs_query_up_with(op, redo, ctx);
-    } else {
-        ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
-        if (op_ctx->trav == 0) {
-            return flecs_query_with(op, redo, ctx);
-        }
-    }
-
-    return false;
-}
-
-static
 bool flecs_query_up(
     const ecs_query_op_t *op,
     bool redo,
@@ -68146,36 +69113,6 @@ bool flecs_query_self_up(
     } else {
         return flecs_query_up_select(op, redo, ctx, 
             FlecsQueryUpSelectSelfUp, FlecsQueryUpSelectDefault);
-    }
-}
-
-static
-bool flecs_query_up_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (flecs_ref_is_written(op, &op->src, EcsQuerySrc, written)) {
-        return flecs_query_up_with(op, redo, ctx);
-    } else {
-        return flecs_query_up_select(op, redo, ctx, 
-            FlecsQueryUpSelectUp, FlecsQueryUpSelectId);
-    }
-}
-
-static
-bool flecs_query_self_up_id(
-    const ecs_query_op_t *op,
-    bool redo,
-    const ecs_query_run_ctx_t *ctx)
-{
-    uint64_t written = ctx->written[ctx->op_index];
-    if (flecs_ref_is_written(op, &op->src, EcsQuerySrc, written)) {
-        return flecs_query_self_up_with(op, redo, ctx, true);
-    } else {
-        return flecs_query_up_select(op, redo, ctx, 
-            FlecsQueryUpSelectSelfUp, FlecsQueryUpSelectId);
     }
 }
 
@@ -69255,16 +70192,13 @@ bool flecs_query_dispatch(
 {
     switch(op->kind) {
     case EcsQueryAnd: return flecs_query_and(op, redo, ctx);
-    case EcsQueryAndId: return flecs_query_and_id(op, redo, ctx);
     case EcsQueryAndAny: return flecs_query_and_any(op, redo, ctx);
     case EcsQueryTriv: return flecs_query_triv(op, redo, ctx);
     case EcsQueryCache: return flecs_query_cache(op, redo, ctx);
     case EcsQueryIsCache: return flecs_query_is_cache(op, redo, ctx);
     case EcsQueryOnlyAny: return flecs_query_only_any(op, redo, ctx);
     case EcsQueryUp: return flecs_query_up(op, redo, ctx);
-    case EcsQueryUpId: return flecs_query_up_id(op, redo, ctx);
     case EcsQuerySelfUp: return flecs_query_self_up(op, redo, ctx);
-    case EcsQuerySelfUpId: return flecs_query_self_up_id(op, redo, ctx);
     case EcsQueryWith: return flecs_query_with(op, redo, ctx);
     case EcsQueryTrav: return flecs_query_trav(op, redo, ctx);
     case EcsQueryAndFrom: return flecs_query_and_from(op, redo, ctx);
@@ -69590,8 +70524,6 @@ void flecs_query_iter_fini_ctx(
             break;
         case EcsQueryUp:
         case EcsQuerySelfUp:
-        case EcsQueryUpId:
-        case EcsQuerySelfUpId: 
         case EcsQueryUnionEqUp:
         case EcsQueryUnionEqSelfUp: {
             ecs_trav_up_cache_t *cache = &ctx[i].is.up.cache;
@@ -69676,7 +70608,7 @@ ecs_iter_t flecs_query_iter(
     it.field_count = q->field_count;
     it.sizes = q->sizes;
     it.set_fields = q->set_fields;
-    it.ref_fields = q->fixed_fields | q->row_fields;
+    it.ref_fields = q->fixed_fields | q->row_fields | q->var_fields;
     it.row_fields = q->row_fields;
     it.up_fields = 0;
     flecs_query_apply_iter_flags(&it, q);
@@ -69746,7 +70678,7 @@ ecs_iter_t ecs_query_iter(
     }
 
     /* Ok, only for stats */
-    ECS_CONST_CAST(ecs_query_t*, q)->eval_count ++;
+    ecs_os_linc(&ECS_CONST_CAST(ecs_query_t*, q)->eval_count);
 
     ecs_query_impl_t *impl = flecs_query_impl(q);
     ecs_query_cache_t *cache = impl->cache;
@@ -71212,6 +72144,373 @@ next_for_union:
 }
 
 /**
+ * @file query/engine/eval.c
+ * @brief Query engine implementation.
+ */
+
+
+/* Find tables with requested component that has traversable entities. */
+static
+bool flecs_query_up_select_table(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    ecs_query_up_select_trav_kind_t trav_kind,
+    ecs_query_up_select_kind_t kind)
+{
+    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+    ecs_iter_t *it = ctx->it;
+    bool self = trav_kind == FlecsQueryUpSelectSelfUp;
+    ecs_table_range_t range;
+
+    do {
+        bool result;
+        if (kind == FlecsQueryUpSelectId) {
+            result = flecs_query_select_id(op, redo, ctx, 0);
+        } else if (kind == FlecsQueryUpSelectDefault) {
+            result = flecs_query_select_w_id(op, redo, ctx, 
+                op_ctx->with, 0);
+        } else if (kind == FlecsQueryUpSelectUnion) {
+            result = flecs_query_union_select(op, redo, ctx);
+        } else {
+            ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        }
+
+        if (!result) {
+            /* No remaining tables with component found. */
+            return false;
+        }
+
+        redo = true;
+
+        range = flecs_query_get_range(op, &op->src, EcsQuerySrc, ctx);
+        ecs_assert(range.table != NULL, ECS_INTERNAL_ERROR, NULL);
+
+        /* Keep searching until we find a table that has the requested component, 
+         * with traversable entities */
+    } while (!self && range.table->_->traversable_count == 0);
+
+    if (!range.count) {
+        range.count = ecs_table_count(range.table);
+    }
+
+    op_ctx->table = range.table;
+    op_ctx->row = range.offset;
+    op_ctx->end = range.offset + range.count;
+    op_ctx->matched = it->ids[op->field_index];
+
+    return true;
+}
+
+/* Find next traversable entity in table. */
+static
+ecs_trav_down_t* flecs_query_up_find_next_traversable(
+    const ecs_query_op_t *op,
+    const ecs_query_run_ctx_t *ctx,
+    ecs_query_up_select_trav_kind_t trav_kind)
+{
+    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+    ecs_world_t *world = ctx->world;
+    ecs_iter_t *it = ctx->it;
+    const ecs_query_t *q = &ctx->query->pub;
+    ecs_table_t *table = op_ctx->table;
+    bool self = trav_kind == FlecsQueryUpSelectSelfUp;
+
+    if (table->_->traversable_count == 0) {
+        /* No traversable entities in table */
+        op_ctx->table = NULL;
+        return NULL;
+    } else {
+        int32_t row;
+        ecs_entity_t entity = 0;
+        const ecs_entity_t *entities = ecs_table_entities(table);
+
+        for (row = op_ctx->row; row < op_ctx->end; row ++) {
+            entity = entities[row];
+            ecs_record_t *record = flecs_entities_get(world, entity);
+            if (record->row & EcsEntityIsTraversable) {
+                /* Found traversable entity */
+                it->sources[op->field_index] = entity;
+                break;
+            }
+        }
+
+        if (row == op_ctx->end) {
+            /* No traversable entities remaining in table */
+            op_ctx->table = NULL;
+            return NULL;
+        }
+
+        op_ctx->row = row;
+
+        /* Get down cache entry for traversable entity */
+        bool match_empty = (q->flags & EcsQueryMatchEmptyTables) != 0;
+        op_ctx->down = flecs_query_get_down_cache(ctx, &op_ctx->cache, 
+            op_ctx->trav, entity, op_ctx->idr_with, self, match_empty);
+        op_ctx->cache_elem = -1;
+    }
+
+    return op_ctx->down;
+}
+
+/* Select all tables that can reach the target component through the traversal
+ * relationship. */
+bool flecs_query_up_select(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    ecs_query_up_select_trav_kind_t trav_kind,
+    ecs_query_up_select_kind_t kind)
+{
+    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+    ecs_iter_t *it = ctx->it;
+    bool redo_select = redo;
+    const ecs_query_t *q = &ctx->query->pub;
+    bool self = trav_kind == FlecsQueryUpSelectSelfUp;
+
+    op_ctx->trav = q->terms[op->term_index].trav;
+
+    /* Reuse id record from previous iteration if possible*/
+    if (!op_ctx->idr_trav) {
+        op_ctx->idr_trav = flecs_id_record_get(ctx->world, 
+            ecs_pair(op_ctx->trav, EcsWildcard));
+    }
+
+    /* If id record is not found, or if it doesn't have any tables, revert to
+     * iterating owned components (no traversal) */
+    if (!op_ctx->idr_trav || 
+        !flecs_table_cache_all_count(&op_ctx->idr_trav->cache))
+    {
+        if (!self) {
+            /* If operation does not match owned components, return false */
+            return false;
+        } else if (kind == FlecsQueryUpSelectId) {
+            return flecs_query_select_id(op, redo, ctx,
+                (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled));
+        } else if (kind == FlecsQueryUpSelectDefault) {
+            return flecs_query_select(op, redo, ctx);
+        } else if (kind == FlecsQueryUpSelectUnion) {
+            return flecs_query_union_select(op, redo, ctx);
+        } else {
+            /* Invalid select kind */
+            ecs_abort(ECS_INTERNAL_ERROR, NULL);
+        }
+    }
+
+    if (!redo) {
+        /* Get component id to match */
+        op_ctx->with = flecs_query_op_get_id(op, ctx);
+
+        /* Get id record for component to match */
+        op_ctx->idr_with = flecs_id_record_get(ctx->world, op_ctx->with);
+        if (!op_ctx->idr_with) {
+            /* If id record does not exist, there can't be any results */
+            return false;
+        }
+
+        op_ctx->down = NULL;
+        op_ctx->cache_elem = 0;
+    }
+
+    /* Get last used entry from down traversal cache. Cache entries in the down
+     * traversal cache contain a list of tables that can reach the requested 
+     * component through the traversal relationship, for a traversable entity
+     * which acts as the key for the cache. */
+    ecs_trav_down_t *down = op_ctx->down;
+
+next_down_entry:
+    /* Get (next) entry in down traversal cache */
+    while (!down) {
+        ecs_table_t *table = op_ctx->table;
+
+        /* Get (next) table with traversable entities that have the 
+         * requested component. We'll traverse downwards from the 
+         * traversable entities in the table to find all entities that can
+         * reach the component through the traversal relationship. */
+        if (!table) {
+            /* Reset source, in case we have to return a component matched
+             * by the entity in the found table. */
+            it->sources[op->field_index] = 0;
+
+            if (!flecs_query_up_select_table(
+                op, redo_select, ctx, trav_kind, kind))
+            {
+                return false;
+            }
+
+            table = op_ctx->table;
+
+            /* If 'self' is true, we're evaluating a term with self|up. This
+             * means that before traversing downwards, we should also return 
+             * the current table as result. */
+            if (self) {
+                if (!flecs_query_table_filter(table, op->other, 
+                    (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)))
+                {
+                    flecs_reset_source_set_flag(it, op->field_index);
+                    op_ctx->row --;
+                    return true;
+                }
+            }
+
+            redo_select = true;
+        } else {
+            /* Evaluate next entity in table */
+            op_ctx->row ++;
+        }
+
+        /* Get down cache entry for next traversable entity in table */
+        down = flecs_query_up_find_next_traversable(op, ctx, trav_kind);
+        if (!down) {
+            goto next_down_entry;
+        }
+    }
+
+next_down_elem:
+    /* Get next element (table) in cache entry */
+    if ((++ op_ctx->cache_elem) >= ecs_vec_count(&down->elems)) {
+        /* No more elements in cache entry, find next.*/
+        down = NULL;
+        goto next_down_entry;
+    }
+
+    ecs_trav_down_elem_t *elem = ecs_vec_get_t(
+        &down->elems, ecs_trav_down_elem_t, op_ctx->cache_elem);
+    flecs_query_var_set_range(op, op->src.var, elem->table, 0, 0, ctx);
+    flecs_query_set_vars(op, op_ctx->matched, ctx);
+
+    if (flecs_query_table_filter(elem->table, op->other, 
+        (EcsTableNotQueryable|EcsTableIsPrefab|EcsTableIsDisabled)))
+    {
+        /* Go to next table if table contains prefabs, disabled entities or
+         * entities that are not queryable. */
+        goto next_down_elem;
+    }
+
+    flecs_set_source_set_flag(it, op->field_index);
+
+    return true;
+}
+
+/* Check if a table can reach the target component through the traversal
+ * relationship. */
+bool flecs_query_up_with(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx)
+{
+    const ecs_query_t *q = &ctx->query->pub;
+    ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+    ecs_iter_t *it = ctx->it;
+
+    op_ctx->trav = q->terms[op->term_index].trav;
+    if (!op_ctx->idr_trav) {
+        op_ctx->idr_trav = flecs_id_record_get(ctx->world, 
+            ecs_pair(op_ctx->trav, EcsWildcard));
+    }
+
+    if (!op_ctx->idr_trav || 
+        !flecs_table_cache_all_count(&op_ctx->idr_trav->cache))
+    {
+        /* If there are no tables with traversable relationship, there are no
+         * matches. */
+        return false;
+    }
+
+    if (!redo) {
+        op_ctx->trav = q->terms[op->term_index].trav;
+        op_ctx->with = flecs_query_op_get_id(op, ctx);
+        op_ctx->idr_with = flecs_id_record_get(ctx->world, op_ctx->with);
+
+        /* If id record for component doesn't exist, there are no matches */
+        if (!op_ctx->idr_with) {
+            return false;
+        }
+
+        /* Get the range (table) that is currently being evaluated. In most 
+         * cases the range will cover the entire table, but in some cases it
+         * can only cover a subset of the entities in the table. */
+        ecs_table_range_t range = flecs_query_get_range(
+            op, &op->src, EcsQuerySrc, ctx);
+        if (!range.table) {
+            return false;
+        }
+
+        /* Get entry from up traversal cache. The up traversal cache contains 
+         * the entity on which the component was found, with additional metadata
+         * on where it is stored. */
+        ecs_trav_up_t *up = flecs_query_get_up_cache(ctx, &op_ctx->cache, 
+            range.table, op_ctx->with, op_ctx->trav, op_ctx->idr_with,
+            op_ctx->idr_trav);
+
+        if (!up) {
+            /* Component is not reachable from table */
+            return false;
+        }
+
+        it->sources[op->field_index] = flecs_entities_get_alive(
+            ctx->world, up->src);
+        it->trs[op->field_index] = up->tr;
+        it->ids[op->field_index] = up->id;
+        flecs_query_set_vars(op, up->id, ctx);
+        flecs_set_source_set_flag(it, op->field_index);
+        return true;
+    } else {
+        /* The table either can or can't reach the component, nothing to do for
+         * a second evaluation of this operation.*/
+        return false;
+    }
+}
+
+/* Check if a table can reach the target component through the traversal
+ * relationship, or if the table has the target component itself. */
+bool flecs_query_self_up_with(
+    const ecs_query_op_t *op,
+    bool redo,
+    const ecs_query_run_ctx_t *ctx,
+    bool id_only)
+{
+    if (!redo) {
+        bool result;
+
+        if (id_only) {
+            /* Simple id, no wildcards */
+            result = flecs_query_with_id(op, redo, ctx);
+            ecs_query_and_ctx_t *op_ctx = flecs_op_ctx(ctx, and);
+            op_ctx->remaining = 1;
+        } else {
+            result = flecs_query_with(op, redo, ctx);
+        }
+
+        flecs_reset_source_set_flag(ctx->it, op->field_index);
+
+        if (result) {
+            /* Table has component, no need to traverse*/
+            ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+            op_ctx->trav = 0;
+            if (flecs_query_ref_flags(op->flags, EcsQuerySrc) & EcsQueryIsVar) {
+                /* Matching self, so set sources to 0 */
+                ecs_iter_t *it = ctx->it;
+                it->sources[op->field_index] = 0;
+            }
+            return true;
+        }
+
+        /* Table doesn't have component, traverse relationship */
+        return flecs_query_up_with(op, redo, ctx);
+    } else {
+        ecs_query_up_ctx_t *op_ctx = flecs_op_ctx(ctx, up);
+        if (op_ctx->trav == 0) {
+            /* If matching components without traversing, make sure to still
+             * match remaining components that match the id (wildcard). */
+            return flecs_query_with(op, redo, ctx);
+        }
+    }
+
+    return false;
+}
+
+/**
  * @file query/engine/eval_utils.c
  * @brief Query engine evaluation utilities.
  */
@@ -71900,6 +73199,11 @@ void flecs_trav_entity_down_isa(
                 continue;
             }
 
+            if (ecs_table_has_id(world, table, idr_with->id)) {
+                /* Table owns component */
+                continue;
+            }
+
             const ecs_entity_t *entities = ecs_table_entities(table);
             int32_t i, count = ecs_table_count(table);
             for (i = 0; i < count; i ++) {
@@ -71917,6 +73221,9 @@ void flecs_trav_entity_down_isa(
                         flecs_trav_entity_down(world, a, cache, dst, trav, e,
                             idr_trav, idr_with, self, empty);
                     }
+
+                    flecs_trav_entity_down_isa(world, a, cache, dst, trav, e, 
+                        idr_with, self, empty);
                 }
             }
         }
@@ -71930,7 +73237,7 @@ ecs_trav_down_t* flecs_trav_entity_down(
     ecs_trav_up_cache_t *cache,
     ecs_trav_down_t *dst,
     ecs_entity_t trav,
-    ecs_entity_t entity,
+    ecs_entity_t e,
     ecs_id_record_t *idr_trav,
     ecs_id_record_t *idr_with,
     bool self,
@@ -71941,7 +73248,7 @@ ecs_trav_down_t* flecs_trav_entity_down(
     ecs_assert(idr_trav != NULL, ECS_INTERNAL_ERROR, NULL);
 
     flecs_trav_entity_down_isa(
-        world, a, cache, dst, trav, entity, idr_with, self, empty);
+        world, a, cache, dst, trav, e, idr_with, self, empty);
 
     int32_t first = ecs_vec_count(&dst->elems);
 
@@ -71952,6 +73259,7 @@ ecs_trav_down_t* flecs_trav_entity_down(
     } else {
         result = flecs_table_cache_iter(&idr_trav->cache, &it);
     }
+
     if (result) {
         ecs_table_record_t *tr; 
         while ((tr = flecs_table_cache_next(&it, ecs_table_record_t))) {

--- a/libs/flecs/flecs.c
+++ b/libs/flecs/flecs.c
@@ -568,10 +568,6 @@ void flecs_table_delete(
     int32_t index,
     bool destruct);
 
-/* Make sure table records are in correct table cache list */
-bool flecs_table_records_update_empty(
-    ecs_table_t *table);
-
 /* Move a row from one table to another */
 void flecs_table_move(
     ecs_world_t *world,
@@ -735,7 +731,6 @@ typedef struct ecs_table_cache_list_t {
 typedef struct ecs_table_cache_t {
     ecs_map_t index; /* <table_id, T*> */
     ecs_table_cache_list_t tables;
-    ecs_table_cache_list_t empty_tables;
 } ecs_table_cache_t;
 
 /* World level allocators are for operations that are not multithreaded */
@@ -852,10 +847,10 @@ struct ecs_stage_t {
     /* Zero if not deferred, positive if deferred, negative if suspended */
     int32_t defer;
 
-    /* Command queue stack, for nested execution */
+    /* Command queue */
     ecs_commands_t *cmd;
-    ecs_commands_t cmd_stack[ECS_MAX_DEFER_STACK];
-    int32_t cmd_sp;
+    ecs_commands_t cmd_stack[2];     /* Two so we can flush one & populate the other */
+    bool cmd_flushing;               /* Ensures only one defer_end call flushes */
 
     /* Thread context */
     ecs_world_t *thread_ctx;         /* Points to stage when a thread stage */
@@ -882,10 +877,10 @@ struct ecs_stage_t {
     ecs_vec_t variables;
     ecs_vec_t operations;
 
-    /* Temporary token storage for DSL parser. This allows for parsing and 
-     * interpreting a term without having to do allocations. */
-    char parser_tokens[1024];
-    char *parser_token; /* Pointer to next token */
+#ifdef FLECS_SCRIPT
+    /* Thread specific runtime for script execution */
+    ecs_script_runtime_t *runtime;
+#endif
 };
 
 /* Component monitor */
@@ -921,9 +916,6 @@ typedef struct ecs_store_t {
     /* Root table */
     ecs_table_t root;
 
-    /* Observers */
-    ecs_sparse_t observers;          /* sparse<table_id, ecs_table_t> */
-
     /* Records cache */
     ecs_vec_t records;
 
@@ -950,9 +942,9 @@ struct ecs_world_t {
     ecs_header_t hdr;
 
     /* --  Type metadata -- */
-    ecs_id_record_t *id_index_lo;
+    ecs_id_record_t **id_index_lo;
     ecs_map_t id_index_hi;           /* map<id, ecs_id_record_t*> */
-    ecs_sparse_t type_info;          /* sparse<type_id, type_info_t> */
+    ecs_map_t type_info;             /* map<type_id, type_info_t> */
 
     /* -- Cached handle to id records -- */
     ecs_id_record_t *idr_wildcard;
@@ -976,10 +968,6 @@ struct ecs_world_t {
     /* --  Data storage -- */
     ecs_store_t store;
 
-    /* --  Pending table event buffers -- */
-    ecs_sparse_t *pending_buffer;    /* sparse<table_id, ecs_table_t*> */
-    ecs_sparse_t *pending_tables;    /* sparse<table_id, ecs_table_t*> */
-
     /* Used to track when cache needs to be updated */
     ecs_monitor_set_t monitors;      /* map<id, ecs_monitor_t> */
 
@@ -993,6 +981,9 @@ struct ecs_world_t {
     /* -- Staging -- */
     ecs_stage_t **stages;            /* Stages */
     int32_t stage_count;             /* Number of stages */
+
+    /* -- Component ids -- */
+    ecs_vec_t component_ids;         /* World local component ids */
 
     /* Internal callback for command inspection. Only one callback can be set at
      * a time. After assignment the action will become active at the start of 
@@ -1064,12 +1055,6 @@ void ecs_table_cache_insert(
     const ecs_table_t *table,
     ecs_table_cache_hdr_t *result);
 
-void ecs_table_cache_insert_w_empty(
-    ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    ecs_table_cache_hdr_t *result,
-    bool is_empty);
-
 void ecs_table_cache_replace(
     ecs_table_cache_t *cache,
     const ecs_table_t *table,
@@ -1084,17 +1069,7 @@ void* ecs_table_cache_get(
     const ecs_table_cache_t *cache,
     const ecs_table_t *table);
 
-bool ecs_table_cache_set_empty(
-    ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    bool empty);
-
-bool ecs_table_cache_is_empty(
-    const ecs_table_cache_t *cache);
-
 #define flecs_table_cache_count(cache) (cache)->tables.count
-#define flecs_table_cache_empty_count(cache) (cache)->empty_tables.count
-#define flecs_table_cache_all_count(cache) ((cache)->tables.count + (cache)->empty_tables.count)
 
 bool flecs_table_cache_iter(
     ecs_table_cache_t *cache,
@@ -1532,6 +1507,7 @@ typedef struct {
 /* *From operator iterator context */
 typedef struct {
     ecs_query_and_ctx_t and;
+    ecs_entity_t type_id;
     ecs_type_t *type;
     int32_t first_id_index;
     int32_t cur_id_index;
@@ -1879,10 +1855,6 @@ void flecs_query_cache_build_sorted_tables(
 
 /* Return number of tables in cache */
 int32_t flecs_query_cache_table_count(
-    ecs_query_cache_t *cache);
-
-/* Return number of empty tables in cache */
-int32_t flecs_query_cache_empty_table_count(
     ecs_query_cache_t *cache);
 
 /* Return number of entities in cache (requires iterating tables) */
@@ -2794,12 +2766,6 @@ void flecs_enqueue(
     ecs_stage_t *stage,
     ecs_event_desc_t *desc);
 
-void flecs_commands_push(
-    ecs_stage_t *stage);
-
-void flecs_commands_pop(
-    ecs_stage_t *stage);
-
 ecs_entity_t flecs_stage_set_system(
     ecs_stage_t *stage,
     ecs_entity_t system);
@@ -2809,6 +2775,14 @@ ecs_allocator_t* flecs_stage_get_allocator(
 
 ecs_stack_t* flecs_stage_get_stack_allocator(
     ecs_world_t *world);
+
+void flecs_commands_init(    
+    ecs_stage_t *stage,
+    ecs_commands_t *cmd);
+
+void flecs_commands_fini(
+    ecs_stage_t *stage,
+    ecs_commands_t *cmd);
 
 #endif
 
@@ -2886,16 +2860,41 @@ void flecs_unregister_table(
     ecs_world_t *world,
     ecs_table_t *table);
 
-void flecs_table_set_empty(
-    ecs_world_t *world,
-    ecs_table_t *table);
-
 void flecs_delete_table(
     ecs_world_t *world,
     ecs_table_t *table);
 
-void flecs_process_pending_tables(
-    const ecs_world_t *world);
+/* Suspend/resume readonly state. To fully support implicit registration of
+ * components, it should be possible to register components while the world is
+ * in readonly mode. It is not uncommon that a component is used first from
+ * within a system, which are often ran while in readonly mode.
+ * 
+ * Suspending readonly mode is only allowed when the world is not multithreaded.
+ * When a world is multithreaded, it is not safe to (even temporarily) leave
+ * readonly mode, so a multithreaded application should always explicitly
+ * register components in advance. 
+ * 
+ * These operations also suspend deferred mode.
+ */
+typedef struct ecs_suspend_readonly_state_t {
+    bool is_readonly;
+    bool is_deferred;
+    bool cmd_flushing;
+    int32_t defer_count;
+    ecs_entity_t scope;
+    ecs_entity_t with;
+    ecs_commands_t cmd_stack[2];
+    ecs_commands_t *cmd;
+    ecs_stage_t *stage;
+} ecs_suspend_readonly_state_t;
+
+ecs_world_t* flecs_suspend_readonly(
+    const ecs_world_t *world,
+    ecs_suspend_readonly_state_t *state);
+
+void flecs_resume_readonly(
+    ecs_world_t *world,
+    ecs_suspend_readonly_state_t *state);
 
 /* Convenience macro's for world allocator */
 #define flecs_walloc(world, size)\
@@ -3098,6 +3097,12 @@ void flecs_invoke_hook(
     const ecs_type_info_t *ti,
     ecs_entity_t event,
     ecs_iter_action_t hook);
+
+void flecs_add_ids(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    ecs_id_t *ids,
+    int32_t count);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Query API
@@ -3960,6 +3965,7 @@ void flecs_bootstrap(
     ecs_make_alive(world, EcsChildOf);
     ecs_make_alive(world, EcsFlecs);
     ecs_make_alive(world, EcsFlecsCore);
+    ecs_make_alive(world, EcsFlecsInternals);
     ecs_make_alive(world, EcsOnAdd);
     ecs_make_alive(world, EcsOnRemove);
     ecs_make_alive(world, EcsOnSet);
@@ -4128,44 +4134,6 @@ void flecs_bootstrap(
     flecs_bootstrap_entity(world, EcsMonitor, "EcsMonitor", EcsFlecsCore);
     flecs_bootstrap_entity(world, EcsOnTableCreate, "OnTableCreate", EcsFlecsCore);
     flecs_bootstrap_entity(world, EcsOnTableDelete, "OnTableDelete", EcsFlecsCore);
-    flecs_bootstrap_entity(world, EcsOnTableEmpty, "OnTableEmpty", EcsFlecsCore);
-    flecs_bootstrap_entity(world, EcsOnTableFill, "OnTableFilled", EcsFlecsCore);
-
-    /* Unqueryable entities */
-    ecs_add_id(world, EcsThis, EcsNotQueryable);
-    ecs_add_id(world, EcsWildcard, EcsNotQueryable);
-    ecs_add_id(world, EcsAny, EcsNotQueryable);
-    ecs_add_id(world, EcsVariable, EcsNotQueryable);
-
-    /* Tag relationships (relationships that should never have data) */
-    ecs_add_id(world, EcsIsA, EcsPairIsTag);
-    ecs_add_id(world, EcsChildOf, EcsPairIsTag);
-    ecs_add_id(world, EcsSlotOf, EcsPairIsTag);
-    ecs_add_id(world, EcsDependsOn, EcsPairIsTag);
-    ecs_add_id(world, EcsFlag, EcsPairIsTag);
-    ecs_add_id(world, EcsWith, EcsPairIsTag);
-
-    /* Exclusive properties */
-    ecs_add_id(world, EcsChildOf, EcsExclusive);
-    ecs_add_id(world, EcsOnDelete, EcsExclusive);
-    ecs_add_id(world, EcsOnDeleteTarget, EcsExclusive);
-    ecs_add_id(world, EcsOnInstantiate, EcsExclusive);
-
-    /* Relationships */
-    ecs_add_id(world, EcsChildOf, EcsRelationship);
-    ecs_add_id(world, EcsIsA, EcsRelationship);
-    ecs_add_id(world, EcsSlotOf, EcsRelationship);
-    ecs_add_id(world, EcsDependsOn, EcsRelationship);
-    ecs_add_id(world, EcsWith, EcsRelationship);
-    ecs_add_id(world, EcsOnDelete, EcsRelationship);
-    ecs_add_id(world, EcsOnDeleteTarget, EcsRelationship);
-    ecs_add_id(world, EcsOnInstantiate, EcsRelationship);
-    ecs_add_id(world, ecs_id(EcsIdentifier), EcsRelationship);
-
-    /* Targets */
-    ecs_add_id(world, EcsOverride, EcsTarget);
-    ecs_add_id(world, EcsInherit, EcsTarget);
-    ecs_add_id(world, EcsDontInherit, EcsTarget);
 
     /* Sync properties of ChildOf and Identifier with bootstrapped flags */
     ecs_add_pair(world, EcsChildOf, EcsOnDeleteTarget, EcsDelete);
@@ -4321,6 +4289,42 @@ void flecs_bootstrap(
     /* Set scope back to flecs core */
     ecs_set_scope(world, EcsFlecsCore);
 
+    /* Exclusive properties */
+    ecs_add_id(world, EcsChildOf, EcsExclusive);
+    ecs_add_id(world, EcsOnDelete, EcsExclusive);
+    ecs_add_id(world, EcsOnDeleteTarget, EcsExclusive);
+    ecs_add_id(world, EcsOnInstantiate, EcsExclusive);
+
+    /* Unqueryable entities */
+    ecs_add_id(world, EcsThis, EcsNotQueryable);
+    ecs_add_id(world, EcsWildcard, EcsNotQueryable);
+    ecs_add_id(world, EcsAny, EcsNotQueryable);
+    ecs_add_id(world, EcsVariable, EcsNotQueryable);
+
+    /* Tag relationships (relationships that should never have data) */
+    ecs_add_id(world, EcsIsA, EcsPairIsTag);
+    ecs_add_id(world, EcsChildOf, EcsPairIsTag);
+    ecs_add_id(world, EcsSlotOf, EcsPairIsTag);
+    ecs_add_id(world, EcsDependsOn, EcsPairIsTag);
+    ecs_add_id(world, EcsFlag, EcsPairIsTag);
+    ecs_add_id(world, EcsWith, EcsPairIsTag);
+
+    /* Relationships */
+    ecs_add_id(world, EcsChildOf, EcsRelationship);
+    ecs_add_id(world, EcsIsA, EcsRelationship);
+    ecs_add_id(world, EcsSlotOf, EcsRelationship);
+    ecs_add_id(world, EcsDependsOn, EcsRelationship);
+    ecs_add_id(world, EcsWith, EcsRelationship);
+    ecs_add_id(world, EcsOnDelete, EcsRelationship);
+    ecs_add_id(world, EcsOnDeleteTarget, EcsRelationship);
+    ecs_add_id(world, EcsOnInstantiate, EcsRelationship);
+    ecs_add_id(world, ecs_id(EcsIdentifier), EcsRelationship);
+
+    /* Targets */
+    ecs_add_id(world, EcsOverride, EcsTarget);
+    ecs_add_id(world, EcsInherit, EcsTarget);
+    ecs_add_id(world, EcsDontInherit, EcsTarget);
+
     /* Traversable relationships are always acyclic */
     ecs_add_pair(world, EcsTraversable, EcsWith, EcsAcyclic);
 
@@ -4353,7 +4357,6 @@ void flecs_bootstrap(
     /* Inherited components */
     ecs_add_pair(world, EcsIsA, EcsOnInstantiate, EcsInherit);
     ecs_add_pair(world, EcsDependsOn, EcsOnInstantiate, EcsInherit);
-    ecs_add_pair(world, EcsDisabled, EcsOnInstantiate, EcsInherit);
     
     /* Run bootstrap functions for other parts of the code */
     flecs_bootstrap_hierarchy(world);
@@ -4381,8 +4384,6 @@ ecs_iter_t ecs_each_id(
     ecs_check(id != 0, ECS_INVALID_PARAMETER, NULL);
 
     const ecs_world_t *world = ecs_get_world(stage);
-
-    flecs_process_pending_tables(world);
 
     ecs_iter_t it = {
         .real_world = ECS_CONST_CAST(ecs_world_t*, world),
@@ -4485,7 +4486,10 @@ typedef struct ecs_script_impl_t {
     ecs_script_t pub;
     ecs_allocator_t allocator;
     ecs_script_scope_t *root;
+    ecs_expr_node_t *expr; /* Only set if script is just an expression */
     char *token_buffer;
+    char *token_remaining; /* Remaining space in token buffer */
+    const char *next_token; /* First character after expression */
     int32_t token_buffer_size;
     int32_t refcount;
 } ecs_script_impl_t;
@@ -4512,31 +4516,50 @@ typedef enum ecs_script_token_kind_t {
     EcsTokParenClose = ')',
     EcsTokBracketOpen = '[',
     EcsTokBracketClose = ']',
-    EcsTokMul = '*',
+    EcsTokMember = '.',
     EcsTokComma = ',',
     EcsTokSemiColon = ';',
     EcsTokColon = ':',
     EcsTokAssign = '=',
+    EcsTokAdd = '+',
+    EcsTokSub = '-',
+    EcsTokMul = '*',
+    EcsTokDiv = '/',
+    EcsTokMod = '%',
     EcsTokBitwiseOr = '|',
+    EcsTokBitwiseAnd = '&',
     EcsTokNot = '!',
     EcsTokOptional = '?',
     EcsTokAnnotation = '@',
     EcsTokNewline = '\n',
-    EcsTokEq,
-    EcsTokNeq,
-    EcsTokMatch,
-    EcsTokOr,
-    EcsTokIdentifier,
-    EcsTokString,
-    EcsTokNumber,
-    EcsTokKeywordModule,
-    EcsTokKeywordUsing,
-    EcsTokKeywordWith,
-    EcsTokKeywordIf,
-    EcsTokKeywordElse,
-    EcsTokKeywordTemplate,
-    EcsTokKeywordProp,
-    EcsTokKeywordConst,
+    EcsTokEq = 100,
+    EcsTokNeq = 101,
+    EcsTokGt = 102,
+    EcsTokGtEq = 103,
+    EcsTokLt = 104,
+    EcsTokLtEq = 105,
+    EcsTokAnd = 106,
+    EcsTokOr = 107,
+    EcsTokMatch = 108,
+    EcsTokRange = 109,
+    EcsTokShiftLeft = 110,
+    EcsTokShiftRight = 111,
+    EcsTokIdentifier = 112,
+    EcsTokString = 113,
+    EcsTokNumber = 114,
+    EcsTokKeywordModule = 115,
+    EcsTokKeywordUsing = 116,
+    EcsTokKeywordWith = 117,
+    EcsTokKeywordIf = 118,
+    EcsTokKeywordFor = 119,
+    EcsTokKeywordIn = 120,
+    EcsTokKeywordElse = 121,
+    EcsTokKeywordTemplate = 122,
+    EcsTokKeywordProp = 130,
+    EcsTokKeywordConst = 131,
+    EcsTokKeywordMatch = 132,
+    EcsTokAddAssign = 133,
+    EcsTokMulAssign = 134,
 } ecs_script_token_kind_t;
 
 typedef struct ecs_script_token_t {
@@ -4549,11 +4572,10 @@ typedef struct ecs_script_tokens_t {
     ecs_script_token_t tokens[256];
 } ecs_script_tokens_t;
 
-const char* flecs_script_expr(
-    ecs_script_parser_t *parser,
-    const char *ptr,
-    ecs_script_token_t *out,
-    char until);
+typedef struct ecs_script_tokenizer_t {
+    ecs_script_tokens_t stack;
+    ecs_script_token_t *tokens;
+} ecs_script_tokenizer_t;
 
 const char* flecs_script_until(
     ecs_script_parser_t *parser,
@@ -4562,6 +4584,9 @@ const char* flecs_script_until(
     char until);
 
 const char* flecs_script_token_kind_str(
+    ecs_script_token_kind_t kind);
+
+const char* flecs_script_token_str(
     ecs_script_token_kind_t kind);
 
 const char* flecs_script_token(
@@ -4574,6 +4599,11 @@ const char* flecs_scan_whitespace(
     ecs_script_parser_t *parser,
     const char *pos);
 
+const char* flecs_script_identifier(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_token_t *out);
+
 #endif
 
 
@@ -4584,12 +4614,19 @@ struct ecs_script_parser_t {
     char *token_cur;
     char *token_keep;
     bool significant_newline;
+    bool merge_variable_members;
 
     /* For term parser */
     ecs_term_t *term;
     ecs_oper_kind_t extra_oper;
     ecs_term_ref_t *extra_args;
 };
+
+typedef struct ecs_function_calldata_t {
+    ecs_entity_t function;
+    ecs_function_callback_t callback;
+    void *ctx;
+} ecs_function_calldata_t;
 
 /**
  * @file addons/script/ast.h
@@ -4618,6 +4655,7 @@ typedef enum ecs_script_node_kind_t {
     EcsAstEntity,
     EcsAstPairScope,
     EcsAstIf,
+    EcsAstFor
 } ecs_script_node_kind_t;
 
 typedef struct ecs_script_node_t {
@@ -4630,6 +4668,10 @@ struct ecs_script_scope_t {
     ecs_vec_t stmts;
     ecs_script_scope_t *parent;
     ecs_id_t default_component_eval;
+
+    /* Array with component ids that are added in scope. Used to limit
+     * archetype moves. */
+    ecs_vec_t components; /* vec<ecs_id_t> */
 };
 
 typedef struct ecs_script_id_t {
@@ -4637,6 +4679,16 @@ typedef struct ecs_script_id_t {
     const char *second;
     ecs_id_t flag;
     ecs_id_t eval;
+
+    /* If first or second refer to a variable, these are the cached variable 
+     * stack pointers so we don't have to lookup variables by name. */
+    int32_t first_sp; 
+    int32_t second_sp;
+
+    /* If true, the lookup result for this id cannot be cached. This is the case
+     * for entities that are defined inside of templates, which have different
+     * values for each instantiation. */
+    bool dynamic;
 } ecs_script_id_t;
 
 typedef struct ecs_script_tag_t {
@@ -4647,20 +4699,21 @@ typedef struct ecs_script_tag_t {
 typedef struct ecs_script_component_t {
     ecs_script_node_t node;
     ecs_script_id_t id;
-    const char *expr;
+    ecs_expr_node_t *expr;
     ecs_value_t eval;
     bool is_collection;
 } ecs_script_component_t;
 
 typedef struct ecs_script_default_component_t {
     ecs_script_node_t node;
-    const char *expr;
+    ecs_expr_node_t *expr;
     ecs_value_t eval;
 } ecs_script_default_component_t;
 
 typedef struct ecs_script_var_component_t {
     ecs_script_node_t node;
     const char *name;
+    int32_t sp;
 } ecs_script_var_component_t;
 
 struct ecs_script_entity_t {
@@ -4670,8 +4723,9 @@ struct ecs_script_entity_t {
     bool name_is_var;
     bool kind_w_expr;
     ecs_script_scope_t *scope;
+    ecs_expr_node_t *name_expr;
 
-    // Populated during eval
+    /* Populated during eval */
     ecs_script_entity_t *parent;
     ecs_entity_t eval;
     ecs_entity_t eval_kind;
@@ -4720,15 +4774,23 @@ typedef struct ecs_script_var_node_t {
     ecs_script_node_t node;
     const char *name;
     const char *type;
-    const char *expr;
+    ecs_expr_node_t *expr;
 } ecs_script_var_node_t;
 
 typedef struct ecs_script_if_t {
     ecs_script_node_t node;
     ecs_script_scope_t *if_true;
     ecs_script_scope_t *if_false;
-    const char *expr;
+    ecs_expr_node_t *expr;
 } ecs_script_if_t;
+
+typedef struct ecs_script_for_range_t {
+    ecs_script_node_t node;
+    const char *loop_var;
+    ecs_expr_node_t *from;
+    ecs_expr_node_t *to;
+    ecs_script_scope_t *scope;
+} ecs_script_for_range_t;
 
 #define ecs_script_node(kind, node)\
     ((ecs_script_##kind##_t*)node)
@@ -4741,7 +4803,8 @@ ecs_script_scope_t* flecs_script_insert_scope(
 
 ecs_script_entity_t* flecs_script_insert_entity(
     ecs_script_parser_t *parser,
-    const char *name);
+    const char *name,
+    bool name_is_expr);
 
 ecs_script_pair_scope_t* flecs_script_insert_pair_scope(
     ecs_script_parser_t *parser,
@@ -4799,6 +4862,404 @@ ecs_script_var_component_t* flecs_script_insert_var_component(
 
 ecs_script_if_t* flecs_script_insert_if(
     ecs_script_parser_t *parser);
+
+ecs_script_for_range_t* flecs_script_insert_for_range(
+    ecs_script_parser_t *parser);
+
+#endif
+
+/**
+ * @file addons/script/expr/expr.h
+ * @brief Script expression support.
+ */
+
+#ifndef FLECS_EXPR_SCRIPT_H
+#define FLECS_EXPR_SCRIPT_H
+
+/**
+ * @file addons/script/expr/stack.h
+ * @brief Script expression AST.
+ */
+
+#ifndef FLECS_SCRIPT_EXPR_STACK_H
+#define FLECS_SCRIPT_EXPR_STACK_H
+
+#define FLECS_EXPR_STACK_MAX (256)
+#define FLECS_EXPR_SMALL_DATA_SIZE (24)
+
+
+typedef union ecs_expr_small_value_t {
+    bool bool_;
+    char char_;
+    ecs_byte_t byte_;
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    intptr_t iptr;
+    uint8_t u8;
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    uintptr_t uptr;
+    double f32;
+    double f64;
+    char *string;
+    ecs_entity_t entity;
+    ecs_id_t id;
+
+    /* Avoid allocations for small trivial types */
+    char small_data[FLECS_EXPR_SMALL_DATA_SIZE];
+} ecs_expr_small_value_t;
+
+typedef struct ecs_expr_value_t {
+    ecs_value_t value;
+    const ecs_type_info_t *type_info;
+    bool owned; /* Is value owned by the runtime */
+} ecs_expr_value_t;
+
+typedef struct ecs_expr_stack_frame_t {
+    ecs_stack_cursor_t *cur;
+    int32_t sp;
+} ecs_expr_stack_frame_t;
+
+typedef struct ecs_expr_stack_t {
+    ecs_expr_value_t values[FLECS_EXPR_STACK_MAX];
+    ecs_expr_stack_frame_t frames[FLECS_EXPR_STACK_MAX];
+    ecs_stack_t stack;
+    int32_t frame;
+} ecs_expr_stack_t;
+
+void flecs_expr_stack_init(
+    ecs_expr_stack_t *stack);
+
+void flecs_expr_stack_fini(
+    ecs_expr_stack_t *stack);
+
+ecs_expr_value_t* flecs_expr_stack_alloc(
+    ecs_expr_stack_t *stack,
+    const ecs_type_info_t *ti);
+
+ecs_expr_value_t* flecs_expr_stack_result(
+    ecs_expr_stack_t *stack,
+    ecs_expr_node_t *node);
+
+void flecs_expr_stack_push(
+    ecs_expr_stack_t *stack);
+
+void flecs_expr_stack_pop(
+    ecs_expr_stack_t *stack);
+
+#endif
+
+/**
+ * @file addons/script/expr_ast.h
+ * @brief Script expression AST.
+ */
+
+#ifndef FLECS_SCRIPT_EXPR_AST_H
+#define FLECS_SCRIPT_EXPR_AST_H
+
+#define FLECS_EXPR_SMALL_DATA_SIZE (24)
+
+typedef enum ecs_expr_node_kind_t {
+    EcsExprValue,
+    EcsExprInterpolatedString,
+    EcsExprInitializer,
+    EcsExprEmptyInitializer,
+    EcsExprUnary,
+    EcsExprBinary,
+    EcsExprIdentifier,
+    EcsExprVariable,
+    EcsExprGlobalVariable,
+    EcsExprFunction,
+    EcsExprMethod,
+    EcsExprMember,
+    EcsExprElement,
+    EcsExprComponent,
+    EcsExprCast,
+    EcsExprCastNumber,
+    EcsExprMatch
+} ecs_expr_node_kind_t;
+
+struct ecs_expr_node_t {
+    ecs_expr_node_kind_t kind;
+    ecs_entity_t type;
+    const ecs_type_info_t *type_info;
+    const char *pos;
+};
+
+typedef struct ecs_expr_value_node_t {
+    ecs_expr_node_t node;
+    void *ptr;
+    ecs_expr_small_value_t storage;
+} ecs_expr_value_node_t;
+
+typedef struct ecs_expr_interpolated_string_t {
+    ecs_expr_node_t node;
+    char *value;              /* modified by parser */
+    char *buffer;             /* for storing expr tokens */
+    ecs_size_t buffer_size;
+    ecs_vec_t fragments;      /* vec<char*> */
+    ecs_vec_t expressions;    /* vec<ecs_expr_node_t*> */
+} ecs_expr_interpolated_string_t;
+
+typedef struct ecs_expr_initializer_element_t {
+    const char *member;
+    ecs_expr_node_t *value;
+    uintptr_t offset;
+    ecs_script_token_kind_t operator;
+} ecs_expr_initializer_element_t;
+
+typedef struct ecs_expr_initializer_t {
+    ecs_expr_node_t node;
+    ecs_vec_t elements;
+    const ecs_type_info_t *type_info;
+    bool is_collection;
+    bool is_dynamic;
+} ecs_expr_initializer_t;
+
+typedef struct ecs_expr_variable_t {
+    ecs_expr_node_t node;
+    const char *name;
+    ecs_value_t global_value; /* Only set for global variables */
+    int32_t sp; /* For fast variable lookups */
+} ecs_expr_variable_t;
+
+typedef struct ecs_expr_identifier_t {
+    ecs_expr_node_t node;
+    const char *value;
+    ecs_expr_node_t *expr;
+} ecs_expr_identifier_t;
+
+typedef struct ecs_expr_unary_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *expr;
+    ecs_script_token_kind_t operator;
+} ecs_expr_unary_t;
+
+typedef struct ecs_expr_binary_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *left;
+    ecs_expr_node_t *right;
+    ecs_script_token_kind_t operator;
+} ecs_expr_binary_t;
+
+typedef struct ecs_expr_member_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *left;
+    const char *member_name;
+    uintptr_t offset;
+} ecs_expr_member_t;
+
+typedef struct ecs_expr_function_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *left;
+    ecs_expr_initializer_t *args;
+    const char *function_name;
+    ecs_function_calldata_t calldata;
+} ecs_expr_function_t;
+
+typedef struct ecs_expr_element_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *left;
+    ecs_expr_node_t *index;
+    ecs_size_t elem_size;
+} ecs_expr_element_t;
+
+typedef struct ecs_expr_component_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *expr;
+    ecs_id_t component;
+} ecs_expr_component_t;
+
+typedef struct ecs_expr_cast_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *expr;
+} ecs_expr_cast_t;
+
+typedef struct ecs_expr_match_element_t {
+    ecs_expr_node_t *compare;
+    ecs_expr_node_t *expr;
+} ecs_expr_match_element_t;
+
+typedef struct ecs_expr_match_t {
+    ecs_expr_node_t node;
+    ecs_expr_node_t *expr;
+    ecs_vec_t elements;
+    ecs_expr_match_element_t any;
+} ecs_expr_match_t;
+
+ecs_expr_value_node_t* flecs_expr_value_from(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    ecs_entity_t type);
+
+ecs_expr_variable_t* flecs_expr_variable_from(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const char *name);
+
+ecs_expr_value_node_t* flecs_expr_bool(
+    ecs_script_parser_t *parser,
+    bool value);
+
+ecs_expr_value_node_t* flecs_expr_int(
+    ecs_script_parser_t *parser,
+    int64_t value);
+
+ecs_expr_value_node_t* flecs_expr_uint(
+    ecs_script_parser_t *parser,
+    uint64_t value);
+
+ecs_expr_value_node_t* flecs_expr_float(
+    ecs_script_parser_t *parser,
+    double value);
+
+ecs_expr_value_node_t* flecs_expr_string(
+    ecs_script_parser_t *parser,
+    const char *value);
+
+ecs_expr_interpolated_string_t* flecs_expr_interpolated_string(
+    ecs_script_parser_t *parser,
+    const char *value);
+
+ecs_expr_value_node_t* flecs_expr_entity(
+    ecs_script_parser_t *parser,
+    ecs_entity_t value);
+
+ecs_expr_initializer_t* flecs_expr_initializer(
+    ecs_script_parser_t *parser);
+
+ecs_expr_identifier_t* flecs_expr_identifier(
+    ecs_script_parser_t *parser,
+    const char *value);
+
+ecs_expr_variable_t* flecs_expr_variable(
+    ecs_script_parser_t *parser,
+    const char *value);
+
+ecs_expr_unary_t* flecs_expr_unary(
+    ecs_script_parser_t *parser);
+
+ecs_expr_binary_t* flecs_expr_binary(
+    ecs_script_parser_t *parser);
+
+ecs_expr_member_t* flecs_expr_member(
+    ecs_script_parser_t *parser);
+
+ecs_expr_function_t* flecs_expr_function(
+    ecs_script_parser_t *parser);
+
+ecs_expr_element_t* flecs_expr_element(
+    ecs_script_parser_t *parser);
+
+ecs_expr_match_t* flecs_expr_match(
+    ecs_script_parser_t *parser);
+
+ecs_expr_cast_t* flecs_expr_cast(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    ecs_entity_t type);
+
+#endif
+
+/**
+ * @file addons/script/exor_visit.h
+ * @brief Script AST visitor utilities.
+ */
+
+#ifndef FLECS_EXPR_SCRIPT_VISIT_H
+#define FLECS_EXPR_SCRIPT_VISIT_H
+
+#define flecs_expr_visit_error(script, node, ...) \
+    ecs_parser_error( \
+        script->name, script->code, \
+            ((const ecs_expr_node_t*)node)->pos - script->code, \
+                __VA_ARGS__);
+
+int flecs_expr_visit_type(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const ecs_expr_eval_desc_t *desc);
+
+int flecs_expr_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node,
+    const ecs_expr_eval_desc_t *desc);
+
+int flecs_expr_visit_eval(
+    const ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const ecs_expr_eval_desc_t *desc,
+    ecs_value_t *out);
+
+void flecs_expr_visit_free(
+    ecs_script_t *script,
+    ecs_expr_node_t *node);
+
+ecs_script_var_t flecs_expr_find_var(
+    ecs_script_t *script,
+    const char *name);
+
+#endif
+
+
+int flecs_value_copy_to(
+    ecs_world_t *world,
+    ecs_value_t *dst,
+    const ecs_expr_value_t *src);
+
+int flecs_value_move_to(
+    ecs_world_t *world,
+    ecs_value_t *dst,
+    ecs_value_t *src);
+
+int flecs_value_binary(
+    const ecs_script_t *script,
+    const ecs_value_t *left,
+    const ecs_value_t *right,
+    ecs_value_t *out,
+    ecs_script_token_kind_t operator);
+
+int flecs_value_unary(
+    const ecs_script_t *script,
+    const ecs_value_t *expr,
+    ecs_value_t *out,
+    ecs_script_token_kind_t operator);
+
+const char* flecs_script_parse_expr(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_token_kind_t left_oper,
+    ecs_expr_node_t **out);
+
+const char* flecs_script_parse_initializer(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    char until,
+    ecs_expr_initializer_t **node_out);
+
+void flecs_expr_to_str_buf(
+    const ecs_world_t *world,
+    const ecs_expr_node_t *expr,
+    ecs_strbuf_t *buf,
+    bool colors);
+
+bool flecs_string_is_interpolated(
+    const char *str);
+
+char* flecs_string_escape(
+    char *str);
+
+bool flecs_value_is_0(
+    const ecs_value_t *value);
+
+bool flecs_expr_is_type_integer(
+    ecs_entity_t type);
+
+bool flecs_expr_is_type_number(
+    ecs_entity_t type);
 
 #endif
 
@@ -4894,19 +5355,17 @@ int32_t ecs_script_node_line_number_(
 typedef struct ecs_script_eval_visitor_t {
     ecs_script_visit_t base;
     ecs_world_t *world;
-    ecs_allocator_t *allocator;
-    ecs_script_template_t *template;
+    ecs_script_runtime_t *r;
+    ecs_script_template_t *template; /* Set when creating template */
+    ecs_entity_t template_entity; /* Set when creating template instance */
     ecs_entity_t module;
     ecs_entity_t parent;
     ecs_script_entity_t *entity;
-    ecs_vec_t using;
-    ecs_vec_t with;
-    ecs_vec_t with_type_info;
-    ecs_vec_t annot;
     ecs_entity_t with_relationship;
     int32_t with_relationship_sp;
+    bool is_with_scope;
+    bool dynamic_variable_binding;
     ecs_script_vars_t *vars;
-    ecs_stack_t stack;
 } ecs_script_eval_visitor_t;
 
 void flecs_script_eval_error_(
@@ -4918,10 +5377,17 @@ void flecs_script_eval_error_(
 #define flecs_script_eval_error(v, node, ...)\
     flecs_script_eval_error_(v, (ecs_script_node_t*)node, __VA_ARGS__)
 
-ecs_entity_t flecs_script_find_entity(
+int flecs_script_find_entity(
     ecs_script_eval_visitor_t *v,
     ecs_entity_t from,
-    const char *path);
+    const char *path,
+    int32_t *frame_offset,
+    ecs_entity_t *out);
+
+ecs_script_var_t* flecs_script_find_var(
+    const ecs_script_vars_t *vars,
+    const char *name,
+    int32_t *frame_offset);
 
 ecs_entity_t flecs_script_create_entity(
     ecs_script_eval_visitor_t *v,
@@ -4934,33 +5400,65 @@ const ecs_type_info_t* flecs_script_get_type_info(
 
 int flecs_script_eval_expr(
     ecs_script_eval_visitor_t *v,
-    const char *expr,
+    ecs_expr_node_t **expr_ptr,
     ecs_value_t *value);
 
-int flecs_script_eval_template(
-    ecs_script_eval_visitor_t *v,
-    ecs_script_template_node_t *template);
-
-ecs_script_template_t* flecs_script_template_init(
-    ecs_script_impl_t *script);
-
-void flecs_script_template_fini(
-    ecs_script_impl_t *script,
-    ecs_script_template_t *template);
-
 void flecs_script_eval_visit_init(
-    ecs_script_impl_t *script,
-    ecs_script_eval_visitor_t *v);
+    const ecs_script_impl_t *script,
+    ecs_script_eval_visitor_t *v,
+    const ecs_script_eval_desc_t *desc);
 
 void flecs_script_eval_visit_fini(
-    ecs_script_eval_visitor_t *v);
+    ecs_script_eval_visitor_t *v,
+    const ecs_script_eval_desc_t *desc);
 
 int flecs_script_eval_node(
     ecs_script_eval_visitor_t *v,
     ecs_script_node_t *node);
 
+int flecs_script_check_node(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_node_t *node);
+
+int flecs_script_check_scope(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_scope_t *node);
+
+/* Functions shared between check and eval visitor */
+
+int flecs_script_eval_scope(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_scope_t *node);
+
+int flecs_script_eval_id(
+    ecs_script_eval_visitor_t *v,
+    void *node,
+    ecs_script_id_t *id);
+
+int flecs_script_eval_using(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_using_t *node);
+
+int flecs_script_eval_const(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_var_node_t *node);
+
+ecs_entity_t flecs_script_find_entity_action(
+    const ecs_world_t *world,
+    const char *path,
+    void *ctx);
+
 #endif
 
+/**
+ * @file addons/script/template.h
+ * @brief Script template implementation.
+ */
+
+#ifndef FLECS_SCRIPT_TEMPLATE_H
+#define FLECS_SCRIPT_TEMPLATE_H
+
+extern ECS_COMPONENT_DECLARE(EcsScriptTemplateSetEvent);
 
 struct ecs_script_template_t {
     /* Template handle */
@@ -4980,6 +5478,48 @@ struct ecs_script_template_t {
 
     /* Type info for template component */
     const ecs_type_info_t *type_info;
+};
+
+#define ECS_TEMPLATE_SMALL_SIZE (36)
+
+/* Event used for deferring template instantiation */
+typedef struct EcsScriptTemplateSetEvent {
+    ecs_entity_t template_entity;
+    ecs_entity_t *entities;
+    void *data;
+    int32_t count;
+
+    /* Storage for small template types */
+    int64_t _align; /* Align data storage to 8 bytes */
+    char data_storage[ECS_TEMPLATE_SMALL_SIZE];
+    ecs_entity_t entity_storage;
+} EcsScriptTemplateSetEvent;
+
+int flecs_script_eval_template(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_template_node_t *template);
+
+ecs_script_template_t* flecs_script_template_init(
+    ecs_script_impl_t *script);
+
+void flecs_script_template_fini(
+    ecs_script_impl_t *script,
+    ecs_script_template_t *template);
+
+void flecs_script_template_import(
+    ecs_world_t *world);
+
+#endif
+
+
+struct ecs_script_runtime_t {
+    ecs_allocator_t allocator;
+    ecs_expr_stack_t expr_stack;
+    ecs_stack_t stack;
+    ecs_vec_t using;
+    ecs_vec_t with;
+    ecs_vec_t with_type_info;
+    ecs_vec_t annot;
 };
 
 ecs_script_t* flecs_script_new(
@@ -5013,6 +5553,19 @@ const char* flecs_term_parse(
     const char *expr,
     ecs_term_t *term,
     char *token_buffer);
+
+ecs_script_runtime_t* flecs_script_runtime_get(
+    ecs_world_t *world);
+
+void flecs_script_register_builtin_functions(
+    ecs_world_t *world);
+
+void flecs_function_import(
+    ecs_world_t *world);
+
+int flecs_script_check(
+    const ecs_script_t *script,
+    const ecs_script_eval_desc_t *desc);
 
 #endif // FLECS_SCRIPT
 #endif // FLECS_SCRIPT_PRIVATE_H
@@ -5846,6 +6399,8 @@ ecs_record_t* flecs_new_entity(
     return record;
 }
 
+static int commit_indent = 0;
+
 static
 void flecs_move_entity(
     ecs_world_t *world,
@@ -5983,6 +6538,8 @@ void flecs_commit(
         return;
     }
 
+    commit_indent += 2;
+
     ecs_os_perf_trace_push("flecs.commit");
 
     if (src_table) {
@@ -6021,6 +6578,8 @@ void flecs_commit(
         ecs_check(entity >= world->info.min_id, 
             ECS_OUT_OF_RANGE, 0);
     }
+
+    commit_indent -=2 ;
 
     ecs_os_perf_trace_pop("flecs.commit");
 
@@ -6204,6 +6763,29 @@ void flecs_remove_id(
     flecs_commit(world, entity, r, dst_table, &diff, true, 0);
 
     flecs_defer_end(world, stage);
+}
+
+void flecs_add_ids(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    ecs_id_t *ids,
+    int32_t count)
+{
+    ecs_record_t *r = flecs_entities_get(world, entity);
+    ecs_table_diff_builder_t diff = ECS_TABLE_DIFF_INIT;
+    flecs_table_diff_builder_init(world, &diff);
+
+    ecs_table_t *table = ecs_get_table(world, entity);
+    int32_t i;
+    for (i = 0; i < count; i ++) {
+        ecs_id_t id = ids[i];
+        table = flecs_find_table_add(world, table, id, &diff);
+    }
+
+    ecs_table_diff_t table_diff;
+    flecs_table_diff_build_noalloc(&diff, &table_diff);
+    flecs_commit(world, entity, r, table, &table_diff, true, 0);
+    flecs_table_diff_builder_fini(world, &diff);
 }
 
 static
@@ -6741,7 +7323,8 @@ int flecs_traverse_add(
         const char *sym = ecs_get_symbol(world, result);
         if (sym) {
             ecs_assert(!ecs_os_strcmp(desc->symbol, sym),
-                ECS_INCONSISTENT_NAME, desc->symbol);
+                ECS_INCONSISTENT_NAME, "%s (provided) vs. %s (existing)",
+                    desc->symbol, sym);
         } else {
             ecs_set_symbol(world, result, desc->symbol);
         }
@@ -6749,7 +7332,12 @@ int flecs_traverse_add(
 
     /* If a name is provided but not yet assigned, add the Name component */
     if (name && !name_assigned) {
-        ecs_add_path_w_sep(world, result, scope, name, sep, root_sep);
+        if (!ecs_add_path_w_sep(world, result, scope, name, sep, root_sep)) {
+            if (name[0] == '#') {
+                /* Numerical ids should always return, unless it's invalid */
+                goto error;
+            }
+        }
     } else if (new_entity && scope) {
         ecs_add_pair(world, result, EcsChildOf, scope);
     }
@@ -6840,6 +7428,7 @@ int flecs_traverse_add(
     ecs_vec_fini_t(&world->allocator, &ids, ecs_id_t);
     return 0;
 error:
+    flecs_table_diff_builder_fini(world, &diff);
     ecs_vec_fini_t(&world->allocator, &ids, ecs_id_t);
     return -1;
 }
@@ -7020,6 +7609,8 @@ ecs_entity_t ecs_entity_init(
     /* Parent field takes precedence over scope */
     if (desc->parent) {
         scope = desc->parent;
+        ecs_check(ecs_is_valid(world, desc->parent), 
+            ECS_INVALID_PARAMETER, "ecs_entity_desc_t::parent is not valid");
     }
 
     /* Find or create entity */
@@ -7090,7 +7681,7 @@ ecs_entity_t ecs_entity_init(
         world, result, ecs_id(EcsIdentifier), EcsName),
             ECS_INTERNAL_ERROR, NULL);
 
-    if (stage->defer) {
+    if (ecs_is_deferred(world)) {
         flecs_deferred_add_remove((ecs_world_t*)stage, result, name, desc, 
             scope, with, flecs_new_entity, name_assigned);
     } else {
@@ -7264,7 +7855,7 @@ ecs_entity_t ecs_component_init(
     }
 
     flecs_resume_readonly(world, &readonly_state);
-    
+
     ecs_assert(result != 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(ecs_has(world, result, EcsComponent), ECS_INTERNAL_ERROR, NULL);
 
@@ -7782,9 +8373,6 @@ void flecs_on_delete(
      * frame will handle the actual cleanup. */
     int32_t i, count = ecs_vec_count(&world->store.marked_ids);
 
-    /* Make sure we're evaluating a consistent list of non-empty tables */
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
-
     /* Collect all ids that need to be deleted */
     flecs_on_delete_mark(world, id, action, delete_id);
 
@@ -7795,9 +8383,6 @@ void flecs_on_delete(
 
         /* Empty tables with all the to be deleted ids */
         flecs_on_delete_clear_tables(world);
-
-        /* All marked tables are empty, ensure they're in the right list */
-        ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
 
         /* Release remaining references to the ids */
         flecs_on_delete_clear_ids(world);
@@ -8462,7 +9047,7 @@ void flecs_modified_id_if(
 
     ecs_record_t *r = flecs_entities_get(world, entity);
     ecs_table_t *table = r->table;
-    if (!flecs_table_record_get(world, table, id)) {
+    if (!table || !flecs_table_record_get(world, table, id)) {
         flecs_defer_end(world, stage);
         return;
     }
@@ -8631,26 +9216,18 @@ void ecs_enable_id(
     ecs_check(flecs_can_toggle(world, id), ECS_INVALID_OPERATION, 
         "add CanToggle trait to component");
 
+    ecs_entity_t bs_id = id | ECS_TOGGLE;
+    ecs_add_id(world, entity, bs_id);
+
     if (flecs_defer_enable(stage, entity, id, enable)) {
         return;
     }
 
-    ecs_record_t *r = flecs_entities_get(world, entity);
-    ecs_entity_t bs_id = id | ECS_TOGGLE;
-    
+    ecs_record_t *r = flecs_entities_get(world, entity);    
     ecs_table_t *table = r->table;
-    int32_t index = -1;
-    if (table) {
-        index = ecs_table_get_type_index(world, table, bs_id);
-    }
+    int32_t index = ecs_table_get_type_index(world, table, bs_id);
+    ecs_assert(index != -1, ECS_INTERNAL_ERROR, NULL);
 
-    if (index == -1) {
-        ecs_add_id(world, entity, bs_id);
-        flecs_defer_end(world, stage);
-        ecs_enable_id(world, entity, id, enable);
-        return;
-    }
-    
     ecs_assert(table->_ != NULL, ECS_INTERNAL_ERROR, NULL);
     index -= table->_->bs_offset;
     ecs_assert(index >= 0, ECS_INTERNAL_ERROR, NULL);
@@ -9256,11 +9833,13 @@ void ecs_set_version(
 
     flecs_entities_make_alive(world, entity_with_generation);
 
-    ecs_record_t *r = flecs_entities_get(world, entity_with_generation);
-    if (r && r->table) {
-        int32_t row = ECS_RECORD_TO_ROW(r->row);
-        ecs_entity_t *entities = r->table->data.entities;
-        entities[row] = entity_with_generation;
+    if (flecs_entities_is_alive(world, entity_with_generation)) {
+        ecs_record_t *r = flecs_entities_get(world, entity_with_generation);
+        if (r && r->table) {
+            int32_t row = ECS_RECORD_TO_ROW(r->row);
+            ecs_entity_t *entities = r->table->data.entities;
+            entities[row] = entity_with_generation;
+        }
     }
 }
 
@@ -9897,24 +10476,26 @@ void flecs_cmd_batch_for_entity(
             ecs_id_t *ids = diff->added.array;
             uint8_t added_index = flecs_ito(uint8_t, diff->added.count);
 
-            table = flecs_find_table_add(world, table, id, diff);
-
-            if (diff->added.count == (added_index + 1)) {
-                /* Single id was added, must be at the end of the array */
-                ecs_assert(ids[added_index] == id, ECS_INTERNAL_ERROR, NULL);
-                set_mask |= (1llu << added_index);
-            } else {
-                /* Id was already added or multiple ids got added. Do a linear
-                 * search to find the index we need to set the set_mask. */
-                int32_t i;
-                for (i = 0; i < diff->added.count; i ++) {
-                    if (ids[i] == id) {
-                        break;
+            ecs_table_t *next = flecs_find_table_add(world, table, id, diff);
+            if (next != table) {
+                table = next;
+                if (diff->added.count == (added_index + 1)) {
+                    /* Single id was added, must be at the end of the array */
+                    ecs_assert(ids[added_index] == id, ECS_INTERNAL_ERROR, NULL);
+                    set_mask |= (1llu << added_index);
+                } else {
+                    /* Id was already added or multiple ids got added. Do a linear
+                    * search to find the index we need to set the set_mask. */
+                    int32_t i;
+                    for (i = 0; i < diff->added.count; i ++) {
+                        if (ids[i] == id) {
+                            break;
+                        }
                     }
-                }
 
-                ecs_assert(i != diff->added.count, ECS_INTERNAL_ERROR, NULL);
-                set_mask |= (1llu << i);
+                    ecs_assert(i != diff->added.count, ECS_INTERNAL_ERROR, NULL);
+                    set_mask |= (1llu << i);
+                }
             }
 
             world->info.cmd.batched_command_count ++;
@@ -10017,15 +10598,17 @@ void flecs_cmd_batch_for_entity(
                         ecs_xtor_t dtor = ti->hooks.dtor;
                         if (dtor) {
                             dtor(cmd->is._1.value, 1, ti);
-                            cmd->is._1.value = NULL;
                         }
                     } else {
                         ecs_os_memcpy(ptr.ptr, cmd->is._1.value, ti->size);
                     }
 
+                    flecs_stack_free(cmd->is._1.value, cmd->is._1.size);
+                    cmd->is._1.value = NULL;
+
                     if (cmd->kind == EcsCmdSet) {
                         /* A set operation is add + copy + modified. We just did
-                         * the add the copy, so the only thing that's left is a 
+                         * the add and copy, so the only thing that's left is a 
                          * modified command, which will call the OnSet 
                          * observers. */
                         cmd->kind = EcsCmdModified;
@@ -10099,7 +10682,7 @@ bool flecs_defer_end(
 
     ecs_assert(stage->defer > 0, ECS_INTERNAL_ERROR, NULL);
 
-    if (!--stage->defer) {
+    if (!--stage->defer && !stage->cmd_flushing) {
         ecs_os_perf_trace_push("flecs.commands.merge");
 
         /* Test whether we're flushing to another queue or whether we're 
@@ -10109,11 +10692,23 @@ bool flecs_defer_end(
             merge_to_world = world->stages[0]->defer == 0;
         }
 
-        ecs_stage_t *dst_stage = flecs_stage_from_world(&world);
-        ecs_commands_t *commands = stage->cmd;
-        ecs_vec_t *queue = &commands->queue;
+        do {
+            ecs_stage_t *dst_stage = flecs_stage_from_world(&world);
+            ecs_commands_t *commands = stage->cmd;
+            ecs_vec_t *queue = &commands->queue;
 
-        if (ecs_vec_count(queue)) {
+            if (stage->cmd == &stage->cmd_stack[0]) {
+                stage->cmd = &stage->cmd_stack[1];
+            } else {
+                stage->cmd = &stage->cmd_stack[0];
+            }
+
+            if (!ecs_vec_count(queue)) {
+                break;
+            }
+
+            stage->cmd_flushing = true;
+
             /* Internal callback for capturing commands */
             if (world->on_commands_active) {
                 world->on_commands_active(stage, queue, 
@@ -10125,7 +10720,6 @@ bool flecs_defer_end(
 
             ecs_table_diff_builder_t diff;
             flecs_table_diff_builder_init(world, &diff);
-            flecs_commands_push(stage);
 
             for (i = 0; i < count; i ++) {
                 ecs_cmd_t *cmd = &cmds[i];
@@ -10283,10 +10877,10 @@ bool flecs_defer_end(
                 }
             }
 
+            stage->cmd_flushing = false;
+
             flecs_stack_reset(&commands->stack);
             ecs_vec_clear(queue);
-            flecs_commands_pop(stage);
-
             flecs_table_diff_builder_fini(world, &diff);
 
             /* Internal callback for capturing commands, signal queue is done */
@@ -10294,7 +10888,7 @@ bool flecs_defer_end(
                 world->on_commands_active(stage, NULL, 
                     world->on_commands_ctx_active);
             }
-        }
+        } while (true);
 
         ecs_os_perf_trace_pop("flecs.commands.merge");
 
@@ -10468,7 +11062,11 @@ ecs_entity_t flecs_name_to_id(
 {
     ecs_assert(name != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_assert(name[0] == '#', ECS_INVALID_PARAMETER, NULL);
-    return flecs_ito(uint64_t, atoll(name + 1));
+    ecs_entity_t res = flecs_ito(uint64_t, atoll(name + 1));
+    if (res >= UINT32_MAX) {
+        return 0; /* Invalid id */
+    }
+    return res;
 }
 
 static
@@ -10542,7 +11140,7 @@ const char* flecs_path_elem(
         }
 
         if (buffer) {
-            if (pos == (size - 1)) {
+            if (pos >= (size - 1)) {
                 if (size == ECS_NAME_BUFFER_LENGTH) { /* stack buffer */
                     char *new_buffer = ecs_os_malloc(size * 2 + 1);
                     ecs_os_memcpy(new_buffer, buffer, size);
@@ -10565,7 +11163,7 @@ const char* flecs_path_elem(
         *size_out = size;
     }
 
-    if (pos) {
+    if (pos || ptr[0]) {
         return ptr;
     } else {
         return NULL;
@@ -10593,8 +11191,11 @@ ecs_entity_t flecs_get_parent_from_path(
     const char **path_ptr,
     const char *sep,
     const char *prefix,
-    bool new_entity)
+    bool new_entity,
+    bool *error)
 {
+    ecs_assert(error != NULL, ECS_INTERNAL_ERROR, NULL);
+
     bool start_from_root = false;
     const char *path = *path_ptr;
 
@@ -10606,6 +11207,10 @@ ecs_entity_t flecs_get_parent_from_path(
 
     if (path[0] == '#') {
         parent = flecs_name_to_id(path);
+        if (!parent && ecs_os_strncmp(path, "#0", 2)) {
+            *error = true;
+            return 0;
+        }
 
         path ++;
         while (path[0] && isdigit(path[0])) {
@@ -10784,6 +11389,8 @@ ecs_entity_t ecs_lookup_path_w_sep(
     }
 
     ecs_check(world != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_check(!parent || ecs_is_valid(world, parent), 
+        ECS_INVALID_PARAMETER, NULL);
     const ecs_world_t *stage = world;
     world = ecs_get_world(world);
 
@@ -10813,8 +11420,12 @@ ecs_entity_t ecs_lookup_path_w_sep(
         sep = ".";
     }
 
+    bool error = false;
     parent = flecs_get_parent_from_path(
-        stage, parent, &path, sep, prefix, true);
+        stage, parent, &path, sep, prefix, true, &error);
+    if (error) {
+        return 0;
+    }
 
     if (parent && !(parent = ecs_get_alive(world, parent))) {
         return 0;
@@ -10970,6 +11581,10 @@ ecs_entity_t ecs_add_path_w_sep(
     const char *prefix)
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    const ecs_world_t *real_world = world;
+    if (flecs_poly_is(world, ecs_stage_t)) {
+        real_world = ecs_get_world(world);
+    }
 
     if (!sep) {
         sep = ".";
@@ -10988,8 +11603,14 @@ ecs_entity_t ecs_add_path_w_sep(
     }
 
     bool root_path = flecs_is_root_path(path, prefix);
+    bool error = false;
     parent = flecs_get_parent_from_path(
-        world, parent, &path, sep, prefix, !entity);
+        world, parent, &path, sep, prefix, !entity, &error);
+    if (error) {
+        /* Invalid id */
+        ecs_err("invalid identifier: '%s'", path);
+        return 0;
+    }
 
     char buff[ECS_NAME_BUFFER_LENGTH];
     const char *ptr = path;
@@ -11000,7 +11621,7 @@ ecs_entity_t ecs_add_path_w_sep(
      * immediately updated. Without this, we could create multiple entities for
      * the same name in a single command queue. */
     bool suspend_defer = ecs_is_deferred(world) &&
-        !(world->flags & EcsWorldMultiThreaded);
+        !(real_world->flags & EcsWorldMultiThreaded);
         
     ecs_entity_t cur = parent;
     char *name = NULL;
@@ -12383,6 +13004,9 @@ char* flecs_load_from_file(
 
     return content;
 error:
+    if (file) {
+        fclose(file);
+    }
     ecs_os_free(content);
     return NULL;
 }
@@ -12884,10 +13508,6 @@ void flecs_emit_propagate_id(
             it->entities = ecs_table_entities(table);
         }
 
-        /* Treat as new event as this could invoke observers again for
-         * different tables. */
-        it->event_cur = ++ world->event_id;
-
         int32_t ider_i;
         for (ider_i = 0; ider_i < ider_count; ider_i ++) {
             ecs_event_id_record_t *ider = iders[ider_i];
@@ -13174,7 +13794,8 @@ void flecs_emit_forward_up(
     ecs_table_t *table,
     ecs_id_record_t *idr,
     ecs_vec_t *stack,
-    ecs_vec_t *reachable_ids);
+    ecs_vec_t *reachable_ids,
+    int32_t depth);
 
 static
 void flecs_emit_forward_id(
@@ -13413,7 +14034,8 @@ void flecs_emit_forward_table_up(
     ecs_record_t *tgt_record,
     ecs_id_record_t *tgt_idr,
     ecs_vec_t *stack,
-    ecs_vec_t *reachable_ids)
+    ecs_vec_t *reachable_ids,
+    int32_t depth)
 {
     ecs_allocator_t *a = &world->allocator;
     int32_t i, id_count = tgt_table->type.count;
@@ -13450,6 +14072,13 @@ void flecs_emit_forward_table_up(
             continue;
         }
 
+        if (idr == tgt_idr) {
+            char *idstr = ecs_id_str(world, idr->id);
+            ecs_assert(idr != tgt_idr, ECS_CYCLE_DETECTED, idstr);
+            ecs_os_free(idstr);
+            return;
+        }
+
         /* Id has the same relationship, traverse to find ids for forwarding */
         if (ECS_PAIR_FIRST(id) == trav || ECS_PAIR_FIRST(id) == EcsIsA) {
             ecs_table_t **t = ecs_vec_append_t(&world->allocator, stack, 
@@ -13474,7 +14103,7 @@ void flecs_emit_forward_table_up(
                 /* Cache is dirty, traverse upwards */
                 do {
                     flecs_emit_forward_up(world, er, er_onset, emit_ids, it, 
-                        table, idr, stack, reachable_ids);
+                        table, idr, stack, reachable_ids, depth);
                     if (++i >= id_count) {
                         break;
                     }
@@ -13556,8 +14185,16 @@ void flecs_emit_forward_up(
     ecs_table_t *table,
     ecs_id_record_t *idr,
     ecs_vec_t *stack,
-    ecs_vec_t *reachable_ids)
+    ecs_vec_t *reachable_ids,
+    int32_t depth)
 {
+    if (depth >= FLECS_DAG_DEPTH_MAX) {
+        char *idstr = ecs_id_str(world, idr->id);
+        ecs_assert(depth < FLECS_DAG_DEPTH_MAX, ECS_CYCLE_DETECTED, idstr);
+        ecs_os_free(idstr);
+        return;
+    }
+
     ecs_id_t id = idr->id;
     ecs_entity_t tgt = ECS_PAIR_SECOND(id);
     tgt = flecs_entities_get_alive(world, tgt);
@@ -13569,7 +14206,7 @@ void flecs_emit_forward_up(
     }
 
     flecs_emit_forward_table_up(world, er, er_onset, emit_ids, it, table, 
-        tgt, tgt_table, tgt_record, idr, stack, reachable_ids);
+        tgt, tgt_table, tgt_record, idr, stack, reachable_ids, depth + 1);
 }
 
 static
@@ -13597,7 +14234,7 @@ void flecs_emit_forward(
         ecs_vec_init_t(&world->allocator, &stack, ecs_table_t*, 0);
         ecs_vec_reset_t(&world->allocator, &rc->ids, ecs_reachable_elem_t);
         flecs_emit_forward_up(world, er, er_onset, emit_ids, it, table, 
-            idr, &stack, &rc->ids);
+            idr, &stack, &rc->ids, 0);
         it->sources[0] = 0;
         ecs_vec_fini_t(&world->allocator, &stack, ecs_table_t*);
 
@@ -13676,6 +14313,11 @@ void flecs_emit_forward(
                     ECS_INTERNAL_ERROR, NULL);
                 ecs_dbg_assert(r->table == elem->table, ECS_INTERNAL_ERROR, NULL);
                 (void)r;
+
+                /* If entities already have the component, don't propagate */
+                if (flecs_id_record_get_table(rc_idr, it->table)) {
+                    continue;
+                }
 
                 ecs_event_id_record_t *iders[5] = {0};
                 int32_t ider_count = flecs_event_observers_get(
@@ -14196,12 +14838,6 @@ ecs_flags32_t flecs_id_flag_for_event(
     if (e == EcsOnSet) {
         return EcsIdHasOnSet;
     }
-    if (e == EcsOnTableFill) {
-        return EcsIdHasOnTableFill;
-    }
-    if (e == EcsOnTableEmpty) {
-        return EcsIdHasOnTableEmpty;
-    }
     if (e == EcsOnTableCreate) {
         return EcsIdHasOnTableCreate;
     }
@@ -14614,8 +15250,6 @@ void flecs_multi_observer_invoke(
         return;
     }
 
-    impl->last_event_id[0] = world->event_id;
-
     ecs_table_t *table = it->table;
     ecs_table_t *prev_table = it->other_table;
     int8_t pivot_term = it->term_index;
@@ -14667,6 +15301,8 @@ void flecs_multi_observer_invoke(
                 goto done;
             }
         }
+
+        impl->last_event_id[0] = it->event_cur;
 
         /* Patch data from original iterator. If the observer query has 
          * wildcards which triggered the original event, the component id that
@@ -14792,8 +15428,6 @@ void flecs_observer_yield_existing(
     if (!run) {
         run = flecs_multi_observer_invoke_no_query;
     }
-
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
 
     ecs_defer_begin(world);
 
@@ -14963,9 +15597,7 @@ int flecs_multi_observer_init(
     bool only_table_events = true;
     for (i = 0; i < o->event_count; i ++) {
         ecs_entity_t e = o->events[i];
-        if (e != EcsOnTableCreate && e != EcsOnTableDelete && 
-            e != EcsOnTableEmpty && e != EcsOnTableFill)
-        {
+        if (e != EcsOnTableCreate && e != EcsOnTableDelete) {
             only_table_events = false;
             break;
         }
@@ -15052,8 +15684,8 @@ int flecs_multi_observer_init(
             term->src.id = EcsThis | EcsIsVariable | EcsSelf;
             term->second.id = 0;
         } else if (term->oper == EcsOptional) {
-            if (only_table_events) {
-                /* For table events optional terms aren't necessary */
+            if (only_table_events || desc->events[0] == EcsMonitor) {
+                /* For table events & monitors optional terms aren't necessary */
                 continue;
             }
         }
@@ -15109,12 +15741,13 @@ ecs_observer_t* flecs_observer_init(
         ECS_INVALID_OPERATION,
             "cannot create observer: must at least specify callback or run");
 
-    ecs_observer_impl_t *impl = flecs_sparse_add_t(
-        &world->store.observers, ecs_observer_impl_t);
+    ecs_observer_impl_t *impl = flecs_calloc_t(
+        &world->allocator, ecs_observer_impl_t);
     ecs_assert(impl != NULL, ECS_INTERNAL_ERROR, NULL);
+    impl->id = ++ world->observable.last_observer_id;
+
     flecs_poly_init(impl, ecs_observer_t);
     ecs_observer_t *o = &impl->pub;
-    impl->id = flecs_sparse_last_id(&world->store.observers);
     impl->dtor = flecs_observer_poly_fini;
 
     /* Make writeable copy of query desc so that we can set name. This will
@@ -15238,7 +15871,7 @@ ecs_entity_t ecs_observer_init(
     const ecs_observer_desc_t *desc)
 {
     ecs_entity_t entity = 0;
-    ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
+    flecs_poly_assert(world, ecs_world_t);
     ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(desc->_canary == 0, ECS_INVALID_PARAMETER,
         "ecs_observer_desc_t was not initialized to zero");
@@ -15393,8 +16026,7 @@ void flecs_observer_fini(
     }
 
     flecs_poly_fini(o, ecs_observer_t);
-    flecs_sparse_remove_t(
-        &world->store.observers, ecs_observer_impl_t, impl->id);
+    flecs_free_t(&world->allocator, ecs_observer_impl_t, o);
 }
 
 void flecs_observer_set_disable_bit(
@@ -16606,6 +17238,7 @@ ecs_cmd_t* flecs_cmd_new(
     ecs_cmd_t *cmd = ecs_vec_append_t(&stage->allocator, &stage->cmd->queue, 
         ecs_cmd_t);
     cmd->is._1.value = NULL;
+    cmd->id = 0;
     cmd->next_for_entity = 0;
     cmd->entry = NULL;
     cmd->system = stage->system;
@@ -16658,7 +17291,7 @@ void flecs_stage_merge(
     bool is_stage = flecs_poly_is(world, ecs_stage_t);
     ecs_stage_t *stage = flecs_stage_from_world(&world);
 
-    bool measure_frame_time = ECS_BIT_IS_SET(world->flags, 
+    bool measure_frame_time = ECS_BIT_IS_SET(ecs_world_get_flags(world), 
         EcsWorldMeasureFrameTime);
 
     ecs_time_t t_start = {0};
@@ -17150,7 +17783,6 @@ void flecs_stage_merge_post_frame(
     ecs_vec_clear(&stage->post_frame_actions);
 }
 
-static
 void flecs_commands_init(
     ecs_stage_t *stage,
     ecs_commands_t *cmd)
@@ -17161,33 +17793,16 @@ void flecs_commands_init(
         &stage->allocators.cmd_entry_chunk, ecs_cmd_entry_t);
 }
 
-static
 void flecs_commands_fini(
     ecs_stage_t *stage,
     ecs_commands_t *cmd)
 {
     /* Make sure stage has no unmerged data */
-    ecs_assert(ecs_vec_count(&stage->cmd->queue) == 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(ecs_vec_count(&cmd->queue) == 0, ECS_INTERNAL_ERROR, NULL);
 
     flecs_stack_fini(&cmd->stack);
     ecs_vec_fini_t(&stage->allocator, &cmd->queue, ecs_cmd_t);
     flecs_sparse_fini(&cmd->entries);
-}
-
-void flecs_commands_push(
-    ecs_stage_t *stage)
-{
-    int32_t sp = ++ stage->cmd_sp;
-    ecs_assert(sp < ECS_MAX_DEFER_STACK, ECS_INTERNAL_ERROR, NULL);
-    stage->cmd = &stage->cmd_stack[sp];
-}
-
-void flecs_commands_pop(
-    ecs_stage_t *stage)
-{
-    int32_t sp = -- stage->cmd_sp;
-    ecs_assert(sp >= 0, ECS_INTERNAL_ERROR, NULL);
-    stage->cmd = &stage->cmd_stack[sp];
 }
 
 ecs_entity_t flecs_stage_set_system(
@@ -17222,7 +17837,7 @@ ecs_stage_t* flecs_stage_new(
     ecs_vec_init_t(a, &stage->post_frame_actions, ecs_action_elem_t, 0);
 
     int32_t i;
-    for (i = 0; i < ECS_MAX_DEFER_STACK; i ++) {
+    for (i = 0; i < 2; i ++) {
         flecs_commands_init(stage, &stage->cmd_stack[i]);
     }
 
@@ -17248,9 +17863,15 @@ void flecs_stage_free(
     ecs_vec_fini(NULL, &stage->operations, 0);
 
     int32_t i;
-    for (i = 0; i < ECS_MAX_DEFER_STACK; i ++) {
+    for (i = 0; i < 2; i ++) {
         flecs_commands_fini(stage, &stage->cmd_stack[i]);
     }
+
+#ifdef FLECS_SCRIPT
+    if (stage->runtime) {
+        ecs_script_runtime_free(stage->runtime);
+    }
+#endif
 
     flecs_stack_fini(&stage->allocators.iter_stack);
     flecs_stack_fini(&stage->allocators.deser_stack);
@@ -17404,8 +18025,6 @@ bool ecs_readonly_begin(
 {
     flecs_poly_assert(world, ecs_world_t);
 
-    flecs_process_pending_tables(world);
-
     ecs_dbg_3("#[bold]readonly");
     ecs_log_push_3();
 
@@ -17540,7 +18159,8 @@ void* ecs_value_new_w_type_info(
     ecs_check(ti != NULL, ECS_INVALID_PARAMETER, NULL);
     (void)world;
 
-    void *result = flecs_alloc(&world->allocator, ti->size);
+    void *result = flecs_alloc_w_dbg_info(
+        &world->allocator, ti->size, ti->name);
     if (ecs_value_init_w_type_info(world, ti, result) != 0) {
         flecs_free(&world->allocator, ti->size, result);
         goto error;
@@ -17804,8 +18424,6 @@ const ecs_entity_t EcsOnDelete =                    FLECS_HI_COMPONENT_ID + 43;
 const ecs_entity_t EcsOnDeleteTarget =              FLECS_HI_COMPONENT_ID + 44;
 const ecs_entity_t EcsOnTableCreate =               FLECS_HI_COMPONENT_ID + 45;
 const ecs_entity_t EcsOnTableDelete =               FLECS_HI_COMPONENT_ID + 46;
-const ecs_entity_t EcsOnTableEmpty =                FLECS_HI_COMPONENT_ID + 47;
-const ecs_entity_t EcsOnTableFill =                 FLECS_HI_COMPONENT_ID + 48;
 
 /* Timers */
 const ecs_entity_t ecs_id(EcsTickSource) =          FLECS_HI_COMPONENT_ID + 49;
@@ -18121,23 +18739,30 @@ ecs_world_t* flecs_suspend_readonly(
 
     /* Cannot suspend when running with multiple threads */
     ecs_assert(!(world->flags & EcsWorldReadonly) ||
-        !(world->flags & EcsWorldMultiThreaded), ECS_INVALID_WHILE_READONLY, NULL);
+        !(world->flags & EcsWorldMultiThreaded), 
+            ECS_INVALID_WHILE_READONLY, NULL);
 
     state->is_readonly = is_readonly;
     state->is_deferred = stage->defer != 0;
+    state->cmd_flushing = stage->cmd_flushing;
 
     /* Silence readonly checks */
     world->flags &= ~EcsWorldReadonly;
+    stage->cmd_flushing = false;
 
     /* Hack around safety checks (this ought to look ugly) */
     state->defer_count = stage->defer;
-    state->commands = stage->cmd->queue;
-    state->defer_stack = stage->cmd->stack;
-    flecs_stack_init(&stage->cmd->stack);
+    state->cmd_stack[0] = stage->cmd_stack[0];
+    state->cmd_stack[1] = stage->cmd_stack[1];
+    state->cmd = stage->cmd;
+
+    flecs_commands_init(stage, &stage->cmd_stack[0]);
+    flecs_commands_init(stage, &stage->cmd_stack[1]);
+    stage->cmd = &stage->cmd_stack[0];
+
     state->scope = stage->scope;
     state->with = stage->with;
     stage->defer = 0;
-    ecs_vec_init_t(NULL, &stage->cmd->queue, ecs_cmd_t, 0);
 
     return world;
 }
@@ -18160,10 +18785,13 @@ void flecs_resume_readonly(
         /* Restore readonly state / defer count */
         ECS_BIT_COND(world->flags, EcsWorldReadonly, state->is_readonly);
         stage->defer = state->defer_count;
-        ecs_vec_fini_t(&stage->allocator, &stage->cmd->queue, ecs_cmd_t);
-        stage->cmd->queue = state->commands;
-        flecs_stack_fini(&stage->cmd->stack);
-        stage->cmd->stack = state->defer_stack;
+        stage->cmd_flushing = state->cmd_flushing;
+        flecs_commands_fini(stage, &stage->cmd_stack[0]);
+        flecs_commands_fini(stage, &stage->cmd_stack[1]);
+        stage->cmd_stack[0] = state->cmd_stack[0];
+        stage->cmd_stack[1] = state->cmd_stack[1];
+        stage->cmd = state->cmd;
+        
         stage->scope = state->scope;
         stage->with = state->with;
     }
@@ -18314,10 +18942,6 @@ void flecs_init_store(
 
     /* Initialize root table */
     flecs_init_root_table(world);
-
-    /* Initialize observer sparse set */
-    flecs_sparse_init_t(&world->store.observers,
-        a, &world->allocators.sparse_chunk, ecs_observer_impl_t);
 }
 
 static
@@ -18432,8 +19056,6 @@ void flecs_fini_roots(
 {
     ecs_id_record_t *idr = flecs_id_record_get(world, ecs_pair(EcsChildOf, 0));
 
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
-
     /* Delete root entities that are not modules. This prioritizes deleting
      * regular entities first, which reduces the chance of components getting
      * destructed in random order because it got deleted before entities,
@@ -18454,10 +19076,6 @@ void flecs_fini_store(ecs_world_t *world) {
     flecs_table_fini(world, &world->store.root);
     flecs_entities_clear(world);
     flecs_hashmap_fini(&world->store.table_map);
-
-    ecs_assert(flecs_sparse_count(&world->store.observers) == 0, 
-        ECS_INTERNAL_ERROR, NULL);
-    flecs_sparse_fini(&world->store.observers);
 
     ecs_assert(ecs_vec_count(&world->store.marked_ids) == 0, 
         ECS_INTERNAL_ERROR, NULL);
@@ -18689,23 +19307,16 @@ ecs_world_t *ecs_mini(void) {
     flecs_world_allocators_init(world);
     ecs_allocator_t *a = &world->allocator;
 
-    world->self = world;
-    flecs_sparse_init_t(&world->type_info, a,
-        &world->allocators.sparse_chunk, ecs_type_info_t);
+    ecs_map_init(&world->type_info, a);
     ecs_map_init_w_params(&world->id_index_hi, &world->allocators.ptr);
-    world->id_index_lo = ecs_os_calloc_n(ecs_id_record_t, FLECS_HI_ID_RECORD_ID);
+    world->id_index_lo = ecs_os_calloc_n(
+        ecs_id_record_t*, FLECS_HI_ID_RECORD_ID);
     flecs_observable_init(&world->observable);
-
-    world->pending_tables = ecs_os_calloc_t(ecs_sparse_t);
-    flecs_sparse_init_t(world->pending_tables, a,
-        &world->allocators.sparse_chunk, ecs_table_t*);
-    world->pending_buffer = ecs_os_calloc_t(ecs_sparse_t);
-    flecs_sparse_init_t(world->pending_buffer, a,
-        &world->allocators.sparse_chunk, ecs_table_t*);
 
     flecs_name_index_init(&world->aliases, a);
     flecs_name_index_init(&world->symbols, a);
     ecs_vec_init_t(a, &world->fini_actions, ecs_action_elem_t, 0);
+    ecs_vec_init_t(a, &world->component_ids, ecs_id_t, 0);
 
     world->info.time_scale = 1.0;
     if (ecs_os_has_time()) {
@@ -18920,6 +19531,77 @@ void flecs_default_move_w_dtor(void *dst_ptr, void *src_ptr,
     cl->dtor(src_ptr, count, ti);
 }
 
+ECS_NORETURN static
+void flecs_ctor_illegal(
+    void * dst,
+    int32_t count,
+    const ecs_type_info_t *ti) {
+    (void)dst; /* silence unused warning */
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid constructor for %s", ti->name);
+}
+
+ECS_NORETURN static
+void flecs_dtor_illegal(
+    void *dst,
+    int32_t count,
+    const ecs_type_info_t *ti) {
+    (void)dst; /* silence unused warning */
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid destructor for %s", ti->name);
+}
+
+ECS_NORETURN static
+void flecs_copy_illegal(
+    void *dst,
+    const void *src,
+    int32_t count,
+    const ecs_type_info_t *ti)
+{
+    (void)dst; /* silence unused warning */
+    (void)src; 
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid copy assignment for %s", ti->name);
+}
+
+ECS_NORETURN static
+void flecs_move_illegal(
+    void * dst,
+    void * src,
+    int32_t count,
+    const ecs_type_info_t *ti) {
+    (void)dst; /* silence unused warning */
+    (void)src;
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid move assignment for %s", ti->name);
+}
+
+ECS_NORETURN static
+void flecs_copy_ctor_illegal(
+    void *dst,
+    const void *src,
+    int32_t count,
+    const ecs_type_info_t *ti)
+{
+    (void)dst; /* silence unused warning */
+    (void)src;
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid copy construct for %s", ti->name);
+}
+
+ECS_NORETURN static
+void flecs_move_ctor_illegal(
+    void *dst,
+    void *src,
+    int32_t count,
+    const ecs_type_info_t *ti)
+{
+    (void)dst; /* silence unused warning */
+    (void)src;
+    (void)count;
+    ecs_abort(ECS_INVALID_OPERATION, "invalid move construct for %s", ti->name);
+}
+
 void ecs_set_hooks_id(
     ecs_world_t *world,
     ecs_entity_t component,
@@ -18927,12 +19609,38 @@ void ecs_set_hooks_id(
 {
     ecs_check(world != NULL, ECS_INVALID_PARAMETER, NULL);
 
+    /* TODO: Refactor to enforce flags consistency: */
+    ecs_flags32_t flags = h->flags;
+    flags &= ~((ecs_flags32_t)ECS_TYPE_HOOKS);
+
+    /* TODO: enable asserts once RTT API is updated */
+    /*
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) || !h->ctor, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_DTOR_ILLEGAL) || !h->dtor, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_COPY_ILLEGAL) || !h->copy, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_MOVE_ILLEGAL) || !h->move, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL) || !h->copy_ctor, 
+        ECS_INVALID_PARAMETER, 
+            "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL) || !h->move_ctor, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL) || 
+        !h->ctor_move_dtor, ECS_INVALID_PARAMETER, 
+            "cannot specify both hook and illegal flag");
+    ecs_check(!(h->flags & ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL) || !h->move_dtor, 
+        ECS_INVALID_PARAMETER, "cannot specify both hook and illegal flag");
+    */
+
     flecs_stage_from_world(&world);
 
     /* Ensure that no tables have yet been created for the component */
-    ecs_assert( ecs_id_in_use(world, component) == false,
+    ecs_check( ecs_id_in_use(world, component) == false,
         ECS_ALREADY_IN_USE, ecs_get_name(world, component));
-    ecs_assert( ecs_id_in_use(world, ecs_pair(component, EcsWildcard)) == false,
+    ecs_check( ecs_id_in_use(world, ecs_pair(component, EcsWildcard)) == false,
         ECS_ALREADY_IN_USE, ecs_get_name(world, component));
 
     ecs_type_info_t *ti = flecs_type_info_ensure(world, component);
@@ -18984,27 +19692,41 @@ void ecs_set_hooks_id(
     }
 
     /* Set default copy ctor, move ctor and merge */
-    if (h->copy && !h->copy_ctor) {
-        ti->hooks.copy_ctor = flecs_default_copy_ctor;
+    if (!h->copy_ctor) {
+        if(flags & ECS_TYPE_HOOK_COPY_ILLEGAL || flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) {
+            flags |= ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL;
+        } else if(h->copy) {
+            ti->hooks.copy_ctor = flecs_default_copy_ctor;
+        }
     }
 
-    if (h->move && !h->move_ctor) {
-        ti->hooks.move_ctor = flecs_default_move_ctor;
+    if (!h->move_ctor) {
+        if(flags & ECS_TYPE_HOOK_MOVE_ILLEGAL || flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) {
+            flags |= ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL;
+        } else if (h->move) {
+            ti->hooks.move_ctor = flecs_default_move_ctor;
+        }
     }
 
     if (!h->ctor_move_dtor) {
+        ecs_flags32_t illegal_check = 0;
         if (h->move) {
+            illegal_check |= ECS_TYPE_HOOK_MOVE_ILLEGAL;
             if (h->dtor) {
+                illegal_check |= ECS_TYPE_HOOK_DTOR_ILLEGAL;
                 if (h->move_ctor) {
+                    illegal_check |= ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL;
                     /* If an explicit move ctor has been set, use callback
                      * that uses the move ctor vs. using a ctor+move */
                     ti->hooks.ctor_move_dtor = flecs_default_move_ctor_w_dtor;
                 } else {
+                    illegal_check |= ECS_TYPE_HOOK_CTOR_ILLEGAL;
                     /* If no explicit move_ctor has been set, use
                      * combination of ctor + move + dtor */
                     ti->hooks.ctor_move_dtor = flecs_default_ctor_w_move_w_dtor;
                 }
             } else {
+                illegal_check |= ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL;
                 /* If no dtor has been set, this is just a move ctor */
                 ti->hooks.ctor_move_dtor = ti->hooks.move_ctor;
             }
@@ -19012,27 +19734,71 @@ void ecs_set_hooks_id(
             /* If move is not set but move_ctor and dtor is, we can still set
              * ctor_move_dtor. */
             if (h->move_ctor) {
+                illegal_check |= ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL;
                 if (h->dtor) {
+                    illegal_check |= ECS_TYPE_HOOK_DTOR_ILLEGAL;
                     ti->hooks.ctor_move_dtor = flecs_default_move_ctor_w_dtor;
                 } else {
                     ti->hooks.ctor_move_dtor = ti->hooks.move_ctor;
                 }
             }
         }
+        if(flags & illegal_check) {
+            flags |= ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL;
+        }
     }
 
     if (!h->move_dtor) {
+        ecs_flags32_t illegal_check = 0;
         if (h->move) {
+            illegal_check |= ECS_TYPE_HOOK_MOVE_ILLEGAL;
             if (h->dtor) {
+                illegal_check |= ECS_TYPE_HOOK_DTOR_ILLEGAL;
                 ti->hooks.move_dtor = flecs_default_move_w_dtor;
             } else {
                 ti->hooks.move_dtor = flecs_default_move;
             }
         } else {
             if (h->dtor) {
+                illegal_check |= ECS_TYPE_HOOK_DTOR_ILLEGAL;
                 ti->hooks.move_dtor = flecs_default_dtor;
             }
         }
+        if(flags & illegal_check) {
+            flags |= ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL;
+        }
+    }
+
+    ti->hooks.flags = flags;
+
+    if (ti->hooks.ctor) ti->hooks.flags |= ECS_TYPE_HOOK_CTOR;
+    if (ti->hooks.dtor) ti->hooks.flags |= ECS_TYPE_HOOK_DTOR;
+    if (ti->hooks.move) ti->hooks.flags |= ECS_TYPE_HOOK_MOVE;
+    if (ti->hooks.move_ctor) ti->hooks.flags |= ECS_TYPE_HOOK_MOVE_CTOR;
+    if (ti->hooks.ctor_move_dtor) ti->hooks.flags |= ECS_TYPE_HOOK_CTOR_MOVE_DTOR;
+    if (ti->hooks.move_dtor) ti->hooks.flags |= ECS_TYPE_HOOK_MOVE_DTOR;
+    if (ti->hooks.copy) ti->hooks.flags |= ECS_TYPE_HOOK_COPY;
+    if (ti->hooks.copy_ctor) ti->hooks.flags |= ECS_TYPE_HOOK_COPY_CTOR;
+
+    if(flags & ECS_TYPE_HOOK_CTOR_ILLEGAL) ti->hooks.ctor = flecs_ctor_illegal;
+    if(flags & ECS_TYPE_HOOK_DTOR_ILLEGAL) ti->hooks.dtor = flecs_dtor_illegal;
+    if(flags & ECS_TYPE_HOOK_COPY_ILLEGAL) ti->hooks.copy = flecs_copy_illegal;
+    if(flags & ECS_TYPE_HOOK_MOVE_ILLEGAL) ti->hooks.move = flecs_move_illegal;
+
+    if(flags & ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL) {
+        ti->hooks.copy_ctor = flecs_copy_ctor_illegal;
+    }
+
+    if(ti->hooks.flags & ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL) {
+        ti->hooks.move_ctor = flecs_move_ctor_illegal;
+    }
+
+    if(ti->hooks.flags & ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL) {
+        ti->hooks.ctor_move_dtor = flecs_move_ctor_illegal;
+    }
+
+    if(ti->hooks.flags & ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL) {
+        ti->hooks.ctor_move_dtor = flecs_move_ctor_illegal;
     }
 
 error:
@@ -19123,14 +19889,13 @@ static
 void flecs_fini_type_info(
     ecs_world_t *world)
 {
-    int32_t i, count = flecs_sparse_count(&world->type_info);
-    ecs_sparse_t *type_info = &world->type_info;
-    for (i = 0; i < count; i ++) {
-        ecs_type_info_t *ti = flecs_sparse_get_dense_t(type_info,
-            ecs_type_info_t, i);
+    ecs_map_iter_t it = ecs_map_iter(&world->type_info);
+    while (ecs_map_next(&it)) {
+        ecs_type_info_t *ti = ecs_map_ptr(&it);
         flecs_type_info_fini(ti);
+        ecs_os_free(ti);
     }
-    flecs_sparse_fini(&world->type_info);
+    ecs_map_fini(&world->type_info);
 }
 
 ecs_entity_t flecs_get_oneof(
@@ -19217,16 +19982,13 @@ int ecs_fini(
     ecs_dbg_1("#[bold]cleanup world data structures");
     ecs_log_push_1();
     flecs_entities_fini(world);
-    flecs_sparse_fini(world->pending_tables);
-    flecs_sparse_fini(world->pending_buffer);
-    ecs_os_free(world->pending_tables);
-    ecs_os_free(world->pending_buffer);
     flecs_fini_id_records(world);
     flecs_fini_type_info(world);
     flecs_observable_fini(&world->observable);
     flecs_name_index_fini(&world->aliases);
     flecs_name_index_fini(&world->symbols);
     ecs_set_stage_count(world, 0);
+    ecs_vec_fini_t(&world->allocator, &world->component_ids, ecs_id_t);
     ecs_log_pop_1();
 
     flecs_world_allocators_fini(world);
@@ -19261,7 +20023,6 @@ void flecs_eval_component_monitors(
     ecs_world_t *world)
 {
     flecs_poly_assert(world, ecs_world_t); 
-    flecs_process_pending_tables(world);  
     flecs_eval_component_monitor(world);
 }
 
@@ -19308,7 +20069,6 @@ void ecs_set_default_query_flags(
     ecs_flags32_t flags)
 {
     flecs_poly_assert(world, ecs_world_t);
-    flecs_process_pending_tables(world);
     world->default_query_flags = flags;
 }
 
@@ -19404,7 +20164,7 @@ const ecs_type_info_t* flecs_type_info_get(
     ecs_assert(component != 0, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(!(component & ECS_ID_FLAGS_MASK), ECS_INTERNAL_ERROR, NULL);
 
-    return flecs_sparse_try_t(&world->type_info, ecs_type_info_t, component);
+    return ecs_map_get_deref(&world->type_info, ecs_type_info_t, component);
 }
 
 ecs_type_info_t* flecs_type_info_ensure(
@@ -19417,7 +20177,7 @@ ecs_type_info_t* flecs_type_info_ensure(
     const ecs_type_info_t *ti = flecs_type_info_get(world, component);
     ecs_type_info_t *ti_mut = NULL;
     if (!ti) {
-        ti_mut = flecs_sparse_ensure_t(
+        ti_mut = ecs_map_ensure_alloc_t(
             &world->type_info, ecs_type_info_t, component);
         ecs_assert(ti_mut != NULL, ECS_INTERNAL_ERROR, NULL);
         ti_mut->component = component;
@@ -19456,7 +20216,7 @@ bool flecs_type_info_init_id(
         ecs_assert(size == 0 && alignment == 0,
             ECS_INVALID_COMPONENT_SIZE, NULL);
         ecs_assert(li == NULL, ECS_INCONSISTENT_COMPONENT_ACTION, NULL);
-        flecs_sparse_remove_t(&world->type_info, ecs_type_info_t, component);
+        ecs_map_remove_free(&world->type_info, component);
     } else {
         ti = flecs_type_info_ensure(world, component);
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -19530,6 +20290,8 @@ void flecs_type_info_free(
     ecs_world_t *world,
     ecs_entity_t component)
 {
+    flecs_poly_assert(world, ecs_world_t);
+
     if (world->flags & EcsWorldQuit) {
         /* If world is in the final teardown stages, cleanup policies are no
          * longer applied and it can't be guaranteed that a component is not
@@ -19538,11 +20300,11 @@ void flecs_type_info_free(
         return;
     }
 
-    ecs_type_info_t *ti = flecs_sparse_try_t(&world->type_info,
-        ecs_type_info_t, component);
+    ecs_type_info_t *ti = ecs_map_get_deref(
+        &world->type_info, ecs_type_info_t, component);
     if (ti) {
         flecs_type_info_fini(ti);
-        flecs_sparse_remove_t(&world->type_info, ecs_type_info_t, component);
+        ecs_map_remove_free(&world->type_info, component);
     }
 }
 
@@ -19734,8 +20496,6 @@ void flecs_process_empty_queries(
         return;
     }
 
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
-
     /* Make sure that we defer adding the inactive tags until after iterating
      * the query */
     flecs_defer_begin(world, world->stages[0]);
@@ -19761,119 +20521,6 @@ void flecs_process_empty_queries(
     flecs_defer_end(world, world->stages[0]);
 }
 
-/** Walk over tables that had a state change which requires bookkeeping */
-void flecs_process_pending_tables(
-    const ecs_world_t *world_r)
-{
-    flecs_poly_assert(world_r, ecs_world_t);
-
-    /* We can't update the administration while in readonly mode, but we can
-     * ensure that when this function is called there are no pending events. */
-    if (world_r->flags & EcsWorldReadonly) {
-        ecs_assert(flecs_sparse_count(world_r->pending_tables) == 0,
-            ECS_INTERNAL_ERROR, NULL);
-        return;
-    }
-
-    /* Safe to cast, world is not readonly */
-    ecs_world_t *world = ECS_CONST_CAST(ecs_world_t*, world_r);
-
-    /* If pending buffer is NULL there already is a stackframe that's iterating
-     * the table list. This can happen when an observer for a table event results
-     * in a mutation that causes another table to change state. A typical
-     * example of this is a system that becomes active/inactive as the result of
-     * a query (and as a result, its matched tables) becoming empty/non empty */
-    if (!world->pending_buffer) {
-        return;
-    }
-
-    /* Swap buffer. The logic could in theory have been implemented with a
-     * single sparse set, but that would've complicated (and slowed down) the
-     * iteration. Additionally, by using a double buffer approach we can still
-     * keep most of the original ordering of events intact, which is desirable
-     * as it means that the ordering of tables in the internal data structures is
-     * more predictable. */
-    int32_t i, count = flecs_sparse_count(world->pending_tables);
-    if (!count) {
-        return;
-    }
-
-    ecs_os_perf_trace_push("flecs.process_pending_tables");
-
-    flecs_journal_begin(world, EcsJournalTableEvents, 0, 0, 0);
-
-    do {
-        ecs_sparse_t *pending_tables = world->pending_tables;
-        world->pending_tables = world->pending_buffer;
-        world->pending_buffer = NULL;
-
-        /* Make sure that any ECS operations that occur while delivering the
-         * events does not cause inconsistencies, like sending an Empty
-         * notification for a table that just became non-empty. */
-        flecs_defer_begin(world, world->stages[0]);
-
-        for (i = 0; i < count; i ++) {
-            ecs_table_t *table = flecs_sparse_get_dense_t(
-                pending_tables, ecs_table_t*, i)[0];
-            if (!table->id) {
-                /* Table is being deleted, ignore empty events */
-                continue;
-            }
-
-            /* For each id in the table, add it to the empty/non empty list
-             * based on its current state */
-            if (flecs_table_records_update_empty(table)) {
-                int32_t table_count = ecs_table_count(table);
-                if (table->flags & (EcsTableHasOnTableFill|EcsTableHasOnTableEmpty)) {
-                    /* Only emit an event when there was a change in the
-                    * administration. It is possible that a table ended up in the
-                    * pending_tables list by going from empty->non-empty, but then
-                    * became empty again. By the time we run this code, no changes
-                    * in the administration would actually be made. */
-                    ecs_entity_t evt = table_count ? EcsOnTableFill : EcsOnTableEmpty;
-                    if (ecs_should_log_3()) {
-                        ecs_dbg_3("table %u state change (%s)",
-                            (uint32_t)table->id,
-                            table_count ? "non-empty" : "empty");
-                    }
-
-                    ecs_log_push_3();
-
-                    flecs_table_emit(world, table, evt);
-
-                    ecs_log_pop_3();
-                }
-                world->info.empty_table_count += (table_count == 0) * 2 - 1;
-            }
-        }
-
-        flecs_sparse_clear(pending_tables);
-        ecs_defer_end(world);
-
-        world->pending_buffer = pending_tables;
-    } while ((count = flecs_sparse_count(world->pending_tables)));
-
-    flecs_journal_end();
-
-    ecs_os_perf_trace_pop("flecs.process_pending_tables");
-}
-
-void flecs_table_set_empty(
-    ecs_world_t *world,
-    ecs_table_t *table)
-{
-    flecs_poly_assert(world, ecs_world_t);
-    ecs_assert(!(world->flags & EcsWorldReadonly), ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-
-    if (ecs_table_count(table)) {
-        table->_->generation = 0;
-    }
-
-    flecs_sparse_ensure_fast_t(world->pending_tables, ecs_table_t*,
-        (uint32_t)table->id)[0] = table;
-}
-
 bool ecs_id_in_use(
     const ecs_world_t *world,
     ecs_id_t id)
@@ -19882,8 +20529,8 @@ bool ecs_id_in_use(
     if (!idr) {
         return false;
     }
-    return (flecs_table_cache_count(&idr->cache) != 0) ||
-        (flecs_table_cache_empty_count(&idr->cache) != 0);
+
+    return (flecs_table_cache_count(&idr->cache) != 0);
 }
 
 void ecs_run_aperiodic(
@@ -19891,10 +20538,6 @@ void ecs_run_aperiodic(
     ecs_flags32_t flags)
 {
     flecs_poly_assert(world, ecs_world_t);
-    
-    if (!flags || (flags & EcsAperiodicEmptyTables)) {
-        flecs_process_pending_tables(world);
-    }
 
     if ((flags & EcsAperiodicEmptyQueries)) {
         flecs_process_empty_queries(world);
@@ -19907,22 +20550,21 @@ void ecs_run_aperiodic(
 
 int32_t ecs_delete_empty_tables(
     ecs_world_t *world,
-    ecs_id_t id,
-    uint16_t clear_generation,
-    uint16_t delete_generation,
-    int32_t min_id_count,
-    double time_budget_seconds)
+    const ecs_delete_empty_tables_desc_t *desc)
 {
     flecs_poly_assert(world, ecs_world_t);
 
     ecs_os_perf_trace_push("flecs.delete_empty_tables");
 
-    /* Make sure empty tables are in the empty table lists */
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
-
     ecs_time_t start = {0}, cur = {0};
     int32_t delete_count = 0;
     bool time_budget = false;
+
+    ecs_id_t id = desc->id;
+    uint16_t clear_generation = desc->clear_generation;
+    uint16_t delete_generation = desc->delete_generation;
+    int32_t min_id_count = desc->min_id_count;
+    double time_budget_seconds = desc->time_budget_seconds;
 
     if (ECS_NEQZERO(time_budget_seconds) || (ecs_should_log_1() && ecs_os_has_time())) {
         ecs_time_measure(&start);
@@ -19984,8 +20626,74 @@ ecs_entities_t ecs_get_entities(
 ecs_flags32_t ecs_world_get_flags(
     const ecs_world_t *world)
 {
+    if (flecs_poly_is(world, ecs_world_t)) {
+        return world->flags;
+    } else {
+        flecs_poly_assert(world, ecs_stage_t);
+        const ecs_stage_t *stage = (const ecs_stage_t*)world;
+        return stage->world->flags;
+    }
+}
+
+static int32_t flecs_component_ids_last_index = 0;
+
+int32_t flecs_component_ids_index_get(void) {
+    if (ecs_os_api.ainc_) {
+        return ecs_os_ainc(&flecs_component_ids_last_index);
+    } else {
+        return ++ flecs_component_ids_last_index;
+    }
+}
+
+ecs_entity_t flecs_component_ids_get(
+    const ecs_world_t *stage_world, 
+    int32_t index)
+{
+    ecs_world_t *world =
+        ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage_world));
     flecs_poly_assert(world, ecs_world_t);
-    return world->flags;
+
+    if (index >= ecs_vec_count(&world->component_ids)) {
+        return 0;
+    }
+
+    return ecs_vec_get_t(
+        &world->component_ids, ecs_entity_t, index)[0];
+}
+
+ecs_entity_t flecs_component_ids_get_alive(
+    const ecs_world_t *stage_world, 
+    int32_t index)
+{
+    ecs_world_t *world =
+        ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage_world));
+    flecs_poly_assert(world, ecs_world_t);
+
+    if (index >= ecs_vec_count(&world->component_ids)) {
+        return 0;
+    }
+
+    ecs_entity_t result = ecs_vec_get_t(
+        &world->component_ids, ecs_entity_t, index)[0];
+    if (!flecs_entities_is_alive(world, result)) {
+        return 0;
+    }
+
+    return result;
+}
+
+void flecs_component_ids_set(
+    ecs_world_t *stage_world, 
+    int32_t index,
+    ecs_entity_t component)
+{
+    ecs_world_t *world =
+        ECS_CONST_CAST(ecs_world_t*, ecs_get_world(stage_world));
+    flecs_poly_assert(world, ecs_world_t);
+
+    ecs_vec_set_min_count_zeromem_t(
+        &world->allocator, &world->component_ids, ecs_entity_t, index + 1);
+    ecs_vec_get_t(&world->component_ids, ecs_entity_t, index)[0] = component;
 }
 
 /**
@@ -20208,6 +20916,7 @@ ecs_entity_t flecs_alert_out_of_range_kind(
     case EcsString:
     case EcsEntity:
     case EcsId:
+    default:
         return 0;
     }
 
@@ -20839,12 +21548,16 @@ static ecs_app_desc_t ecs_app_desc;
 #ifdef ECS_TARGET_EM
 #include <emscripten.h>
 
-ecs_http_server_t *flecs_wasm_rest_server;
+ecs_http_server_t *flecs_wasm_rest_server = NULL;
 
 EMSCRIPTEN_KEEPALIVE
-char* flecs_explorer_request(const char *method, char *request) {
+char* flecs_explorer_request(const char *method, char *request, char *body) {
+    ecs_assert(flecs_wasm_rest_server != NULL, ECS_INVALID_OPERATION,
+        "wasm REST server is not initialized yet");
+
     ecs_http_reply_t reply = ECS_HTTP_REPLY_INIT;
-    ecs_http_server_request(flecs_wasm_rest_server, method, request, &reply);
+    ecs_http_server_request(
+        flecs_wasm_rest_server, method, request, body, &reply);
     if (reply.code == 200) {
         return ecs_strbuf_get(&reply.body);
     } else {
@@ -20865,7 +21578,6 @@ int ecs_app_run(
 {
     ecs_app_desc = *desc;
 
-    /* Don't set FPS & threads if using emscripten */
 #ifndef ECS_TARGET_EM
     if (ECS_NEQZERO(ecs_app_desc.target_fps)) {
         ecs_set_target_fps(world, ecs_app_desc.target_fps);
@@ -20880,6 +21592,8 @@ int ecs_app_run(
 #ifdef FLECS_REST
 #ifdef ECS_TARGET_EM
         flecs_wasm_rest_server = ecs_rest_server_init(world, NULL);
+        ecs_assert(flecs_wasm_rest_server != NULL, ECS_INTERNAL_ERROR, 
+            "failed to create wasm REST server (unexpected error)");
 #else
         ECS_IMPORT(world, FlecsRest);
         ecs_set(world, EcsWorld, EcsRest, {.port = desc->port });
@@ -21155,8 +21869,6 @@ void flecs_doc_import_core_definitions(
     ecs_doc_set_brief(world, EcsOnRemove, "Event emitted when component is removed");
     ecs_doc_set_brief(world, EcsOnSet, "Event emitted when component is set");
     ecs_doc_set_brief(world, EcsMonitor, "Marker used to create monitor observers");
-    ecs_doc_set_brief(world, EcsOnTableFill, "Event emitted when table becomes non-empty");
-    ecs_doc_set_brief(world, EcsOnTableEmpty, "Event emitted when table becomes empty");
     ecs_doc_set_brief(world, EcsOnTableCreate, "Event emitted when table is created");
     ecs_doc_set_brief(world, EcsOnTableDelete, "Event emitted when table is deleted");
 
@@ -21426,94 +22138,31 @@ const char* ecs_cpp_trim_module(
     return type_name;
 }
 
-// Validate registered component
-void ecs_cpp_component_validate(
+ecs_entity_t ecs_cpp_component_find(
     ecs_world_t *world,
     ecs_entity_t id,
     const char *name,
     const char *symbol,
     size_t size,
     size_t alignment,
-    bool implicit_name)
-{
-    /* If entity has a name check if it matches */
-    if (ecs_is_valid(world, id) && ecs_get_name(world, id) != NULL) {
-        if (!implicit_name && id >= EcsFirstUserComponentId) {
-#ifndef FLECS_NDEBUG
-            char *path = ecs_get_path_w_sep(
-                world, 0, id, "::", NULL);
-            if (ecs_os_strcmp(path, name)) {
-                ecs_abort(ECS_INCONSISTENT_NAME,
-                    "component '%s' already registered with name '%s'",
-                    name, path);
-            }
-            ecs_os_free(path);
-#endif
-        }
-
-        if (symbol) {
-            const char *existing_symbol = ecs_get_symbol(world, id);
-            if (existing_symbol) {
-                if (ecs_os_strcmp(symbol, existing_symbol)) {
-                    ecs_abort(ECS_INCONSISTENT_NAME,
-                        "component '%s' with symbol '%s' already registered with symbol '%s'",
-                        name, symbol, existing_symbol);
-                }
-            }
-        }
-    } else {
-        /* Ensure that the entity id valid */
-        if (!ecs_is_alive(world, id)) {
-            ecs_make_alive(world, id);
-        }
-
-        /* Register name with entity, so that when the entity is created the
-        * correct id will be resolved from the name. Only do this when the
-        * entity is empty. */
-        ecs_add_path_w_sep(world, id, 0, name, "::", "::");
-    }
-
-    /* If a component was already registered with this id but with a 
-     * different size, the ecs_component_init function will fail. */
-
-    /* We need to explicitly call ecs_component_init here again. Even though
-     * the component was already registered, it may have been registered
-     * with a different world. This ensures that the component is registered
-     * with the same id for the current world. 
-     * If the component was registered already, nothing will change. */
-    ecs_entity_t ent = ecs_component_init(world, &(ecs_component_desc_t){
-        .entity = id,
-        .type.size = flecs_uto(int32_t, size),
-        .type.alignment = flecs_uto(int32_t, alignment)
-    });
-    (void)ent;
-    ecs_assert(ent == id, ECS_INTERNAL_ERROR, NULL);
-}
-
-ecs_entity_t ecs_cpp_component_register(
-    ecs_world_t *world,
-    ecs_entity_t id,
-    const char *name,
-    const char *symbol,
-    ecs_size_t size,
-    ecs_size_t alignment,
     bool implicit_name,
     bool *existing_out)
 {
     (void)size;
     (void)alignment;
 
+    ecs_assert(existing_out != NULL, ECS_INTERNAL_ERROR, NULL);
+
     /* If the component is not yet registered, ensure no other component
      * or entity has been registered with this name. Ensure component is 
      * looked up from root. */
-    bool existing = false;
     ecs_entity_t prev_scope = ecs_set_scope(world, 0);
     ecs_entity_t ent;
     if (id) {
         ent = id;
     } else {
         ent = ecs_lookup_path_w_sep(world, 0, name, "::", "::", false);
-        existing = ent != 0 && ecs_has(world, ent, EcsComponent);
+        *existing_out = ent != 0 && ecs_has(world, ent, EcsComponent);
     }
     ecs_set_scope(world, prev_scope);
 
@@ -21541,16 +22190,23 @@ ecs_entity_t ecs_cpp_component_register(
                  * to alias the type, vs. accidentally registering an unrelated
                  * type with the same size/alignment. */
                 char *type_path = ecs_get_path(world, ent);
-                if (ecs_os_strcmp(type_path, symbol) || 
-                    component->size != size || 
-                    component->alignment != alignment) 
-                {
+                if (ecs_os_strcmp(type_path, symbol)) {
                     ecs_err(
                         "component with name '%s' is already registered for"\
                         " type '%s' (trying to register for type '%s')",
                             name, sym, symbol);
                     ecs_abort(ECS_NAME_IN_USE, NULL);
                 }
+
+                if (flecs_itosize(component->size) != size || 
+                    flecs_itosize(component->alignment) != alignment)
+                {
+                    ecs_err(
+                        "component with name '%s' is already registered with"\
+                        " mismatching size/alignment)", name);
+                    ecs_abort(ECS_INVALID_COMPONENT_SIZE, NULL);
+                }
+
                 ecs_os_free(type_path);
             } else if (!sym) {
                 ecs_set_symbol(world, ent, symbol);
@@ -21561,17 +22217,14 @@ ecs_entity_t ecs_cpp_component_register(
      * registered under a different name. */
     } else if (!implicit_name) {
         ent = ecs_lookup_symbol(world, symbol, false, false);
-        ecs_assert(ent == 0 || (ent == id), ECS_INCONSISTENT_COMPONENT_ID, symbol);
-    }
-
-    if (existing_out) {
-        *existing_out = existing;
+        ecs_assert(ent == 0 || (ent == id), 
+            ECS_INCONSISTENT_COMPONENT_ID, symbol);
     }
 
     return ent;
 }
 
-ecs_entity_t ecs_cpp_component_register_explicit(
+ecs_entity_t ecs_cpp_component_register(
     ecs_world_t *world,
     ecs_entity_t s_id,
     ecs_entity_t id,
@@ -21584,7 +22237,8 @@ ecs_entity_t ecs_cpp_component_register_explicit(
     bool *existing_out)
 {
     char *existing_name = NULL;
-    if (existing_out) *existing_out = false;
+
+    ecs_assert(existing_out != NULL, ECS_INTERNAL_ERROR, NULL);
 
     // If an explicit id is provided, it is possible that the symbol and
     // name differ from the actual type, as the application may alias
@@ -21597,7 +22251,7 @@ ecs_entity_t ecs_cpp_component_register_explicit(
             if (id) {
                 existing_name = ecs_get_path_w_sep(world, 0, id, "::", "::");
                 name = existing_name;
-                if (existing_out) *existing_out = true;
+                *existing_out = true;
             } else {
                 // If type is not yet known, derive from type name
                 name = ecs_cpp_trim_module(world, type_name);
@@ -21651,14 +22305,16 @@ ecs_entity_t ecs_cpp_component_register_explicit(
 
 void ecs_cpp_enum_init(
     ecs_world_t *world,
-    ecs_entity_t id)
+    ecs_entity_t id,
+    ecs_entity_t underlying_type)
 {
     (void)world;
     (void)id;
+    (void)underlying_type;
 #ifdef FLECS_META
     ecs_suspend_readonly_state_t readonly_state;
     world = flecs_suspend_readonly(world, &readonly_state);
-    ecs_set(world, id, EcsEnum, {0});
+    ecs_set(world, id, EcsEnum, { .underlying_type = underlying_type });
     flecs_resume_readonly(world, &readonly_state);
 #endif
 }
@@ -21668,8 +22324,11 @@ ecs_entity_t ecs_cpp_enum_constant_register(
     ecs_entity_t parent,
     ecs_entity_t id,
     const char *name,
-    int value)
+    void *value,
+    ecs_entity_t value_type,
+    size_t value_size)
 {
+#ifdef FLECS_META
     ecs_suspend_readonly_state_t readonly_state;
     world = flecs_suspend_readonly(world, &readonly_state);
 
@@ -21690,34 +22349,38 @@ ecs_entity_t ecs_cpp_enum_constant_register(
     ecs_assert(id != 0, ECS_INVALID_OPERATION, name);
     ecs_set_scope(world, prev);
 
-    #ifdef FLECS_DEBUG
+#ifdef FLECS_DEBUG
     const EcsComponent *cptr = ecs_get(world, parent, EcsComponent);
     ecs_assert(cptr != NULL, ECS_INVALID_PARAMETER, "enum is not a component");
-    ecs_assert(cptr->size == ECS_SIZEOF(int32_t), ECS_UNSUPPORTED,
-        "enum component must have 32bit size");
-    #endif
-
-#ifdef FLECS_META
-    ecs_set_id(world, id, ecs_pair(EcsConstant, ecs_id(ecs_i32_t)), 
-        sizeof(ecs_i32_t), &value);
 #endif
+
+    ecs_set_id(world, id, ecs_pair(EcsConstant, value_type), value_size, value);
 
     flecs_resume_readonly(world, &readonly_state);
 
-    ecs_trace("#[green]constant#[reset] %s.%s created with value %d", 
-        ecs_get_name(world, parent), name, value);
+    if (ecs_should_log(0)) {
+        ecs_value_t v = { .type = value_type, .ptr = value };
+        char *str = NULL;
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, 
+            ecs_id(ecs_string_t), &str);
+        ecs_meta_set_value(&cur, &v);
+        ecs_trace("#[green]constant#[reset] %s.%s created with value %s", 
+            ecs_get_name(world, parent), name, str);
+        ecs_os_free(str);
+    }
 
     return id;
-}
-
-static int32_t flecs_reset_count = 0;
-
-int32_t ecs_cpp_reset_count_get(void) {
-    return flecs_reset_count;
-}
-
-int32_t ecs_cpp_reset_count_inc(void) {
-    return ++flecs_reset_count;
+#else
+    (void)world;
+    (void)parent;
+    (void)id;
+    (void)name;
+    (void)value;
+    (void)value_type;
+    (void)value_size;
+    ecs_err("enum reflection not supported without FLECS_META addon");
+    return 0;
+#endif
 }
 
 #ifdef FLECS_META
@@ -21836,7 +22499,7 @@ typedef int ecs_http_socket_t;
 #define ECS_HTTP_MIN_STATS_INTERVAL (10 * 1000)
 
 /* Receive buffer size */
-#define ECS_HTTP_SEND_RECV_BUFFER_SIZE (16 * 1024)
+#define ECS_HTTP_SEND_RECV_BUFFER_SIZE (64 * 1024)
 
 /* Max length of request (path + query + headers + body) */
 #define ECS_HTTP_REQUEST_LEN_MAX (10 * 1024 * 1024)
@@ -22556,7 +23219,7 @@ bool http_parse_request(
                 frag->state = HttpFragStateCRLF;
             } else {
                 frag->state = HttpFragStateHeaderStart;
-            }
+            } 
             break;
         case HttpFragStateCRLF:
             if (c == '\r') {
@@ -22799,13 +23462,15 @@ void http_recv_connection(
     ecs_http_socket_t sock)
 {
     ecs_size_t bytes_read;
-    char recv_buf[ECS_HTTP_SEND_RECV_BUFFER_SIZE];
+    char *recv_buf = ecs_os_malloc(ECS_HTTP_SEND_RECV_BUFFER_SIZE);
     ecs_http_fragment_t frag = {0};
     int32_t retries = 0;
 
+    ecs_os_sleep(0, 10 * 1000 * 1000);
+
     do {
         if ((bytes_read = http_recv(
-            sock, recv_buf, ECS_SIZEOF(recv_buf), 0)) > 0) 
+            sock, recv_buf, ECS_HTTP_SEND_RECV_BUFFER_SIZE, 0)) > 0) 
         {
             bool is_alive = conn->pub.id == conn_id;
             if (!is_alive) {
@@ -22850,11 +23515,17 @@ void http_recv_connection(
         ecs_os_sleep(0, 10 * 1000 * 1000);
     } while ((bytes_read == -1) && (++retries < ECS_HTTP_REQUEST_RECV_RETRY));
 
+    if (bytes_read == ECS_HTTP_SEND_RECV_BUFFER_SIZE) {
+        ecs_warn("request exceeded receive buffer size (%d)",
+            ECS_HTTP_SEND_RECV_BUFFER_SIZE);
+    }
+
     if (retries == ECS_HTTP_REQUEST_RECV_RETRY) {
         http_close(&sock);
     }
 
 done:
+    ecs_os_free(recv_buf);
     ecs_strbuf_reset(&frag.buf);
 }
 
@@ -23081,7 +23752,6 @@ void http_do_request(
     if (srv->callback(ECS_CONST_CAST(ecs_http_request_t*, req), reply, 
         srv->ctx) == false) 
     {
-        reply->code = 404;
         reply->status = "Resource not found";
         ecs_os_linc(&ecs_http_request_not_handled_count);
     } else {
@@ -23228,11 +23898,10 @@ const char* ecs_http_get_param(
 ecs_http_server_t* ecs_http_server_init(
     const ecs_http_server_desc_t *desc) 
 {
-    ecs_check(ecs_os_has_threading(), ECS_UNSUPPORTED, 
-        "missing OS API implementation");
-
     ecs_http_server_t* srv = ecs_os_calloc_t(ecs_http_server_t);
-    srv->lock = ecs_os_mutex_new();
+    if (ecs_os_has_threading()) {
+        srv->lock = ecs_os_mutex_new();
+    }
     srv->sock = HTTP_SOCKET_INVALID;
 
     srv->should_run = false;
@@ -23275,8 +23944,6 @@ ecs_http_server_t* ecs_http_server_init(
 #endif
 
     return srv;
-error:
-    return NULL;
 }
 
 void ecs_http_server_fini(
@@ -23285,7 +23952,9 @@ void ecs_http_server_fini(
     if (srv->should_run) {
         ecs_http_server_stop(srv);
     }
-    ecs_os_mutex_free(srv->lock);
+    if (ecs_os_has_threading()) {
+        ecs_os_mutex_free(srv->lock);
+    }
     http_purge_request_cache(srv, true);
     flecs_sparse_fini(&srv->requests);
     flecs_sparse_fini(&srv->connections);
@@ -23299,6 +23968,8 @@ int ecs_http_server_start(
     ecs_check(srv->initialized, ECS_INVALID_PARAMETER, NULL);
     ecs_check(!srv->should_run, ECS_INVALID_PARAMETER, NULL);
     ecs_check(!srv->thread, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(ecs_os_has_threading(), ECS_UNSUPPORTED,
+        "missing OS API implementation");
 
     srv->should_run = true;
 
@@ -23327,6 +23998,8 @@ void ecs_http_server_stop(
         "cannot stop HTTP server: not initialized");
     ecs_check(srv->should_run, ECS_INVALID_PARAMETER, 
         "cannot stop HTTP server: already stopped/stopping");
+    ecs_check(ecs_os_has_threading(), ECS_UNSUPPORTED,
+        "missing OS API implementation");
 
     /* Stop server thread */
     ecs_dbg("http: shutting down server thread");
@@ -23458,25 +24131,52 @@ int ecs_http_server_request(
     ecs_http_server_t* srv,
     const char *method,
     const char *req,
+    const char *body,
     ecs_http_reply_t *reply_out)
 {
-    const char *http_ver = " HTTP/1.1\r\n\r\n";
+    ecs_check(srv != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(method != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(req != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(reply_out != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    const char *http_ver = " HTTP/1.1\r\n";
     int32_t method_len = ecs_os_strlen(method);
     int32_t req_len = ecs_os_strlen(req);
+    int32_t body_len = body ? ecs_os_strlen(body) : 0;
     int32_t http_ver_len = ecs_os_strlen(http_ver);
     char reqbuf[1024], *reqstr = reqbuf;
+    char content_length[32] = {0};
 
-    int32_t len = method_len + req_len + http_ver_len + 1;
-    if (method_len + req_len + http_ver_len >= 1024) {
-        reqstr = ecs_os_malloc(len + 1);
+    if (body_len) {
+        ecs_os_snprintf(content_length, 32, 
+            "Content-Length: %d\r\n\r\n", body_len);
     }
+
+    int32_t content_length_len = ecs_os_strlen(content_length);
+
+    int32_t len = method_len + req_len + content_length_len + body_len + 
+        http_ver_len;
+    if (len >= 1024) {
+        reqstr = ecs_os_malloc(len);
+    }
+
+    len += 3;
 
     char *ptr = reqstr;
     ecs_os_memcpy(ptr, method, method_len); ptr += method_len;
     ptr[0] = ' '; ptr ++;
     ecs_os_memcpy(ptr, req, req_len); ptr += req_len;
     ecs_os_memcpy(ptr, http_ver, http_ver_len); ptr += http_ver_len;
-    ptr[0] = '\n';
+
+    if (body) {
+        ecs_os_memcpy(ptr, content_length, content_length_len);
+        ptr += content_length_len;
+        ecs_os_memcpy(ptr, body, body_len);
+        ptr += body_len;
+    }
+
+    ptr[0] = '\r';
+    ptr[1] = '\n';
 
     int result = ecs_http_server_http_request(srv, reqstr, len, reply_out);
     if (reqbuf != reqstr) {
@@ -23484,6 +24184,8 @@ int ecs_http_server_request(
     }
 
     return result;
+error:
+    return -1;
 }
 
 void* ecs_http_server_ctx(
@@ -23613,9 +24315,6 @@ void flecs_journal_begin(
     } else if (kind == EcsJournalRemoveAll) {
         ecs_print(4, "#[cyan]ecs_remove_all#[reset](world, %s); "
             "#[grey] // remove_all(%s)", var_id, path);
-    } else if (kind == EcsJournalTableEvents) {
-        ecs_print(4, "#[cyan]ecs_run_aperiodic#[reset](world, "
-            "EcsAperiodicEmptyTables);");
     }
     ecs_os_free(var_id);
     ecs_os_free(path);
@@ -23857,12 +24556,14 @@ void ecs_log_pop_(
     }
 }
 
-void ecs_parser_errorv_(
+static
+void flecs_parser_errorv(
     const char *name,
     const char *expr, 
     int64_t column_arg,
     const char *fmt,
-    va_list args)
+    va_list args,
+    bool is_warning)
 {
     if (column_arg > 65536) {
         /* Limit column size, which prevents the code from throwing up when the
@@ -23938,9 +24639,33 @@ void ecs_parser_errorv_(
         }
 
         char *msg = ecs_strbuf_get(&msg_buf);
-        ecs_os_err(name, 0, msg);
+        if (is_warning) {
+            ecs_os_warn(name, 0, msg);
+        } else {
+            ecs_os_err(name, 0, msg);
+        }
         ecs_os_free(msg);
     }
+}
+
+void ecs_parser_errorv_(
+    const char *name,
+    const char *expr, 
+    int64_t column_arg,
+    const char *fmt,
+    va_list args)
+{
+    flecs_parser_errorv(name, expr, column_arg, fmt, args, false);
+}
+
+void ecs_parser_warningv_(
+    const char *name,
+    const char *expr, 
+    int64_t column_arg,
+    const char *fmt,
+    va_list args)
+{
+    flecs_parser_errorv(name, expr, column_arg, fmt, args, true);
 }
 
 void ecs_parser_error_(
@@ -23954,6 +24679,21 @@ void ecs_parser_error_(
         va_list args;
         va_start(args, fmt);
         ecs_parser_errorv_(name, expr, column, fmt, args);
+        va_end(args);
+    }
+}
+
+void ecs_parser_warning_(
+    const char *name,
+    const char *expr, 
+    int64_t column,
+    const char *fmt,
+    ...)
+{
+    if (ecs_os_api.log_level_  >= -2) {
+        va_list args;
+        va_start(args, fmt);
+        ecs_parser_warningv_(name, expr, column, fmt, args);
         va_end(args);
     }
 }
@@ -24105,6 +24845,34 @@ void ecs_parser_error_(
 }
 
 void ecs_parser_errorv_(
+    const char *name,
+    const char *expr, 
+    int64_t column,
+    const char *fmt,
+    va_list args)
+{
+    (void)name;
+    (void)expr;
+    (void)column;
+    (void)fmt;
+    (void)args;
+}
+
+
+void ecs_parser_warning_(
+    const char *name,
+    const char *expr, 
+    int64_t column,
+    const char *fmt,
+    ...)
+{
+    (void)name;
+    (void)expr;
+    (void)column;
+    (void)fmt;
+}
+
+void ecs_parser_warningv_(
     const char *name,
     const char *expr, 
     int64_t column,
@@ -24842,7 +25610,7 @@ int flecs_oneof_metric_init(
 
             ecs_entity_t mbr = ecs_entity(world, {
                 .name = to_snake_case,
-                .parent = ecs_childof(metric)
+                .parent = metric
             });
 
             ecs_os_free(to_snake_case);
@@ -25183,6 +25951,7 @@ ecs_entity_t ecs_import(
     ecs_module_action_t module,
     const char *module_name)
 {
+    flecs_poly_assert(world, ecs_world_t);
     ecs_check(!(world->flags & EcsWorldReadonly), 
         ECS_INVALID_WHILE_READONLY, NULL);
 
@@ -25531,6 +26300,16 @@ static ECS_DTOR(EcsRest, ptr, {
 
 static char *rest_last_err;
 static ecs_os_api_log_t rest_prev_log;
+static ecs_os_api_log_t rest_prev_fatal_log;
+
+static
+void flecs_set_prev_log(
+    ecs_os_api_log_t prev_log,
+    bool try)
+{
+    rest_prev_log = try ? NULL : prev_log;
+    rest_prev_fatal_log = prev_log;
+}
 
 static 
 void flecs_rest_capture_log(
@@ -25541,7 +26320,20 @@ void flecs_rest_capture_log(
 {
     (void)file; (void)line;
 
+    if (level <= -4) {
+        /* Make sure to always log fatal errors */
+        if (rest_prev_fatal_log) {
+            ecs_log_enable_colors(true);
+            rest_prev_fatal_log(level, file, line, msg);
+            ecs_log_enable_colors(false);
+            return;
+        } else {
+            fprintf(stderr, "%s:%d: %s", file, line, msg);
+        }
+    }
+
 #ifdef FLECS_DEBUG
+    /* In debug mode, log unexpected errors to the console */
     if (level < 0) {
         /* Also log to previous log function in debug mode */
         if (rest_prev_log) {
@@ -25552,7 +26344,7 @@ void flecs_rest_capture_log(
     }
 #endif
 
-    if (!rest_last_err && level < 0) {
+    if (!rest_last_err && level <= -3) {
         rest_last_err = ecs_os_strdup(msg);
     }
 }
@@ -25974,16 +26766,23 @@ bool flecs_rest_script(
 
     const char *code = ecs_http_get_param(req, "code");
     if (!code) {
-        flecs_reply_error(reply, "missing data parameter");
-        return true;
+        code = req->body;
     }
-
+    
     bool try = false;
     flecs_rest_bool_param(req, "try", &try);
 
+    if (!code) {
+        flecs_reply_error(reply, "missing code parameter");
+        if (!try) {
+            reply->code = 400;
+        }
+        return true;
+    }
+
     bool prev_color = ecs_log_enable_colors(false);
     ecs_os_api_log_t prev_log = ecs_os_api.log_;
-    rest_prev_log = try ? NULL : prev_log;
+    flecs_set_prev_log(ecs_os_api.log_, try);
     ecs_os_api.log_ = flecs_rest_capture_log;
 
     script = ecs_script(world, {
@@ -25995,7 +26794,7 @@ bool flecs_rest_script(
         char *err = flecs_rest_get_captured_log();
         char *escaped_err = flecs_astresc('"', err);
         if (escaped_err) {
-            flecs_reply_error(reply, escaped_err);
+            flecs_reply_error(reply, "%s", escaped_err);
         } else {
             flecs_reply_error(reply, "error parsing script");
         }
@@ -26022,7 +26821,7 @@ void flecs_rest_reply_set_captured_log(
     char *err = flecs_rest_get_captured_log();
     if (err) {
         char *escaped_err = flecs_astresc('"', err);
-        flecs_reply_error(reply, escaped_err);
+        flecs_reply_error(reply, "%s", escaped_err);
         ecs_os_free(escaped_err);
         ecs_os_free(err);
     }
@@ -26074,6 +26873,9 @@ bool flecs_rest_reply_existing_query(
         return true;
     }
 
+    bool try = false;
+    flecs_rest_bool_param(req, "try", &try);
+
     ecs_query_t *q = NULL;
     const EcsPoly *poly_comp = ecs_get_pair(world, qe, EcsPoly, EcsQuery);
     if (!poly_comp) {
@@ -26100,7 +26902,7 @@ bool flecs_rest_reply_existing_query(
 
     ecs_dbg_2("rest: request query '%s'", name);
     bool prev_color = ecs_log_enable_colors(false);
-    rest_prev_log = ecs_os_api.log_;
+    flecs_set_prev_log(ecs_os_api.log_, try);
     ecs_os_api.log_ = flecs_rest_capture_log;
 
     const char *vars = ecs_http_get_param(req, "vars");
@@ -26150,7 +26952,7 @@ bool flecs_rest_get_query(
     ecs_dbg_2("rest: request query '%s'", expr);
     bool prev_color = ecs_log_enable_colors(false);
     ecs_os_api_log_t prev_log = ecs_os_api.log_;
-    rest_prev_log = try ? NULL : prev_log;
+    flecs_set_prev_log(ecs_os_api.log_, try);
     ecs_os_api.log_ = flecs_rest_capture_log;
 
     ecs_query_t *q = ecs_query(world, { .expr = expr });
@@ -28835,6 +29637,10 @@ void flecs_ballocator_init(
     ba->data_size = size;
 #ifdef FLECS_SANITIZE
     ba->alloc_count = 0;
+    if (size != 24) { /* Prevent stack overflow as map uses block allocator */
+        ba->outstanding = ecs_os_malloc_t(ecs_map_t);
+        ecs_map_init(ba->outstanding, NULL);
+    }
     size += ECS_SIZEOF(int64_t);
 #endif
     ba->chunk_size = ECS_ALIGN(size, 16);
@@ -28859,8 +29665,27 @@ void flecs_ballocator_fini(
     ecs_assert(ba != NULL, ECS_INTERNAL_ERROR, NULL);
 
 #ifdef FLECS_SANITIZE
-    ecs_assert(ba->alloc_count == 0, ECS_LEAK_DETECTED, 
-        "(size = %u)", (uint32_t)ba->data_size);
+    if (ba->alloc_count != 0) {
+        ecs_err("Leak detected! (size %u, remaining = %d)",
+            (uint32_t)ba->data_size, ba->alloc_count);
+        if (ba->outstanding) {
+            ecs_map_iter_t it = ecs_map_iter(ba->outstanding);
+            while (ecs_map_next(&it)) {
+                uint64_t key = ecs_map_key(&it);
+                char *type_name = ecs_map_ptr(&it);
+                if (type_name) {
+                    printf(" - %p (%s)\n", (void*)key, type_name);
+                } else {
+                    printf(" - %p (unknown type)\n", (void*)key);
+                }
+            }
+        }
+        ecs_abort(ECS_LEAK_DETECTED, NULL);
+    }
+    if (ba->outstanding) {
+        ecs_map_fini(ba->outstanding);
+        ecs_os_free(ba->outstanding);
+    }
 #endif
 
     ecs_block_allocator_block_t *block;
@@ -28882,8 +29707,16 @@ void flecs_ballocator_free(
 }
 
 void* flecs_balloc(
-    ecs_block_allocator_t *ba) 
+    ecs_block_allocator_t *ba)
 {
+    return flecs_balloc_w_dbg_info(ba, NULL);
+}
+
+void* flecs_balloc_w_dbg_info(
+    ecs_block_allocator_t *ba,
+    const char *type_name)
+{
+    (void)type_name;
     void *result;
 #ifdef FLECS_USE_OS_ALLOC
     result = ecs_os_malloc(ba->data_size);
@@ -28901,8 +29734,12 @@ void* flecs_balloc(
 
 #ifdef FLECS_SANITIZE
     ecs_assert(ba->alloc_count >= 0, ECS_INTERNAL_ERROR, "corrupted allocator");
+    if (ba->outstanding) {
+        uint64_t *v = ecs_map_ensure(ba->outstanding, (uintptr_t)result);
+        *(const char**)v = type_name;
+    }
     ba->alloc_count ++;
-    *(int64_t*)result = ba->chunk_size;
+    *(int64_t*)result = (uintptr_t)ba;
     result = ECS_OFFSET(result, ECS_SIZEOF(int64_t));
 #endif
 #endif
@@ -28917,12 +29754,21 @@ void* flecs_balloc(
 void* flecs_bcalloc(
     ecs_block_allocator_t *ba) 
 {
+    return flecs_bcalloc_w_dbg_info(ba, NULL);
+}
+
+void* flecs_bcalloc_w_dbg_info(
+    ecs_block_allocator_t *ba,
+    const char *type_name)
+{
+    (void)type_name;
+
 #ifdef FLECS_USE_OS_ALLOC
     ecs_assert(ba != NULL, ECS_INTERNAL_ERROR, NULL);
     return ecs_os_calloc(ba->data_size);
 #else
     if (!ba) return NULL;
-    void *result = flecs_balloc(ba);
+    void *result = flecs_balloc_w_dbg_info(ba, type_name);
     ecs_os_memset(result, 0, ba->data_size);
     return result;
 #endif
@@ -28958,27 +29804,32 @@ void flecs_bfree_w_dbg_info(
 
 #ifdef FLECS_SANITIZE
     memory = ECS_OFFSET(memory, -ECS_SIZEOF(int64_t));
-    if (*(int64_t*)memory != ba->chunk_size) {
+    ecs_block_allocator_t *actual = *(ecs_block_allocator_t**)memory;
+    if (actual != ba) {
         if (type_name) {
             ecs_err("chunk %p returned to wrong allocator "
                 "(chunk = %ub, allocator = %ub, type = %s)",
-                    memory, *(int64_t*)memory, ba->chunk_size, type_name);
+                    memory, actual->data_size, ba->data_size, type_name);
         } else {
             ecs_err("chunk %p returned to wrong allocator "
                 "(chunk = %ub, allocator = %ub)",
-                    memory, *(int64_t*)memory, ba->chunk_size);
+                    memory, actual->data_size, ba->chunk_size);
         }
         ecs_abort(ECS_INTERNAL_ERROR, NULL);
     }
 
+    if (ba->outstanding) {
+        ecs_map_remove(ba->outstanding, (uintptr_t)memory);
+    }
+
     ba->alloc_count --;
+    ecs_assert(ba->alloc_count >= 0, ECS_INTERNAL_ERROR, 
+        "corrupted allocator (size = %d)", ba->chunk_size);
 #endif
 
     ecs_block_allocator_chunk_header_t *chunk = memory;
     chunk->next = ba->head;
     ba->head = chunk;
-    ecs_assert(ba->alloc_count >= 0, ECS_INTERNAL_ERROR, 
-        "corrupted allocator (size = %d)", ba->chunk_size);
 #endif
 }
 
@@ -28987,6 +29838,17 @@ void* flecs_brealloc(
     ecs_block_allocator_t *src, 
     void *memory)
 {
+    return flecs_brealloc_w_dbg_info(dst, src, memory, NULL);
+}
+
+void* flecs_brealloc_w_dbg_info(
+    ecs_block_allocator_t *dst, 
+    ecs_block_allocator_t *src, 
+    void *memory,
+    const char *type_name)
+{
+    (void)type_name;
+
     void *result;
 #ifdef FLECS_USE_OS_ALLOC
     (void)src;
@@ -28996,7 +29858,7 @@ void* flecs_brealloc(
         return memory;
     }
 
-    result = flecs_balloc(dst);
+    result = flecs_balloc_w_dbg_info(dst, type_name);
     if (result && src) {
         ecs_size_t size = src->data_size;
         if (dst->data_size < size) {
@@ -29004,7 +29866,7 @@ void* flecs_brealloc(
         }
         ecs_os_memcpy(result, memory, size);
     }
-    flecs_bfree(src, memory);
+    flecs_bfree_w_dbg_info(src, memory, type_name);
 #endif
 #ifdef FLECS_MEMSET_UNINITIALIZED
     if (dst && src && (dst->data_size > src->data_size)) {
@@ -29245,7 +30107,7 @@ void flecs_hashmap_fini(
         ecs_hm_bucket_t *bucket = ecs_map_ptr(&it);
         ecs_vec_fini(a, &bucket->keys, map->key_size);
         ecs_vec_fini(a, &bucket->values, map->value_size);
-#ifdef FLECS_SANITIZE        
+#if defined(FLECS_SANITIZE) || defined(FLECS_USE_OS_ALLOC)
         flecs_bfree(&map->bucket_allocator, bucket);
 #endif
     }
@@ -29700,7 +30562,7 @@ void ecs_map_fini(
     }
 
     bool sanitize = false;
-#ifdef FLECS_SANITIZE
+#if defined(FLECS_SANITIZE) || defined(FLECS_USE_OS_ALLOC)
     sanitize = true;
 #endif
 
@@ -30899,6 +31761,7 @@ ecs_stack_page_t* flecs_stack_page_new(uint32_t page_id) {
     result->data = ECS_OFFSET(result, FLECS_STACK_PAGE_OFFSET);
     result->next = NULL;
     result->id = page_id + 1;
+    result->sp = 0;
     ecs_os_linc(&ecs_stack_allocator_alloc_count);
     return result;
 }
@@ -30911,10 +31774,7 @@ void* flecs_stack_alloc(
     ecs_assert(size > 0, ECS_INTERNAL_ERROR, NULL);
 
     ecs_stack_page_t *page = stack->tail_page;
-    if (page == &stack->first && !page->data) {
-        page->data = ecs_os_malloc(ECS_STACK_PAGE_SIZE);
-        ecs_os_linc(&ecs_stack_allocator_alloc_count);
-    }
+    ecs_assert(page->data != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int16_t sp = flecs_ito(int16_t, ECS_ALIGN(page->sp, align));
     int16_t next_sp = flecs_ito(int16_t, sp + size);
@@ -30940,6 +31800,7 @@ void* flecs_stack_alloc(
     result = ECS_OFFSET(page->data, sp);
 
 done:
+    ecs_assert(result != NULL, ECS_INTERNAL_ERROR, NULL);
 #ifdef FLECS_SANITIZE
     ecs_os_memset(result, 0xAA, size);
 #endif
@@ -31033,7 +31894,7 @@ void flecs_stack_restore_cursor(
     /* If the cursor count is zero, stack should be empty
      * if the cursor count is non-zero, stack should not be empty */
     ecs_dbg_assert((stack->cursor_count == 0) == 
-        (stack->tail_page == &stack->first && stack->tail_page->sp == 0), 
+        (stack->tail_page == stack->first && stack->tail_page->sp == 0), 
             ECS_LEAK_DETECTED, FLECS_STACK_LEAK_MSG);
 }
 
@@ -31042,8 +31903,8 @@ void flecs_stack_reset(
 {
     ecs_dbg_assert(stack->cursor_count == 0, ECS_LEAK_DETECTED, 
         FLECS_STACK_LEAK_MSG);
-    stack->tail_page = &stack->first;
-    stack->first.sp = 0;
+    stack->tail_page = stack->first;
+    stack->first->sp = 0;
     stack->tail_cursor = NULL;
 }
 
@@ -31051,32 +31912,26 @@ void flecs_stack_init(
     ecs_stack_t *stack)
 {
     ecs_os_zeromem(stack);
-    stack->tail_page = &stack->first;
-    stack->first.data = NULL;
+    stack->first = flecs_stack_page_new(0);
+    stack->first->sp = 0;
+    stack->tail_page = stack->first;
 }
 
 void flecs_stack_fini(
     ecs_stack_t *stack)
 {
-    ecs_stack_page_t *next, *cur = &stack->first;
+    ecs_stack_page_t *next, *cur = stack->first;
     ecs_dbg_assert(stack->cursor_count == 0, ECS_LEAK_DETECTED, 
         FLECS_STACK_LEAK_MSG);
-    ecs_assert(stack->tail_page == &stack->first, ECS_LEAK_DETECTED, 
+    ecs_assert(stack->tail_page == stack->first, ECS_LEAK_DETECTED, 
         FLECS_STACK_LEAK_MSG);
     ecs_assert(stack->tail_page->sp == 0, ECS_LEAK_DETECTED, 
         FLECS_STACK_LEAK_MSG);
 
     do {
         next = cur->next;
-        if (cur == &stack->first) {
-            if (cur->data) {
-                ecs_os_linc(&ecs_stack_allocator_free_count);
-            }
-            ecs_os_free(cur->data);
-        } else {
-            ecs_os_linc(&ecs_stack_allocator_free_count);
-            ecs_os_free(cur);
-        }
+        ecs_os_linc(&ecs_stack_allocator_free_count);
+        ecs_os_free(cur);
     } while ((cur = next));
 }
 
@@ -31887,12 +32742,24 @@ void ecs_vec_init(
     ecs_size_t size,
     int32_t elem_count)
 {
+    ecs_vec_init_w_dbg_info(allocator, v, size, elem_count, NULL);
+}
+
+void ecs_vec_init_w_dbg_info(
+    struct ecs_allocator_t *allocator,
+    ecs_vec_t *v,
+    ecs_size_t size,
+    int32_t elem_count,
+    const char *type_name)
+{
+    (void)type_name;
     ecs_assert(size != 0, ECS_INVALID_PARAMETER, NULL);
     v->array = NULL;
     v->count = 0;
     if (elem_count) {
         if (allocator) {
-            v->array = flecs_alloc(allocator, size * elem_count);
+            v->array = flecs_alloc_w_dbg_info(
+                allocator, size * elem_count, type_name);
         } else {
             v->array = ecs_os_malloc(size * elem_count);
         }
@@ -31900,6 +32767,7 @@ void ecs_vec_init(
     v->size = elem_count;
 #ifdef FLECS_SANITIZE
     v->elem_size = size;
+    v->type_name = type_name;
 #endif
 }
 
@@ -32045,8 +32913,14 @@ void ecs_vec_set_size(
         }
         if (elem_count != v->size) {
             if (allocator) {
+#ifdef FLECS_SANITIZE
+                v->array = flecs_realloc_w_dbg_info(
+                    allocator, size * elem_count, size * v->size, v->array,
+                    v->type_name);
+#else
                 v->array = flecs_realloc(
                     allocator, size * elem_count, size * v->size, v->array);
+#endif
             } else {
                 v->array = ecs_os_realloc(v->array, size * elem_count);
             }
@@ -32474,7 +33348,7 @@ void flecs_query_fini(
 
         ecs_id_record_t *idr = flecs_id_record_get(q->real_world, term->id);
         if (idr) {
-            if (!(q->world->flags & EcsWorldQuit)) {
+            if (!(ecs_world_get_flags(q->world) & EcsWorldQuit)) {
                 if (ecs_os_has_threading()) {
                     int32_t idr_keep_alive = ecs_os_adec(&idr->keep_alive);
                     ecs_assert(idr_keep_alive >= 0, ECS_INTERNAL_ERROR, NULL);
@@ -32677,23 +33551,13 @@ ecs_query_count_t ecs_query_count(
         return result;
     }
 
-    ecs_run_aperiodic(q->world, EcsAperiodicEmptyTables);
+    ecs_iter_t it = flecs_query_iter(q->world, q);
+    it.flags |= EcsIterNoData;
 
-    ecs_query_impl_t *impl = flecs_query_impl(q);
-    if (impl->cache && q->flags & EcsQueryIsCacheable) {
-        result.results = flecs_query_cache_table_count(impl->cache);
-        result.entities = flecs_query_cache_entity_count(impl->cache);
-        result.tables = flecs_query_cache_table_count(impl->cache);
-        result.empty_tables = flecs_query_cache_empty_table_count(impl->cache);
-    } else {
-        ecs_iter_t it = flecs_query_iter(q->world, q);
-        it.flags |= EcsIterNoData;
-
-        while (ecs_query_next(&it)) {
-            result.results ++;
-            result.entities += it.count;
-            ecs_iter_skip(&it);
-        }
+    while (ecs_query_next(&it)) {
+        result.results ++;
+        result.entities += it.count;
+        ecs_iter_skip(&it);
     }
 
     return result;
@@ -32704,15 +33568,8 @@ bool ecs_query_is_true(
 {
     flecs_poly_assert(q, ecs_query_t);
 
-    ecs_run_aperiodic(q->world, EcsAperiodicEmptyTables);
-
-    ecs_query_impl_t *impl = flecs_query_impl(q);
-    if (impl->cache && q->flags & EcsQueryIsCacheable) {
-        return flecs_query_cache_table_count(impl->cache) != 0;
-    } else {
-        ecs_iter_t it = flecs_query_iter(q->world, q);
-        return ecs_iter_is_true(&it);
-    }
+    ecs_iter_t it = flecs_query_iter(q->world, q);
+    return ecs_iter_is_true(&it);
 }
 
 int32_t ecs_query_match_count(
@@ -32736,6 +33593,19 @@ const ecs_query_t* ecs_query_get_cache_query(
         return NULL;
     } else {
         return impl->cache->query;
+    }
+}
+
+const ecs_query_t* ecs_query_get(
+    const ecs_world_t *world,
+    ecs_entity_t query)
+{
+    const EcsPoly *poly_comp = ecs_get_pair(world, query, EcsPoly, EcsQuery);
+    if (!poly_comp) {
+        return NULL;
+    } else {
+        flecs_poly_assert(poly_comp->poly, ecs_query_t);
+        return poly_comp->poly;
     }
 }
 
@@ -33296,7 +34166,11 @@ void flecs_term_to_buf(
         {
             ecs_strbuf_appendlit(buf, "this");
         } else if (term->src.id & EcsIsVariable) {
-            ecs_strbuf_appendstr(buf, term->src.name);
+            if (term->src.name) {
+                ecs_strbuf_appendstr(buf, term->src.name);
+            } else {
+                ecs_strbuf_appendstr(buf, "<<invalid variable name>>");
+            }
         } else {
             /* Shouldn't happen */
         }
@@ -34799,6 +35673,8 @@ int flecs_query_finalize_terms(
             ECS_TERMSET_SET(q->var_fields, 1u << term->field_index);
         }
 
+        bool is_sparse = false;
+
         ecs_id_record_t *idr = flecs_id_record_get(world, term->id);
         if (idr) {
             if (ecs_os_has_threading()) {
@@ -34810,17 +35686,26 @@ int flecs_query_finalize_terms(
             term->flags_ |= EcsTermKeepAlive;
 
             if (idr->flags & EcsIdIsSparse) {
-                term->flags_ |= EcsTermIsSparse;
-                ECS_BIT_CLEAR16(term->flags_, EcsTermIsTrivial);
-                if (term->flags_ & EcsTermIsCacheable) {
-                    cacheable_terms --;
-                    ECS_BIT_CLEAR16(term->flags_, EcsTermIsCacheable);
-                }
+                is_sparse = true;
+            }
+        } else {
+            ecs_entity_t type = ecs_get_typeid(world, term->id);
+            if (type && ecs_has_id(world, type, EcsSparse)) {
+                is_sparse = true;
+            }
+        }
 
-                /* Sparse component fields must be accessed with ecs_field_at */
-                if (!nodata_term) {
-                    q->row_fields |= flecs_uto(uint32_t, 1llu << i);
-                }
+        if (is_sparse) {
+            term->flags_ |= EcsTermIsSparse;
+            ECS_BIT_CLEAR16(term->flags_, EcsTermIsTrivial);
+            if (term->flags_ & EcsTermIsCacheable) {
+                cacheable_terms --;
+                ECS_BIT_CLEAR16(term->flags_, EcsTermIsCacheable);
+            }
+
+            /* Sparse component fields must be accessed with ecs_field_at */
+            if (!nodata_term) {
+                q->row_fields |= flecs_uto(uint32_t, 1llu << i);
             }
         }
 
@@ -34867,6 +35752,7 @@ int flecs_query_finalize_terms(
 
         if (scope_nesting < 0) {
             flecs_query_validator_error(&ctx, "'}' without matching '{'");
+            return -1;
         }
     }
 
@@ -35326,11 +36212,11 @@ ecs_entity_index_page_t* flecs_entity_index_ensure_page(
 {
     int32_t page_index = (int32_t)(id >> FLECS_ENTITY_PAGE_BITS);
     if (page_index >= ecs_vec_count(&index->pages)) {
-        ecs_vec_set_min_count_zeromem_t(index->allocator, &index->pages, 
+        ecs_vec_set_min_count_zeromem_t(index->allocator, &index->pages,
             ecs_entity_index_page_t*, page_index + 1);
     }
 
-    ecs_entity_index_page_t **page_ptr = ecs_vec_get_t(&index->pages, 
+    ecs_entity_index_page_t **page_ptr = ecs_vec_get_t(&index->pages,
         ecs_entity_index_page_t*, page_index);
     ecs_entity_index_page_t *page = *page_ptr;
     if (!page) {
@@ -35350,7 +36236,7 @@ void flecs_entity_index_init(
     ecs_vec_init_t(allocator, &index->dense, uint64_t, 1);
     ecs_vec_set_count_t(allocator, &index->dense, uint64_t, 1);
     ecs_vec_init_t(allocator, &index->pages, ecs_entity_index_page_t*, 0);
-    flecs_ballocator_init(&index->page_allocator, 
+    flecs_ballocator_init(&index->page_allocator,
         ECS_SIZEOF(ecs_entity_index_page_t));
 }
 
@@ -35375,10 +36261,10 @@ ecs_record_t* flecs_entity_index_get_any(
 {
     uint32_t id = (uint32_t)entity;
     int32_t page_index = (int32_t)(id >> FLECS_ENTITY_PAGE_BITS);
-    ecs_entity_index_page_t *page = ecs_vec_get_t(&index->pages, 
+    ecs_entity_index_page_t *page = ecs_vec_get_t(&index->pages,
         ecs_entity_index_page_t*, page_index)[0];
     ecs_record_t *r = &page->records[id & FLECS_ENTITY_PAGE_MASK];
-    ecs_assert(r->dense != 0, ECS_INVALID_PARAMETER, 
+    ecs_assert(r->dense != 0, ECS_INVALID_PARAMETER,
         "entity %u does not exist", (uint32_t)entity);
     return r;
 }
@@ -35389,7 +36275,7 @@ ecs_record_t* flecs_entity_index_get(
 {
     ecs_record_t *r = flecs_entity_index_get_any(index, entity);
     ecs_assert(r->dense < index->alive_count, ECS_INVALID_PARAMETER, NULL);
-    ecs_assert(ecs_vec_get_t(&index->dense, uint64_t, r->dense)[0] == entity, 
+    ecs_assert(ecs_vec_get_t(&index->dense, uint64_t, r->dense)[0] == entity,
         ECS_INVALID_PARAMETER, "mismatching liveliness generation for entity");
     return r;
 }
@@ -35404,7 +36290,7 @@ ecs_record_t* flecs_entity_index_try_get_any(
         return NULL;
     }
 
-    ecs_entity_index_page_t *page = ecs_vec_get_t(&index->pages, 
+    ecs_entity_index_page_t *page = ecs_vec_get_t(&index->pages,
         ecs_entity_index_page_t*, page_index)[0];
     if (!page) {
         return NULL;
@@ -35448,7 +36334,7 @@ ecs_record_t* flecs_entity_index_ensure(
         /* Entity is already alive, nothing to be done */
         if (dense < index->alive_count) {
             ecs_assert(
-                ecs_vec_get_t(&index->dense, uint64_t, dense)[0] == entity, 
+                ecs_vec_get_t(&index->dense, uint64_t, dense)[0] == entity,
                 ECS_INTERNAL_ERROR, NULL);
             return r;
         }
@@ -35465,7 +36351,7 @@ ecs_record_t* flecs_entity_index_ensure(
     uint64_t *ids = ecs_vec_first(&index->dense);
     uint64_t e_swap = ids[index->alive_count];
     ecs_record_t *r_swap = flecs_entity_index_get_any(index, e_swap);
-    ecs_assert(r_swap->dense == index->alive_count, 
+    ecs_assert(r_swap->dense == index->alive_count,
         ECS_INTERNAL_ERROR, NULL);
 
     r_swap->dense = dense;
@@ -35473,7 +36359,7 @@ ecs_record_t* flecs_entity_index_ensure(
     ids[dense] = e_swap;
     ids[index->alive_count ++] = entity;
 
-    ecs_assert(flecs_entity_index_is_alive(index, entity), 
+    ecs_assert(flecs_entity_index_is_alive(index, entity),
         ECS_INTERNAL_ERROR, NULL);
 
     return r;
@@ -35503,7 +36389,7 @@ void flecs_entity_index_remove(
     r->dense = i_swap;
     ecs_vec_get_t(&index->dense, uint64_t, dense)[0] = e_swap;
     e_swap_ptr[0] = ECS_GENERATION_INC(entity);
-    ecs_assert(!flecs_entity_index_is_alive(index, entity), 
+    ecs_assert(!flecs_entity_index_is_alive(index, entity),
         ECS_INTERNAL_ERROR, NULL);
 }
 
@@ -35540,7 +36426,7 @@ bool flecs_entity_index_is_valid(
     const ecs_entity_index_t *index,
     uint64_t entity)
 {
-    uint32_t id = (uint32_t)entity;    
+    uint32_t id = (uint32_t)entity;
     ecs_record_t *r = flecs_entity_index_try_get_any(index, id);
     if (!r || !r->dense) {
         /* Doesn't exist yet, so is valid */
@@ -35569,8 +36455,11 @@ uint64_t flecs_entity_index_new_id(
     /* Create new id */
     uint32_t id = (uint32_t)++ index->max_id;
 
+    ecs_assert(index->max_id <= UINT32_MAX, ECS_INVALID_OPERATION,
+        "max id %u exceeds 32 bits", index->max_id);
+
     /* Make sure id hasn't been issued before */
-    ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION, 
+    ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION,
         "new entity %u id already in use (likely due to overlapping ranges)", (uint32_t)id);
 
     ecs_vec_append_t(index->allocator, &index->dense, uint64_t)[0] = id;
@@ -35579,7 +36468,7 @@ uint64_t flecs_entity_index_new_id(
     ecs_assert(page != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_record_t *r = &page->records[id & FLECS_ENTITY_PAGE_MASK];
     r->dense = index->alive_count ++;
-    ecs_assert(index->alive_count == ecs_vec_count(&index->dense), 
+    ecs_assert(index->alive_count == ecs_vec_count(&index->dense),
         ECS_INTERNAL_ERROR, NULL);
 
     return id;
@@ -35605,8 +36494,11 @@ uint64_t* flecs_entity_index_new_ids(
     for (i = 0; i < to_add; i ++) {
         uint32_t id = (uint32_t)++ index->max_id;
 
+        ecs_assert(index->max_id <= UINT32_MAX, ECS_INVALID_OPERATION,
+        	"max id %u exceeds 32 bits", index->max_id);
+
         /* Make sure id hasn't been issued before */
-        ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION, 
+        ecs_assert(!flecs_entity_index_exists(index, id), ECS_INVALID_OPERATION,
             "new entity %u id already in use (likely due to overlapping ranges)", (uint32_t)id);
 
         int32_t dense = dense_count + i;
@@ -35650,7 +36542,7 @@ void flecs_entity_index_clear(
     ecs_entity_index_t *index)
 {
     int32_t i, count = ecs_vec_count(&index->pages);
-    ecs_entity_index_page_t **pages = ecs_vec_first_t(&index->pages, 
+    ecs_entity_index_page_t **pages = ecs_vec_first_t(&index->pages,
         ecs_entity_index_page_t*);
     for (i = 0; i < count; i ++) {
         ecs_entity_index_page_t *page = pages[i];
@@ -35851,8 +36743,6 @@ ecs_flags32_t flecs_id_record_event_flags(
     result |= flecs_observers_exist(o, id, EcsOnAdd) * EcsIdHasOnAdd;
     result |= flecs_observers_exist(o, id, EcsOnRemove) * EcsIdHasOnRemove;
     result |= flecs_observers_exist(o, id, EcsOnSet) * EcsIdHasOnSet;
-    result |= flecs_observers_exist(o, id, EcsOnTableFill) * EcsIdHasOnTableFill;
-    result |= flecs_observers_exist(o, id, EcsOnTableEmpty) * EcsIdHasOnTableEmpty;
     result |= flecs_observers_exist(o, id, EcsOnTableCreate) * EcsIdHasOnTableCreate;
     result |= flecs_observers_exist(o, id, EcsOnTableDelete) * EcsIdHasOnTableDelete;
     return result;
@@ -35865,12 +36755,12 @@ ecs_id_record_t* flecs_id_record_new(
 {
     ecs_id_record_t *idr, *idr_t = NULL;
     ecs_id_t hash = flecs_id_record_hash(id);
+    idr = flecs_bcalloc(&world->allocators.id_record);
+
     if (hash >= FLECS_HI_ID_RECORD_ID) {
-        idr = flecs_bcalloc(&world->allocators.id_record);
         ecs_map_insert_ptr(&world->id_index_hi, hash, idr);
     } else {
-        idr = &world->id_index_lo[hash];
-        ecs_os_zeromem(idr);
+        world->id_index_lo[hash] = idr;
     }
 
     ecs_table_cache_init(world, &idr->cache);
@@ -36038,6 +36928,14 @@ ecs_id_record_t* flecs_id_record_new(
             /* Add reference to (*, tgt) id record to entity record */
             tgt_r->idr = idr_t;
         }
+
+        /* If second element of pair determines the type, check if the pair 
+         * should be stored as a sparse component. */
+        if (idr->type_info && idr->type_info->component == tgt) {
+            if (ecs_has_id(world, tgt, EcsSparse)) {
+                idr->flags |= EcsIdIsSparse;
+            }
+        }
     }
 
     idr->flags |= flecs_id_record_event_flags(world, id);
@@ -36071,8 +36969,6 @@ void flecs_id_record_assert_empty(
 {
     (void)idr;
     ecs_assert(flecs_table_cache_count(&idr->cache) == 0, 
-        ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(flecs_table_cache_empty_count(&idr->cache) == 0, 
         ECS_INTERNAL_ERROR, NULL);
 }
 
@@ -36146,10 +37042,11 @@ void flecs_id_record_free(
     ecs_id_t hash = flecs_id_record_hash(id);
     if (hash >= FLECS_HI_ID_RECORD_ID) {
         ecs_map_remove(&world->id_index_hi, hash);
-        flecs_bfree(&world->allocators.id_record, idr);
     } else {
-        idr->id = 0; /* Tombstone */
+        world->id_index_lo[hash] = NULL;
     }
+
+    flecs_bfree(&world->allocators.id_record, idr);
 
     if (ecs_should_log_1()) {
         char *id_str = ecs_id_str(world, id);
@@ -36187,10 +37084,7 @@ ecs_id_record_t* flecs_id_record_get(
     if (hash >= FLECS_HI_ID_RECORD_ID) {
         idr = ecs_map_get_deref(&world->id_index_hi, ecs_id_record_t, hash);
     } else {
-        idr = &world->id_index_lo[hash];
-        if (!idr->id) {
-            idr = NULL;
-        }
+        idr = world->id_index_lo[hash];
     }
 
     return idr;
@@ -36345,8 +37239,8 @@ void flecs_fini_id_records(
 
     int32_t i;
     for (i = 0; i < FLECS_HI_ID_RECORD_ID; i ++) {
-        ecs_id_record_t *idr = &world->id_index_lo[i];
-        if (idr->id) {
+        ecs_id_record_t *idr = world->id_index_lo[i];
+        if (idr) {
             flecs_id_record_release(world, idr);
         }
     }
@@ -36720,6 +37614,7 @@ void flecs_table_emit(
     ecs_table_t *table,
     ecs_entity_t event)
 {
+    ecs_defer_begin(world);
     flecs_emit(world, world, 0, &(ecs_event_desc_t) {
         .ids = &table->type,
         .event = event,
@@ -36727,6 +37622,7 @@ void flecs_table_emit(
         .flags = EcsEventTableOnly,
         .observable = world
     });
+    ecs_defer_end(world);
 }
 
 /* Main table initialization function */
@@ -37051,13 +37947,12 @@ void flecs_table_add_trigger_flags(
         flags = EcsTableHasOnRemove;
     } else if (event == EcsOnSet) {
         flags = EcsTableHasOnSet;
-    } else if (event == EcsOnTableFill) {
-        flags = EcsTableHasOnTableFill;
-    } else if (event == EcsOnTableEmpty) {
-        flags = EcsTableHasOnTableEmpty;
+    } else if (event == EcsOnTableCreate) {
+        flags = EcsTableHasOnTableCreate;
+    } else if (event == EcsOnTableDelete) {
+        flags = EcsTableHasOnTableDelete;
     } else if (event == EcsWildcard) {
         flags = EcsTableHasOnAdd|EcsTableHasOnRemove|EcsTableHasOnSet|
-            EcsTableHasOnTableFill|EcsTableHasOnTableEmpty|
             EcsTableHasOnTableCreate|EcsTableHasOnTableDelete;
     }
 
@@ -37296,7 +38191,6 @@ void flecs_table_fini_data(
     ecs_table_t *table,
     bool do_on_remove,
     bool is_delete,
-    bool deactivate,
     bool deallocate)
 {
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
@@ -37355,11 +38249,6 @@ void flecs_table_fini_data(
     }
 
     table->data.count = 0;
-
-    if (deactivate && count) {
-        flecs_table_set_empty(world, table);
-    }
-
     table->_->traversable_count = 0;
     table->flags &= ~EcsTableHasTraversable;
 }
@@ -37375,7 +38264,7 @@ void ecs_table_clear_entities(
     ecs_world_t* world,
     ecs_table_t* table)
 {
-    flecs_table_fini_data(world, table, true, true, true, false);
+    flecs_table_fini_data(world, table, true, true, false);
 }
 
 /* Cleanup, no OnRemove, clear entity index, deactivate table, free allocations */
@@ -37383,7 +38272,7 @@ void flecs_table_clear_entities_silent(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, false, false, true, true);
+    flecs_table_fini_data(world, table, false, false, true);
 }
 
 /* Cleanup, run OnRemove, clear entity index, deactivate table, free allocations */
@@ -37391,7 +38280,7 @@ void flecs_table_clear_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, false, true, true);
+    flecs_table_fini_data(world, table, true, false, true);
 }
 
 /* Cleanup, run OnRemove, delete from entity index, deactivate table, free allocations */
@@ -37399,7 +38288,7 @@ void flecs_table_delete_entities(
     ecs_world_t *world,
     ecs_table_t *table)
 {
-    flecs_table_fini_data(world, table, true, true, true, true);
+    flecs_table_fini_data(world, table, true, true, true);
 }
 
 /* Unset all components in table. This function is called before a table is 
@@ -37417,6 +38306,8 @@ void flecs_table_fini(
     ecs_world_t *world,
     ecs_table_t *table)
 {
+    flecs_poly_assert(world, ecs_world_t);
+
     bool is_root = table == &world->store.root;
     ecs_assert(!table->_->lock, ECS_LOCKED_STORAGE, FLECS_LOCKED_STORAGE_MSG);
     ecs_assert(is_root || table->id != 0, ECS_INTERNAL_ERROR, NULL);
@@ -37441,10 +38332,8 @@ void flecs_table_fini(
         ecs_log_push_2();
     }
 
-    world->info.empty_table_count -= (ecs_table_count(table) == 0);
-
     /* Cleanup data, no OnRemove, delete from entity index, don't deactivate */
-    flecs_table_fini_data(world, table, false, true, false, true);
+    flecs_table_fini_data(world, table, false, true, true);
     flecs_table_clear_edges(world, table);
 
     if (!is_root) {
@@ -37739,6 +38628,8 @@ int32_t flecs_table_grow_data(
     int32_t size,
     const ecs_entity_t *ids)
 {
+    flecs_poly_assert(world, ecs_world_t);
+
     ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
 
     int32_t count = ecs_table_count(table);
@@ -37795,10 +38686,6 @@ int32_t flecs_table_grow_data(
 
     /* If the table is monitored indicate that there has been a change */
     flecs_table_mark_table_dirty(world, table, 0);
-
-    if (!(world->flags & EcsWorldReadonly) && !count) {
-        flecs_table_set_empty(world, table);
-    }
 
     /* Return index of first added entity */
     return count;
@@ -37859,9 +38746,6 @@ int32_t flecs_table_append(
         flecs_table_fast_append(world, table);
         table->data.count = v_entities.count;
         table->data.size = v_entities.size;
-        if (!count) {
-            flecs_table_set_empty(world, table); /* See below */
-        }
         return count;
     }
 
@@ -37872,12 +38756,6 @@ int32_t flecs_table_append(
         ECS_INTERNAL_ERROR, NULL);
     table->data.count = v_entities.count;
     table->data.size = v_entities.size;
-
-    /* If this is the first entity in this table, signal queries so that the
-     * table moves from an inactive table to an active table. */
-    if (!count) {
-        flecs_table_set_empty(world, table);
-    }
 
     /* Reobtain size to ensure that the columns have the same size as the 
      * entities and record vectors. This keeps reasoning about when allocations
@@ -37988,9 +38866,6 @@ void flecs_table_delete(
         }
 
         table->data.count --;
-        if (!count) {
-            flecs_table_set_empty(world, table);
-        }
 
         flecs_table_check_sanity(world, table);
         return;
@@ -38054,9 +38929,6 @@ void flecs_table_delete(
     }
 
     table->data.count --;
-    if (!count) {
-        flecs_table_set_empty(world, table);
-    }
 
     flecs_table_check_sanity(world, table);
 }
@@ -38580,11 +39452,6 @@ void flecs_table_merge(
     flecs_table_merge_data(world, dst_table, src_table, dst_count, src_count);
 
     if (src_count) {
-        if (!dst_count) {
-            flecs_table_set_empty(world, dst_table);
-        }
-        flecs_table_set_empty(world, src_table);
-
         flecs_table_traversable_add(dst_table, src_table->_->traversable_count);
         flecs_table_traversable_add(src_table, -src_table->_->traversable_count);
         ecs_assert(src_table->_->traversable_count == 0, ECS_INTERNAL_ERROR, NULL);
@@ -38601,6 +39468,8 @@ void flecs_table_notify(
     ecs_id_t id,
     ecs_table_event_t *event)
 {
+    flecs_poly_assert(world, ecs_world_t);
+
     if (world->flags & EcsWorldFini) {
         return;
     }
@@ -38971,20 +39840,19 @@ void flecs_table_cache_list_remove(
         prev->next = next;
     }
 
-    cache->empty_tables.count -= !!elem->empty;
-    cache->tables.count -= !elem->empty;
+    cache->tables.count --;
 
-    if (cache->empty_tables.first == elem) {
-        cache->empty_tables.first = next;
-    } else if (cache->tables.first == elem) {
+    if (cache->tables.first == elem) {
         cache->tables.first = next;
-    }
-    if (cache->empty_tables.last == elem) {
-        cache->empty_tables.last = prev;
     }
     if (cache->tables.last == elem) {
         cache->tables.last = prev;
     }
+
+    ecs_assert(cache->tables.first == NULL || cache->tables.count,
+        ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(cache->tables.first == NULL || cache->tables.last != NULL,
+        ECS_INTERNAL_ERROR, NULL);
 }
 
 static
@@ -38992,19 +39860,10 @@ void flecs_table_cache_list_insert(
     ecs_table_cache_t *cache,
     ecs_table_cache_hdr_t *elem)
 {
-    ecs_table_cache_hdr_t *last;
-    if (elem->empty) {
-        last = cache->empty_tables.last;
-        cache->empty_tables.last = elem;
-        if ((++ cache->empty_tables.count) == 1) {
-            cache->empty_tables.first = elem;
-        }
-    } else {
-        last = cache->tables.last;
-        cache->tables.last = elem;
-        if ((++ cache->tables.count) == 1) {
-            cache->tables.first = elem;
-        }
+    ecs_table_cache_hdr_t *last = cache->tables.last;
+    cache->tables.last = elem;
+    if ((++ cache->tables.count) == 1) {
+        cache->tables.first = elem;
     }
 
     elem->next = NULL;
@@ -39013,6 +39872,10 @@ void flecs_table_cache_list_insert(
     if (last) {
         last->next = elem;
     }
+
+    ecs_assert(
+        cache->tables.count != 1 || cache->tables.first == cache->tables.last,
+        ECS_INTERNAL_ERROR, NULL);
 }
 
 void ecs_table_cache_init(
@@ -39030,17 +39893,10 @@ void ecs_table_cache_fini(
     ecs_map_fini(&cache->index);
 }
 
-bool ecs_table_cache_is_empty(
-    const ecs_table_cache_t *cache)
-{
-    return ecs_map_count(&cache->index) == 0;
-}
-
-void ecs_table_cache_insert_w_empty(
+void ecs_table_cache_insert(
     ecs_table_cache_t *cache,
     const ecs_table_t *table,
-    ecs_table_cache_hdr_t *result,
-    bool empty)
+    ecs_table_cache_hdr_t *result)
 {
     ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(ecs_table_cache_get(cache, table) == NULL,
@@ -39049,7 +39905,6 @@ void ecs_table_cache_insert_w_empty(
 
     result->cache = cache;
     result->table = ECS_CONST_CAST(ecs_table_t*, table);
-    result->empty = empty;
 
     flecs_table_cache_list_insert(cache, result);
 
@@ -39057,25 +39912,7 @@ void ecs_table_cache_insert_w_empty(
         ecs_map_insert_ptr(&cache->index, table->id, result);
     }
 
-    ecs_assert(empty || cache->tables.first != NULL, 
-        ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(!empty || cache->empty_tables.first != NULL, 
-        ECS_INTERNAL_ERROR, NULL);
-}
-
-void ecs_table_cache_insert(
-    ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    ecs_table_cache_hdr_t *result)
-{
-    bool empty;
-    if (!table) {
-        empty = false;
-    } else {
-        empty = ecs_table_count(table) == 0;
-    }
-    
-    ecs_table_cache_insert_w_empty(cache, table, result, empty);
+    ecs_assert(cache->tables.first != NULL, ECS_INTERNAL_ERROR, NULL);
 }
 
 void ecs_table_cache_replace(
@@ -39100,12 +39937,6 @@ void ecs_table_cache_replace(
         next->prev = elem;
     }
 
-    if (cache->empty_tables.first == old) {
-        cache->empty_tables.first = elem;
-    }
-    if (cache->empty_tables.last == old) {
-        cache->empty_tables.last = elem;
-    }
     if (cache->tables.first == old) {
         cache->tables.first = elem;
     }
@@ -39152,31 +39983,6 @@ void* ecs_table_cache_remove(
     return elem;
 }
 
-bool ecs_table_cache_set_empty(
-    ecs_table_cache_t *cache,
-    const ecs_table_t *table,
-    bool empty)
-{
-    ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(table != NULL, ECS_INTERNAL_ERROR, NULL);
-
-    ecs_table_cache_hdr_t *elem = ecs_map_get_deref(&cache->index, 
-        ecs_table_cache_hdr_t, table->id);
-    if (!elem) {
-        return false;
-    }
-
-    if (elem->empty == empty) {
-        return false;
-    }
-
-    flecs_table_cache_list_remove(cache, elem);
-    elem->empty = empty;
-    flecs_table_cache_list_insert(cache, elem);
-
-    return true;
-}
-
 bool flecs_table_cache_iter(
     ecs_table_cache_t *cache,
     ecs_table_cache_iter_t *out)
@@ -39184,8 +39990,9 @@ bool flecs_table_cache_iter(
     ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(out != NULL, ECS_INTERNAL_ERROR, NULL);
     out->next = cache->tables.first;
-    out->next_list = NULL;
     out->cur = NULL;
+    out->iter_fill = true;
+    out->iter_empty = false;
     return out->next != NULL;
 }
 
@@ -39195,9 +40002,10 @@ bool flecs_table_cache_empty_iter(
 {
     ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(out != NULL, ECS_INTERNAL_ERROR, NULL);
-    out->next = cache->empty_tables.first;
-    out->next_list = NULL;
+    out->next = cache->tables.first;
     out->cur = NULL;
+    out->iter_fill = false;
+    out->iter_empty = true;
     return out->next != NULL;
 }
 
@@ -39207,26 +40015,36 @@ bool flecs_table_cache_all_iter(
 {
     ecs_assert(cache != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(out != NULL, ECS_INTERNAL_ERROR, NULL);
-    out->next = cache->empty_tables.first;
-    out->next_list = cache->tables.first;
+    out->next = cache->tables.first;
     out->cur = NULL;
-    return out->next != NULL || out->next_list != NULL;
+    out->iter_fill = true;
+    out->iter_empty = true;
+    return out->next != NULL;
 }
 
 ecs_table_cache_hdr_t* flecs_table_cache_next_(
     ecs_table_cache_iter_t *it)
 {
-    ecs_table_cache_hdr_t *next = it->next;
-    if (!next) {
-        next = it->next_list;
-        it->next_list = NULL;
-        if (!next) {
-            return NULL;
+    ecs_table_cache_hdr_t *next;
+
+repeat:
+    next = it->next;
+    it->cur = next;
+
+    if (next) {
+        it->next = next->next;
+
+        if (ecs_table_count(next->table)) {
+            if (!it->iter_fill) {
+                goto repeat;
+            }
+        } else {
+            if (!it->iter_empty) {
+                goto repeat;
+            }
         }
     }
 
-    it->cur = next;
-    it->next = next->next;
     return next;
 }
 
@@ -39737,22 +40555,6 @@ void flecs_table_init_node(
     flecs_table_init_edges(&node->remove);
 }
 
-bool flecs_table_records_update_empty(
-    ecs_table_t *table)
-{
-    bool result = false;
-    bool is_empty = ecs_table_count(table) == 0;
-
-    int32_t i, count = table->_->record_count;
-    for (i = 0; i < count; i ++) {
-        ecs_table_record_t *tr = &table->_->records[i];
-        ecs_table_cache_t *cache = tr->hdr.cache;
-        result |= ecs_table_cache_set_empty(cache, table, is_empty);
-    }
-
-    return result;
-}
-
 static
 void flecs_init_table(
     ecs_world_t *world,
@@ -39825,7 +40627,6 @@ ecs_table_t *flecs_table_new(
 
     /* Update counters */
     world->info.table_count ++;
-    world->info.empty_table_count ++;
     world->info.table_create_total ++;
 
     ecs_log_pop_2();
@@ -40019,7 +40820,8 @@ void flecs_add_overrides_for_base(
     ecs_id_t pair)
 {
     ecs_entity_t base = ecs_pair_second(world, pair);
-    ecs_assert(base != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(base != 0, ECS_INVALID_PARAMETER, 
+        "target of IsA pair is not alive");
     ecs_table_t *base_table = ecs_get_table(world, base);
     if (!base_table) {
         return;
@@ -44047,7 +44849,7 @@ bool flecs_json_serialize_table_tags(
         ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
 
         if (src_table) {
-            if (idr->flags & EcsIdOnInstantiateDontInherit) {
+            if (!(idr->flags & EcsIdOnInstantiateInherit)) {
                 continue;
             }
         }
@@ -44114,7 +44916,7 @@ bool flecs_json_serialize_table_pairs(
         ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
 
         if (src_table) {
-            if (idr->flags & EcsIdOnInstantiateDontInherit) {
+            if (!(idr->flags & EcsIdOnInstantiateInherit)) {
                 continue;
             }
         }
@@ -44212,7 +45014,7 @@ int flecs_json_serialize_table_components(
         ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
 
         if (src_table) {
-            if (idr->flags & EcsIdOnInstantiateDontInherit) {
+            if (!(idr->flags & EcsIdOnInstantiateInherit)) {
                 continue;
             }
         }
@@ -46006,7 +46808,30 @@ ecs_entity_t ecs_enum_init(
         t = ecs_new_low_id(world);
     }
 
-    ecs_add(world, t, EcsEnum);
+    ecs_entity_t underlying = desc->underlying_type;
+
+    if (!underlying) {
+        underlying = ecs_id(ecs_i32_t);
+    }
+
+    ecs_assert(ecs_is_valid(world, underlying), ECS_INVALID_PARAMETER, 
+        "invalid underlying type for enum");
+
+    const EcsPrimitive *p = ecs_get(world, underlying, EcsPrimitive);
+    if (!p) {
+        char *path = ecs_get_path(world, underlying);
+        ecs_err("underlying type '%s' must be a primitive type", path);
+        ecs_os_free(path);
+        return 0;
+    }
+
+    bool ut_is_unsigned = false;
+    ecs_primitive_kind_t kind = p->kind;
+    if (kind == EcsU8 || kind == EcsU16 || kind == EcsU32 || kind == EcsU64) {
+        ut_is_unsigned = true;
+    }
+
+    ecs_set(world, t, EcsEnum, { .underlying_type = underlying });
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
@@ -46021,11 +46846,46 @@ ecs_entity_t ecs_enum_init(
             .name = m_desc->name
         });
 
-        if (!m_desc->value) {
+        if (!m_desc->value && !m_desc->value_unsigned) {
             ecs_add_id(world, c, EcsConstant);
         } else {
-            ecs_set_pair_second(world, c, EcsConstant, ecs_i32_t, 
-                {m_desc->value});
+            void *ptr = ecs_ensure_id(world, c, 
+                ecs_pair(EcsConstant, underlying));
+            ecs_assert(ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+            ecs_meta_cursor_t cur = ecs_meta_cursor(world, underlying, ptr);
+
+            int ret;
+            if (m_desc->value) {
+                if (ut_is_unsigned) {
+                    char *path = ecs_get_path(world, c);
+                    ecs_err("use desc::value_unsigned for constant '%s' which"
+                        "has an unsigned underlying type", path);
+                    ecs_os_free(path);
+                    return 0;
+                }
+                ret = ecs_meta_set_int(&cur, m_desc->value);
+            } else {
+                if (!ut_is_unsigned) {
+                    char *path = ecs_get_path(world, c);
+                    ecs_err("use desc::value for constant '%s' which"
+                        "has a signed underlying type", path);
+                    ecs_os_free(path);
+                    return 0;
+                }
+                ret = ecs_meta_set_uint(&cur, m_desc->value_unsigned);
+            }
+
+            if (ret) {
+                char *type_str = ecs_get_path(world, t);
+                char *utype_str = ecs_get_path(world, underlying);
+                ecs_err("value for constant '%s' for enum '%s' is not valid "
+                    "for underlying type '%s'", type_str, utype_str);
+                ecs_os_free(utype_str);
+                ecs_os_free(type_str);
+                continue;
+            }
+
+            ecs_modified_id(world, c, ecs_pair(EcsConstant, underlying));
         }
     }
 
@@ -46072,7 +46932,7 @@ ecs_entity_t ecs_bitmask_init(
             ecs_add_id(world, c, EcsConstant);
         } else {
             ecs_set_pair_second(world, c, EcsConstant, ecs_u32_t, 
-                {m_desc->value});
+                { flecs_uto(uint32_t, m_desc->value) });
         }
     }
 
@@ -46424,41 +47284,41 @@ ecs_entity_t ecs_quantity_init(
 
 typedef char ecs_meta_token_t[ECS_META_IDENTIFIER_LENGTH];
 
-typedef struct meta_parse_ctx_t {
+typedef struct flecs_meta_utils_parse_ctx_t {
     const char *name;
     const char *desc;
-} meta_parse_ctx_t;
+} flecs_meta_utils_parse_ctx_t;
 
-typedef struct meta_type_t {
+typedef struct flecs_meta_utils_type_t {
     ecs_meta_token_t type;
     ecs_meta_token_t params;
     bool is_const;
     bool is_ptr;
-} meta_type_t;
+} flecs_meta_utils_type_t;
 
-typedef struct meta_member_t {
-    meta_type_t type;
+typedef struct flecs_meta_utils_member_t {
+    flecs_meta_utils_type_t type;
     ecs_meta_token_t name;
     int64_t count;
     bool is_partial;
-} meta_member_t;
+} flecs_meta_utils_member_t;
 
-typedef struct meta_constant_t {
+typedef struct flecs_meta_utils_constant_t {
     ecs_meta_token_t name;
     int64_t value;
     bool is_value_set;
-} meta_constant_t;
+} flecs_meta_utils_constant_t;
 
-typedef struct meta_params_t {
-    meta_type_t key_type;
-    meta_type_t type;
+typedef struct flecs_meta_utils_params_t {
+    flecs_meta_utils_type_t key_type;
+    flecs_meta_utils_type_t type;
     int64_t count;
     bool is_key_value;
     bool is_fixed_size;
-} meta_params_t;
+} flecs_meta_utils_params_t;
 
 static
-const char* skip_scope(const char *ptr, meta_parse_ctx_t *ctx) {
+const char* skip_scope(const char *ptr, flecs_meta_utils_parse_ctx_t *ctx) {
     /* Keep track of which characters were used to open the scope */
     char stack[256];
     int32_t sp = 0;
@@ -46519,7 +47379,7 @@ const char* parse_c_identifier(
     const char *ptr, 
     char *buff,
     char *params,
-    meta_parse_ctx_t *ctx) 
+    flecs_meta_utils_parse_ctx_t *ctx) 
 {
     ecs_assert(ptr != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(buff != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -46575,9 +47435,9 @@ error:
 }
 
 static
-const char * meta_open_scope(
+const char * flecs_meta_utils_open_scope(
     const char *ptr,
-    meta_parse_ctx_t *ctx)    
+    flecs_meta_utils_parse_ctx_t *ctx)    
 {
     /* Skip initial whitespaces */
     ptr = flecs_parse_ws_eol(ptr);
@@ -46616,12 +47476,12 @@ error:
 }
 
 static
-const char* meta_parse_constant(
+const char* flecs_meta_utils_parse_constant(
     const char *ptr,
-    meta_constant_t *token,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_constant_t *token,
+    flecs_meta_utils_parse_ctx_t *ctx)
 {    
-    ptr = meta_open_scope(ptr, ctx);
+    ptr = flecs_meta_utils_open_scope(ptr, ctx);
     if (!ptr) {
         return NULL;
     }
@@ -46663,10 +47523,10 @@ error:
 }
 
 static
-const char* meta_parse_type(
+const char* flecs_meta_utils_parse_type(
     const char *ptr,
-    meta_type_t *token,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_type_t *token,
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
     token->is_ptr = false;
     token->is_const = false;
@@ -46707,12 +47567,12 @@ error:
 }
 
 static
-const char* meta_parse_member(
+const char* flecs_meta_utils_parse_member(
     const char *ptr,
-    meta_member_t *token,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_member_t *token,
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
-    ptr = meta_open_scope(ptr, ctx);
+    ptr = flecs_meta_utils_open_scope(ptr, ctx);
     if (!ptr) {
         return NULL;
     }
@@ -46721,7 +47581,7 @@ const char* meta_parse_member(
     token->is_partial = false;
 
     /* Parse member type */
-    ptr = meta_parse_type(ptr, &token->type, ctx);
+    ptr = flecs_meta_utils_parse_type(ptr, &token->type, ctx);
     if (!ptr) {
         token->is_partial = true;
         goto error;
@@ -46786,10 +47646,10 @@ error:
 }
 
 static
-int meta_parse_desc(
+int flecs_meta_utils_parse_desc(
     const char *ptr,
-    meta_params_t *token,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_params_t *token,
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
     token->is_key_value = false;
     token->is_fixed_size = false;
@@ -46804,7 +47664,7 @@ int meta_parse_desc(
     ptr ++;
 
     /* Parse type identifier */
-    ptr = meta_parse_type(ptr, &token->type, ctx);
+    ptr = flecs_meta_utils_parse_type(ptr, &token->type, ctx);
     if (!ptr) {
         goto error;
     }
@@ -46828,7 +47688,7 @@ int meta_parse_desc(
             token->key_type = token->type;
 
             /* Parse element type */
-            ptr = meta_parse_type(ptr, &token->type, ctx);
+            ptr = flecs_meta_utils_parse_type(ptr, &token->type, ctx);
             ptr = flecs_parse_ws_eol(ptr);
 
             token->is_key_value = true;
@@ -46847,27 +47707,27 @@ error:
 }
 
 static
-ecs_entity_t meta_lookup(
+ecs_entity_t flecs_meta_utils_lookup(
     ecs_world_t *world,
-    meta_type_t *token,
+    flecs_meta_utils_type_t *token,
     const char *ptr,
     int64_t count,
-    meta_parse_ctx_t *ctx);
+    flecs_meta_utils_parse_ctx_t *ctx);
 
 static
-ecs_entity_t meta_lookup_array(
+ecs_entity_t flecs_meta_utils_lookup_array(
     ecs_world_t *world,
     ecs_entity_t e,
     const char *params_decl,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
-    meta_parse_ctx_t param_ctx = {
+    flecs_meta_utils_parse_ctx_t param_ctx = {
         .name = ctx->name,
         .desc = params_decl
     };
 
-    meta_params_t params;
-    if (meta_parse_desc(params_decl, &params, &param_ctx)) {
+    flecs_meta_utils_params_t params;
+    if (flecs_meta_utils_parse_desc(params_decl, &params, &param_ctx)) {
         goto error;
     }
     if (!params.is_fixed_size) {
@@ -46901,19 +47761,19 @@ error:
 }
 
 static
-ecs_entity_t meta_lookup_vector(
+ecs_entity_t flecs_meta_utils_lookup_vector(
     ecs_world_t *world,
     ecs_entity_t e,
     const char *params_decl,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
-    meta_parse_ctx_t param_ctx = {
+    flecs_meta_utils_parse_ctx_t param_ctx = {
         .name = ctx->name,
         .desc = params_decl
     };
 
-    meta_params_t params;
-    if (meta_parse_desc(params_decl, &params, &param_ctx)) {
+    flecs_meta_utils_params_t params;
+    if (flecs_meta_utils_parse_desc(params_decl, &params, &param_ctx)) {
         goto error;
     }
 
@@ -46923,7 +47783,7 @@ ecs_entity_t meta_lookup_vector(
         goto error;
     }
 
-    ecs_entity_t element_type = meta_lookup(
+    ecs_entity_t element_type = flecs_meta_utils_lookup(
         world, &params.type, params_decl, 1, &param_ctx);
 
     if (!e) {
@@ -46938,21 +47798,21 @@ error:
 }
 
 static
-ecs_entity_t meta_lookup_bitmask(
+ecs_entity_t flecs_meta_utils_lookup_bitmask(
     ecs_world_t *world,
     ecs_entity_t e,
     const char *params_decl,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
     (void)e;
 
-    meta_parse_ctx_t param_ctx = {
+    flecs_meta_utils_parse_ctx_t param_ctx = {
         .name = ctx->name,
         .desc = params_decl
     };
 
-    meta_params_t params;
-    if (meta_parse_desc(params_decl, &params, &param_ctx)) {
+    flecs_meta_utils_params_t params;
+    if (flecs_meta_utils_parse_desc(params_decl, &params, &param_ctx)) {
         goto error;
     }
 
@@ -46968,7 +47828,7 @@ ecs_entity_t meta_lookup_bitmask(
         goto error;
     }
 
-    ecs_entity_t bitmask_type = meta_lookup(
+    ecs_entity_t bitmask_type = flecs_meta_utils_lookup(
         world, &params.type, params_decl, 1, &param_ctx);
     ecs_check(bitmask_type != 0, ECS_INVALID_PARAMETER, NULL);
 
@@ -46985,12 +47845,12 @@ error:
 }
 
 static
-ecs_entity_t meta_lookup(
+ecs_entity_t flecs_meta_utils_lookup(
     ecs_world_t *world,
-    meta_type_t *token,
+    flecs_meta_utils_type_t *token,
     const char *ptr,
     int64_t count,
-    meta_parse_ctx_t *ctx)
+    flecs_meta_utils_parse_ctx_t *ctx)
 {
     ecs_assert(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(token != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -47003,15 +47863,15 @@ ecs_entity_t meta_lookup(
     /* Parse vector type */
     if (!token->is_ptr) {
         if (!ecs_os_strcmp(typename, "ecs_array")) {
-            type = meta_lookup_array(world, 0, token->params, ctx);
+            type = flecs_meta_utils_lookup_array(world, 0, token->params, ctx);
 
         } else if (!ecs_os_strcmp(typename, "ecs_vector") || 
                 !ecs_os_strcmp(typename, "flecs::vector")) 
         {
-            type = meta_lookup_vector(world, 0, token->params, ctx);
+            type = flecs_meta_utils_lookup_vector(world, 0, token->params, ctx);
 
         } else if (!ecs_os_strcmp(typename, "flecs::bitmask")) {
-            type = meta_lookup_bitmask(world, 0, token->params, ctx);
+            type = flecs_meta_utils_lookup_bitmask(world, 0, token->params, ctx);
 
         } else if (!ecs_os_strcmp(typename, "flecs::byte")) {
             type = ecs_id(ecs_byte_t);
@@ -47091,7 +47951,7 @@ error:
 }
 
 static
-int meta_parse_struct(
+int flecs_meta_utils_parse_struct(
     ecs_world_t *world,
     ecs_entity_t t,
     const char *desc)
@@ -47099,20 +47959,20 @@ int meta_parse_struct(
     const char *ptr = desc;
     const char *name = ecs_get_name(world, t);
 
-    meta_member_t token;
-    meta_parse_ctx_t ctx = {
+    flecs_meta_utils_member_t token;
+    flecs_meta_utils_parse_ctx_t ctx = {
         .name = name,
         .desc = ptr
     };
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
-    while ((ptr = meta_parse_member(ptr, &token, &ctx)) && ptr[0]) {
+    while ((ptr = flecs_meta_utils_parse_member(ptr, &token, &ctx)) && ptr[0]) {
         ecs_entity_t m = ecs_entity(world, {
             .name = token.name
         });
 
-        ecs_entity_t type = meta_lookup(
+        ecs_entity_t type = flecs_meta_utils_lookup(
             world, &token.type, ptr, 1, &ctx);
         if (!type) {
             goto error;
@@ -47132,7 +47992,7 @@ error:
 }
 
 static
-int meta_parse_constants(
+int flecs_meta_utils_parse_constants(
     ecs_world_t *world,
     ecs_entity_t t,
     const char *desc,
@@ -47149,17 +48009,17 @@ int meta_parse_constants(
     const char *name_prefix = info->name_prefix;
     int32_t name_prefix_len = name_prefix ? ecs_os_strlen(name_prefix) : 0;
 
-    meta_parse_ctx_t ctx = {
+    flecs_meta_utils_parse_ctx_t ctx = {
         .name = name,
         .desc = ptr
     };
 
-    meta_constant_t token;
+    flecs_meta_utils_constant_t token;
     int64_t last_value = 0;
 
     ecs_entity_t old_scope = ecs_set_scope(world, t);
 
-    while ((ptr = meta_parse_constant(ptr, &token, &ctx))) {
+    while ((ptr = flecs_meta_utils_parse_constant(ptr, &token, &ctx))) {
         if (token.is_value_set) {
             last_value = token.value;
         } else if (is_bitmask) {
@@ -47203,23 +48063,23 @@ error:
 }
 
 static
-int meta_parse_enum(
+int flecs_meta_utils_parse_enum(
     ecs_world_t *world,
     ecs_entity_t t,
     const char *desc)
 {
-    ecs_add(world, t, EcsEnum);
-    return meta_parse_constants(world, t, desc, false);
+    ecs_set(world, t, EcsEnum, { .underlying_type = ecs_id(ecs_i32_t) });
+    return flecs_meta_utils_parse_constants(world, t, desc, false);
 }
 
 static
-int meta_parse_bitmask(
+int flecs_meta_utils_parse_bitmask(
     ecs_world_t *world,
     ecs_entity_t t,
     const char *desc)
 {
     ecs_add(world, t, EcsBitmask);
-    return meta_parse_constants(world, t, desc, true);
+    return flecs_meta_utils_parse_constants(world, t, desc, true);
 }
 
 int ecs_meta_from_desc(
@@ -47230,17 +48090,17 @@ int ecs_meta_from_desc(
 {
     switch(kind) {
     case EcsStructType:
-        if (meta_parse_struct(world, component, desc)) {
+        if (flecs_meta_utils_parse_struct(world, component, desc)) {
             goto error;
         }
         break;
     case EcsEnumType:
-        if (meta_parse_enum(world, component, desc)) {
+        if (flecs_meta_utils_parse_enum(world, component, desc)) {
             goto error;
         }
         break;
     case EcsBitmaskType:
-        if (meta_parse_bitmask(world, component, desc)) {
+        if (flecs_meta_utils_parse_bitmask(world, component, desc)) {
             goto error;
         }
         break;
@@ -47265,6 +48125,7 @@ error:
  * @brief API for assigning values of runtime types with reflection.
  */
 
+#include <inttypes.h>
 #include <ctype.h>
 
 #ifdef FLECS_META
@@ -47500,7 +48361,8 @@ int ecs_meta_next(
         }
 
         if (scope->elem_cur >= get_elem_count(scope)) {
-            ecs_err("out of collection bounds (%d)", scope->elem_cur);
+            ecs_err("out of collection bounds (%d elements vs. size %d)", 
+                scope->elem_cur + 1, get_elem_count(scope));
             return -1;
         }
         return 0;
@@ -47649,8 +48511,18 @@ int ecs_meta_push(
 
     if (cursor->depth == 0) {
         if (!cursor->is_primitive_scope) {
+            bool is_primitive = false;
             if ((op->kind > EcsOpScope) && (op->count <= 1)) {
-                cursor->is_primitive_scope = true;
+                is_primitive = true;
+            } else if (op->kind == EcsOpOpaque) {
+                const EcsOpaque *t = ecs_get(world, op->type, EcsOpaque);
+                ecs_assert(t != NULL, ECS_INTERNAL_ERROR, NULL);
+                if (ecs_has(world, t->as_type, EcsPrimitive)) {
+                    is_primitive = true;
+                }
+            }
+
+            if ((cursor->is_primitive_scope = is_primitive)) {
                 return 0;
             }
         }
@@ -47951,6 +48823,10 @@ bool ecs_meta_is_collection(
 ecs_entity_t ecs_meta_get_type(
     const ecs_meta_cursor_t *cursor)
 {
+    if (cursor->depth == 0) {
+        return cursor->scope[0].type;
+    }
+
     ecs_meta_scope_t *scope = flecs_meta_cursor_get_scope(cursor);
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     return op->type;
@@ -48145,6 +49021,17 @@ int ecs_meta_set_bool(
     cases_T_bool(ptr, value);
     cases_T_signed(ptr, value, ecs_meta_bounds_signed);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_unsigned);
+    case EcsOpString: {
+        char *result;
+        if (value) {
+            result = ecs_os_strdup("true");
+        } else {
+            result = ecs_os_strdup("false");
+        }
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *ot = ecs_get(cursor->world, op->type, EcsOpaque);
         if (ot && ot->assign_bool) {
@@ -48161,7 +49048,6 @@ int ecs_meta_set_bool(
     case EcsOpPrimitive:
     case EcsOpF32:
     case EcsOpF64:
-    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "bool");
         return -1;
     default:
@@ -48184,6 +49070,12 @@ int ecs_meta_set_char(
     switch(op->kind) {
     cases_T_bool(ptr, value);
     cases_T_signed(ptr, value, ecs_meta_bounds_signed);
+    case EcsOpString: {
+        char *result = flecs_asprintf("%c", value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, 
@@ -48216,7 +49108,6 @@ int ecs_meta_set_char(
     case EcsOpF32:
     case EcsOpF64:
     case EcsOpUPtr:
-    case EcsOpString:
     case EcsOpEntity:
     case EcsOpId:
         flecs_meta_conversion_error(cursor, op, "char");
@@ -48243,6 +49134,12 @@ int ecs_meta_set_int(
     cases_T_signed(ptr, value, ecs_meta_bounds_signed);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_signed);
     cases_T_float(ptr, value);
+    case EcsOpString: {
+        char *result = flecs_asprintf("%"PRId64, value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, 
@@ -48268,8 +49165,7 @@ int ecs_meta_set_int(
     case EcsOpPush:
     case EcsOpPop:
     case EcsOpScope:
-    case EcsOpPrimitive:
-    case EcsOpString: {
+    case EcsOpPrimitive: {
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "int");
         return -1;
@@ -48296,6 +49192,12 @@ int ecs_meta_set_uint(
     cases_T_signed(ptr, value, ecs_meta_bounds_unsigned);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_unsigned);
     cases_T_float(ptr, value);
+    case EcsOpString: {
+        char *result = flecs_asprintf("%"PRIu64, value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, 
@@ -48322,7 +49224,6 @@ int ecs_meta_set_uint(
     case EcsOpPop:
     case EcsOpScope:
     case EcsOpPrimitive:
-    case EcsOpString:
         if(!value) return ecs_meta_set_null(cursor);
         flecs_meta_conversion_error(cursor, op, "uint");
         return -1;
@@ -48354,6 +49255,12 @@ int ecs_meta_set_float(
     cases_T_signed(ptr, value, ecs_meta_bounds_float);
     cases_T_unsigned(ptr, value, ecs_meta_bounds_float);
     cases_T_float(ptr, value);
+    case EcsOpString: {
+        char *result = flecs_asprintf("%f", value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         ecs_assert(opaque != NULL, ECS_INVALID_OPERATION, 
@@ -48384,7 +49291,6 @@ int ecs_meta_set_float(
     case EcsOpPop:
     case EcsOpScope:
     case EcsOpPrimitive:
-    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "float");
         return -1;
     default:
@@ -48747,6 +49653,10 @@ int ecs_meta_set_string_literal(
     ecs_meta_type_op_t *op = flecs_meta_cursor_get_op(scope);
     void *ptr = flecs_meta_cursor_get_ptr(cursor->world, scope);
 
+    if (!value) {
+        return -1;
+    }
+
     ecs_size_t len = ecs_os_strlen(value);
     if (value[0] != '\"' || value[len - 1] != '\"') {
         ecs_err("invalid string literal '%s'", value);
@@ -48822,6 +49732,12 @@ int ecs_meta_set_entity(
     case EcsOpId:
         set_T(ecs_id_t, ptr, value); /* entities are valid ids */
         break;
+    case EcsOpString: {
+        char *result = ecs_get_path(cursor->world, value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }   
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         if (opaque && opaque->assign_entity) {
@@ -48854,7 +49770,6 @@ int ecs_meta_set_entity(
     case EcsOpF64:
     case EcsOpUPtr:
     case EcsOpIPtr:
-    case EcsOpString:
         flecs_meta_conversion_error(cursor, op, "entity");
         goto error;
     default:
@@ -48879,6 +49794,12 @@ int ecs_meta_set_id(
     case EcsOpId:
         set_T(ecs_id_t, ptr, value);
         break;
+    case EcsOpString: {
+        char *result = ecs_id_str(cursor->world, value);
+        ecs_os_free(*(ecs_string_t*)ptr);
+        set_T(ecs_string_t, ptr, result);
+        break;
+    }
     case EcsOpOpaque: {
         const EcsOpaque *opaque = ecs_get(cursor->world, op->type, EcsOpaque);
         if (opaque && opaque->assign_id) {
@@ -48911,7 +49832,6 @@ int ecs_meta_set_id(
     case EcsOpF64:
     case EcsOpUPtr:
     case EcsOpIPtr:
-    case EcsOpString:
     case EcsOpEntity:
         flecs_meta_conversion_error(cursor, op, "id");
         goto error;
@@ -49624,6 +50544,13 @@ void flecs_meta_import_meta_definitions(
     });
 
     ecs_struct_init(world, &(ecs_struct_desc_t){
+        .entity = ecs_id(EcsEnum),
+        .members = {
+            { .name = "underlying_type", .type = ecs_id(ecs_entity_t) }
+        }
+    });
+
+    ecs_struct_init(world, &(ecs_struct_desc_t){
         .entity = ecs_id(EcsArray),
         .members = {
             { .name = "type", .type = ecs_id(ecs_entity_t) },
@@ -49858,11 +50785,13 @@ static void flecs_constants_copy(
 static ECS_COPY(EcsEnum, dst, src, {
     flecs_constants_dtor(&dst->constants);
     flecs_constants_copy(&dst->constants, &src->constants);
+    dst->underlying_type = src->underlying_type;
 })
 
 static ECS_MOVE(EcsEnum, dst, src, {
     flecs_constants_dtor(&dst->constants);
     dst->constants = src->constants;
+    dst->underlying_type = src->underlying_type;
     ecs_os_zeromem(&src->constants);
 })
 
@@ -50293,6 +51222,36 @@ int flecs_add_constant_to_enum(
     ecs_id_t constant_id)
 {
     EcsEnum *ptr = ecs_ensure(world, type, EcsEnum);
+    ecs_entity_t ut = ptr->underlying_type;
+
+    /* It's possible that a constant is added to an entity that didn't have an
+     * Enum component yet. In that case derive the underlying type from the
+     * first constant. */
+    if (!ut) {
+        if (ecs_id_is_pair(constant_id)) {
+            ut = ptr->underlying_type = ecs_pair_second(world, constant_id);
+        } else {
+            /* Default to i32 */
+            ut = ecs_id(ecs_i32_t);
+        }
+    }
+
+    ecs_assert(ut != 0, ECS_INVALID_OPERATION, 
+        "missing underlying type for enum");
+
+    const EcsPrimitive *p = ecs_get(world, ut, EcsPrimitive);
+    if (!p) {
+        char *path = ecs_get_path(world, ut);
+        ecs_err("underlying type '%s' must be a primitive type", path);
+        ecs_os_free(path);
+        return -1;
+    }
+
+    bool ut_is_unsigned = false;
+    ecs_primitive_kind_t kind = p->kind;
+    if (kind == EcsU8 || kind == EcsU16 || kind == EcsU32 || kind == EcsU64) {
+        ut_is_unsigned = true;
+    }
 
     /* Remove constant from map if it was already added */
     ecs_map_iter_t it = ecs_map_iter(&ptr->constants);
@@ -50305,20 +51264,41 @@ int flecs_add_constant_to_enum(
     }
 
     /* Check if constant sets explicit value */
-    int32_t value = 0;
+    int64_t value = 0;
+    uint64_t value_unsigned = 0;
     bool value_set = false;
     if (ecs_id_is_pair(constant_id)) {
-        if (ecs_pair_second(world, constant_id) != ecs_id(ecs_i32_t)) {
+        ecs_value_t v = { .type = ut };
+        v.ptr = ecs_get_mut_id(world, e, ecs_pair(EcsConstant, ut));
+
+        if (!v.ptr) {
+            char *has_pair = ecs_id_str(world, constant_id);
+            char *expect_pair = ecs_id_str(world, ecs_pair(EcsConstant, ut));
             char *path = ecs_get_path(world, e);
-            ecs_err("expected i32 type for enum constant '%s'", path);
+            ecs_err(
+                "enum constant '%s' has incorrect value pair (expected %s, got %s)",
+                    path, expect_pair, has_pair);
+            ecs_os_free(path);
+            ecs_os_free(has_pair);
+            ecs_os_free(expect_pair);
+            return -1;
+        }
+
+        ecs_meta_cursor_t c;
+        if (ut_is_unsigned) {
+            /* It doesn't matter that the underlying value is an i64*/
+            c = ecs_meta_cursor(world, ecs_id(ecs_u64_t), &value_unsigned);
+        } else {
+            c = ecs_meta_cursor(world, ecs_id(ecs_i64_t), &value);
+        }
+
+        if (ecs_meta_set_value(&c, &v)) {
+            char *path = ecs_get_path(world, e);
+            ecs_err("failed to get constant value for '%s'", path);
             ecs_os_free(path);
             return -1;
         }
 
-        const int32_t *value_ptr = ecs_get_pair_second(
-            world, e, EcsConstant, ecs_i32_t);
-        ecs_assert(value_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
-        value = *value_ptr;
         value_set = true;
     }
 
@@ -50326,35 +51306,77 @@ int flecs_add_constant_to_enum(
     it = ecs_map_iter(&ptr->constants);
     while (ecs_map_next(&it)) {
         ecs_enum_constant_t *c = ecs_map_ptr(&it);
-        if (value_set) {
-            if (c->value == value) {
-                char *path = ecs_get_path(world, e);
-                ecs_err("conflicting constant value %d for '%s' (other is '%s')",
-                    value, path, c->name);
-                ecs_os_free(path);
-                return -1;
+        if (ut_is_unsigned) {
+            if (value_set) {
+                if (c->value_unsigned == value_unsigned) {
+                    char *path = ecs_get_path(world, e);
+                    ecs_abort(ECS_INTERNAL_ERROR, 
+                        "conflicting constant value %u for '%s' (other is '%s')",
+                        value_unsigned, path, c->name);
+                    ecs_os_free(path);
+                    
+                    return -1;
+                }
+            } else {
+                if (c->value_unsigned >= value_unsigned) {
+                    value_unsigned = c->value_unsigned + 1;
+                }
             }
         } else {
-            if (c->value >= value) {
-                value = c->value + 1;
+            if (value_set) {
+                if (c->value == value) {
+                    char *path = ecs_get_path(world, e);
+                    ecs_err("conflicting constant value %d for '%s' (other is '%s')",
+                        value, path, c->name);
+                    ecs_os_free(path);
+                    flecs_dump_backtrace(stdout);
+                    return -1;
+                }
+            } else {
+                if (c->value >= value) {
+                    value = c->value + 1;
+                }
             }
         }
     }
 
     ecs_map_init_if(&ptr->constants, &world->allocator);
-    ecs_enum_constant_t *c = ecs_map_insert_alloc_t(&ptr->constants, 
-        ecs_enum_constant_t, (ecs_map_key_t)value);
+    ecs_enum_constant_t *c;
+    if (ut_is_unsigned) {
+        c = ecs_map_insert_alloc_t(&ptr->constants, 
+            ecs_enum_constant_t, value_unsigned);
+        c->value_unsigned = value_unsigned;
+        c->value = 0;
+    } else {
+        c = ecs_map_insert_alloc_t(&ptr->constants, 
+            ecs_enum_constant_t, (ecs_map_key_t)value);
+        c->value_unsigned = 0;
+        c->value = value;
+
+    }
     c->name = ecs_os_strdup(ecs_get_name(world, e));
-    c->value = value;
     c->constant = e;
 
-    ecs_i32_t *cptr = ecs_ensure_pair_second(
-        world, e, EcsConstant, ecs_i32_t);
-    ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
-    cptr[0] = value;
-
-    cptr = ecs_ensure_id(world, e, type);
-    cptr[0] = value;
+    if (!value_set) {
+        void *cptr = ecs_ensure_id(world, e, ecs_pair(EcsConstant, ut));
+        ecs_assert(cptr != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, ut, cptr);
+        if (ut_is_unsigned) {
+            if (ecs_meta_set_uint(&cur, value_unsigned)) {
+                char *path = ecs_get_path(world, e);
+                ecs_err("failed to assign value to constant '%s'", path);
+                ecs_os_free(path);
+                return -1;
+            }
+        } else {
+            if (ecs_meta_set_int(&cur, value)) {
+                char *path = ecs_get_path(world, e);
+                ecs_err("failed to assign value to constant '%s'", path);
+                ecs_os_free(path);
+                return -1;
+            }
+        }
+    }
 
     ecs_modified(world, type, EcsEnum);
     return 0;
@@ -50545,11 +51567,26 @@ static
 void flecs_add_enum(ecs_iter_t *it) {
     ecs_world_t *world = it->world;
 
+    EcsEnum *data = ecs_field(it, EcsEnum, 0);
+
     int i, count = it->count;
     for (i = 0; i < count; i ++) {
         ecs_entity_t e = it->entities[i];
+        ecs_entity_t underlying_type = data[i].underlying_type;
 
-        if (init_type_t(world, e, EcsEnumType, ecs_i32_t)) {
+        if (!underlying_type) {
+            underlying_type = data[i].underlying_type = ecs_id(ecs_i32_t);
+        }
+
+        const EcsComponent *uc = ecs_get(world, underlying_type, EcsComponent);
+        if (!uc) {
+            char *str = ecs_get_path(world, underlying_type);
+            ecs_err("uderlying_type entity for enum '%s' is not a type", str);
+            ecs_os_free(str);
+            continue;
+        }
+
+        if (flecs_init_type(world, e, EcsEnumType, uc->size, uc->alignment)) {
             continue;
         }
 
@@ -50664,6 +51701,7 @@ void flecs_set_custom_type(ecs_iter_t *it) {
         if (!comp || !comp->size || !comp->alignment) {
             ecs_err("custom type '%s' has no size/alignment, register as component first",
                 ecs_get_name(world, e));
+            flecs_dump_backtrace(stdout);
             continue;
         }
 
@@ -51044,7 +52082,7 @@ void FlecsMetaImport(
 
     ecs_observer(world, {
         .query.terms[0] = { .id = ecs_id(EcsEnum) },
-        .events = {EcsOnAdd},
+        .events = {EcsOnSet},
         .callback = flecs_add_enum
     });
 
@@ -51150,7 +52188,7 @@ void FlecsMetaImport(
         .dtor = ecs_dtor(ecs_string_t)
     });
 
-    /* Set default child components */
+    /* Set default child components. Can be used as hint by deserializers */
     ecs_set(world, ecs_id(EcsStruct),  EcsDefaultChildComponent, {ecs_id(EcsMember)});
     ecs_set(world, ecs_id(EcsMember),  EcsDefaultChildComponent, {ecs_id(EcsMember)});
     ecs_set(world, ecs_id(EcsEnum),    EcsDefaultChildComponent, {EcsConstant});
@@ -51370,6 +52408,7 @@ static
 ecs_rtt_struct_ctx_t * flecs_rtt_configure_struct_hooks(
     ecs_world_t *world,
     const ecs_type_info_t *ti,
+    ecs_flags32_t flags,
     bool ctor,
     bool dtor,
     bool move,
@@ -51406,6 +52445,8 @@ ecs_rtt_struct_ctx_t * flecs_rtt_configure_struct_hooks(
         hooks.lifecycle_ctx = NULL;
         hooks.lifecycle_ctx_free = NULL;
     }
+    hooks.flags |= flags;
+    hooks.flags &= ECS_TYPE_HOOKS_ILLEGAL;
     ecs_set_hooks_id(world, ti->component, &hooks);
     return rtt_ctx;
 }
@@ -51434,6 +52475,7 @@ void flecs_rtt_init_default_hooks_struct(
      * the struct itself will need to have that hook: */
     int i, member_count = ecs_vec_count(&struct_info->members);
     ecs_member_t *members = ecs_vec_first(&struct_info->members);
+    ecs_flags32_t flags = 0;
     for (i = 0; i < member_count; i++) {
         ecs_member_t *m = &members[i];
         const ecs_type_info_t *member_ti = ecs_get_type_info(world, m->type);
@@ -51442,6 +52484,7 @@ void flecs_rtt_init_default_hooks_struct(
         dtor_hook_required |= member_ti->hooks.dtor != NULL;
         move_hook_required |= member_ti->hooks.move != NULL;
         copy_hook_required |= member_ti->hooks.copy != NULL;
+        flags |= member_ti->hooks.flags;
     }
 
     /* If any hook is required, then create a lifecycle context and configure a
@@ -51449,6 +52492,7 @@ void flecs_rtt_init_default_hooks_struct(
     ecs_rtt_struct_ctx_t *rtt_ctx = flecs_rtt_configure_struct_hooks(
         world,
         ti,
+        flags,
         ctor_hook_required,
         dtor_hook_required,
         move_hook_required,
@@ -51621,22 +52665,27 @@ void flecs_rtt_init_default_hooks_array(
     bool dtor_hook_required = array_ti->hooks.dtor != NULL;
     bool move_hook_required = array_ti->hooks.move != NULL;
     bool copy_hook_required = array_ti->hooks.copy != NULL;
+    ecs_flags32_t flags = array_ti->hooks.flags;
 
-    if (!ctor_hook_required && !dtor_hook_required && !move_hook_required &&
-        !copy_hook_required) {
-        return; /* no hooks required */
-    }
-
-    ecs_rtt_array_ctx_t *rtt_ctx = ecs_os_malloc_t(ecs_rtt_array_ctx_t);
-    rtt_ctx->type_info = array_ti;
-    rtt_ctx->elem_count = array_info->count;
     ecs_type_hooks_t hooks = *ecs_get_hooks_id(world, component);
+
     if (hooks.lifecycle_ctx_free) {
         hooks.lifecycle_ctx_free(hooks.lifecycle_ctx);
+        hooks.lifecycle_ctx_free = NULL;
     }
 
-    hooks.lifecycle_ctx = rtt_ctx;
-    hooks.lifecycle_ctx_free = flecs_rtt_free_lifecycle_array_ctx;
+    if (ctor_hook_required || dtor_hook_required || move_hook_required ||
+        copy_hook_required) {
+        ecs_rtt_array_ctx_t *rtt_ctx = ecs_os_malloc_t(ecs_rtt_array_ctx_t);
+        rtt_ctx->type_info = array_ti;
+        rtt_ctx->elem_count = array_info->count;
+        if (hooks.lifecycle_ctx_free) {
+            hooks.lifecycle_ctx_free(hooks.lifecycle_ctx);
+        }
+
+        hooks.lifecycle_ctx = rtt_ctx;
+        hooks.lifecycle_ctx_free = flecs_rtt_free_lifecycle_array_ctx;
+    }
 
     if (ctor_hook_required) {
         hooks.ctor = flecs_rtt_array_ctor;
@@ -51654,6 +52703,8 @@ void flecs_rtt_init_default_hooks_array(
         hooks.copy = flecs_rtt_array_copy;
     }
 
+    hooks.flags |= flags;
+    hooks.flags &= ECS_TYPE_HOOKS_ILLEGAL;
     ecs_set_hooks_id(world, component, &hooks);
 }
 
@@ -51791,6 +52842,7 @@ void flecs_rtt_init_default_hooks_vector(
     hooks.dtor = flecs_rtt_vector_dtor;
     hooks.move = flecs_rtt_vector_move;
     hooks.copy = flecs_rtt_vector_copy;
+    hooks.flags &= ECS_TYPE_HOOKS_ILLEGAL;
     ecs_set_hooks_id(world, component, &hooks);
 }
 
@@ -51837,10 +52889,9 @@ void flecs_rtt_init_default_hooks(
          * could cause serializers to crash when for example inspecting string
          * fields. */
         if (!ti || !ti->hooks.ctor) {
-            ecs_set_hooks_id(
-                world,
-                component,
-                &(ecs_type_hooks_t){.ctor = flecs_default_ctor});
+            ecs_set_hooks_id(world, component, &(ecs_type_hooks_t){
+                .ctor = flecs_default_ctor
+            });
         }
     }
 }
@@ -54046,8 +55097,6 @@ bool ecs_using_task_threads(
 
 #ifdef FLECS_SCRIPT
 
-#define flecs_ast_strdup(parser, str)\
-    (str ? flecs_strdup(&parser->script->allocator, str) : NULL)
 #define flecs_ast_new(parser, T, kind)\
     (T*)flecs_ast_new_(parser, ECS_SIZEOF(T), kind)
 #define flecs_ast_vec(parser, vec, T) \
@@ -54063,7 +55112,8 @@ void* flecs_ast_new_(
 {
     ecs_assert(parser->script != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_allocator_t *a = &parser->script->allocator;
-    ecs_script_node_t *result = flecs_calloc(a, size);
+    ecs_script_node_t *result = flecs_calloc_w_dbg_info(
+        a, size, "ecs_script_node_t");
     result->kind = kind;
     result->pos = parser->pos;
     return result;
@@ -54075,6 +55125,7 @@ ecs_script_scope_t* flecs_script_scope_new(
     ecs_script_scope_t *result = flecs_ast_new(
         parser, ecs_script_scope_t, EcsAstScope);
     flecs_ast_vec(parser, result->stmts, ecs_script_node_t);
+    ecs_vec_init_t(NULL, &result->components, ecs_id_t, 0);
     return result;
 }
 
@@ -54091,12 +55142,14 @@ ecs_script_scope_t* flecs_script_insert_scope(
     ecs_assert(scope != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_script_scope_t *result = flecs_script_scope_new(parser);
     flecs_ast_append(parser, scope->stmts, ecs_script_scope_t, result);
+    ecs_vec_init_t(NULL, &result->components, ecs_id_t, 0);
     return result;
 }
 
 ecs_script_entity_t* flecs_script_insert_entity(
     ecs_script_parser_t *parser,
-    const char *name)
+    const char *name,
+    bool name_is_expr)
 {
     ecs_script_scope_t *scope = parser->scope;
     ecs_assert(scope != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -54110,12 +55163,24 @@ ecs_script_entity_t* flecs_script_insert_entity(
 
     result->name = name;
 
+    if (name_is_expr) {
+        parser->significant_newline = false;
+        result->name_expr = (ecs_expr_node_t*)
+            flecs_expr_interpolated_string(parser, name);
+        if (!result->name_expr) {
+            goto error;
+        }
+        parser->significant_newline = true;
+    }
+
     ecs_script_scope_t *entity_scope = flecs_script_scope_new(parser);
     ecs_assert(entity_scope != NULL, ECS_INTERNAL_ERROR, NULL);
     result->scope = entity_scope;
 
     flecs_ast_append(parser, scope->stmts, ecs_script_entity_t, result);
     return result;
+error:
+    return NULL;
 }
 
 static
@@ -54127,6 +55192,8 @@ void flecs_script_set_id(
     ecs_assert(first != NULL, ECS_INTERNAL_ERROR, NULL);
     id->first = first;
     id->second = second;
+    id->first_sp = -1;
+    id->second_sp = -1;
 }
 
 ecs_script_pair_scope_t* flecs_script_insert_pair_scope(
@@ -54218,6 +55285,7 @@ ecs_script_var_component_t* flecs_script_insert_var_component(
     ecs_script_var_component_t *result = flecs_ast_new(
             parser, ecs_script_var_component_t, EcsAstVarComponent);
     result->name = var_name;
+    result->sp = -1;
 
     flecs_ast_append(parser, scope->stmts, 
         ecs_script_var_component_t, result);
@@ -54336,1944 +55404,877 @@ ecs_script_if_t* flecs_script_insert_if(
     return result;
 }
 
+ecs_script_for_range_t* flecs_script_insert_for_range(
+    ecs_script_parser_t *parser)
+{
+    ecs_script_scope_t *scope = parser->scope;
+    ecs_assert(scope != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_script_for_range_t *result = flecs_ast_new(
+        parser, ecs_script_for_range_t, EcsAstFor);
+    result->scope = flecs_script_scope_new(parser);
+
+    flecs_ast_append(parser, scope->stmts, ecs_script_for_range_t, result);
+    return result;
+}
+
 #endif
 
 /**
- * @file addons/script/expr.c
- * @brief Evaluate script expressions.
+ * @file addons/script/function.c
+ * @brief Script function API.
  */
 
 
 #ifdef FLECS_SCRIPT
-#include <ctype.h>
+
+static
+void ecs_script_params_free(ecs_vec_t *params) {
+    ecs_script_parameter_t *array = ecs_vec_first(params);
+    int32_t i, count = ecs_vec_count(params);
+    for (i = 0; i < count; i ++) {
+        /* Safe, component owns string */
+        ecs_os_free(ECS_CONST_CAST(char*, array[i].name));
+    }
+    ecs_vec_fini_t(NULL, params, ecs_script_parameter_t);
+}
+
+static
+ECS_MOVE(EcsScriptConstVar, dst, src, {
+    if (dst->type_info->hooks.dtor) {
+        dst->type_info->hooks.dtor(dst->value.ptr, 1, dst->type_info);
+    }
+
+    ecs_os_free(dst->value.ptr);
+    
+    *dst = *src;
+
+    src->value.ptr = NULL;
+    src->value.type = 0;
+    src->type_info = NULL;
+})
+
+static
+ECS_DTOR(EcsScriptConstVar, ptr, {
+    if (ptr->type_info->hooks.dtor) {
+        ptr->type_info->hooks.dtor(ptr->value.ptr, 1, ptr->type_info);
+    }
+    ecs_os_free(ptr->value.ptr);
+})
+
+static
+ECS_MOVE(EcsScriptFunction, dst, src, {
+    ecs_script_params_free(&dst->params);
+    *dst = *src;
+    ecs_os_zeromem(src);
+})
+
+static
+ECS_DTOR(EcsScriptFunction, ptr, {
+    ecs_script_params_free(&ptr->params);
+})
+
+static
+ECS_MOVE(EcsScriptMethod, dst, src, {
+    ecs_script_params_free(&dst->params);
+    *dst = *src;
+    ecs_os_zeromem(src);
+})
+
+static
+ECS_DTOR(EcsScriptMethod, ptr, {
+    ecs_script_params_free(&ptr->params);
+})
+
+ecs_entity_t ecs_const_var_init(
+    ecs_world_t *world,
+    ecs_const_var_desc_t *desc)
+{
+    flecs_poly_assert(world, ecs_world_t);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->name != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->type != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->value != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    const ecs_type_info_t *ti = ecs_get_type_info(world, desc->type);
+    ecs_check(ti != NULL, ECS_INVALID_PARAMETER, 
+        "ecs_const_var_desc_t::type is not a valid type");
+
+    ecs_entity_t result = ecs_entity(world, { 
+        .name = desc->name,
+        .parent = desc->parent
+    });
+
+    if (!result) {
+        goto error;
+    }
+
+    EcsScriptConstVar *v = ecs_ensure(world, result, EcsScriptConstVar);
+    v->value.ptr = ecs_os_malloc(ti->size);
+    v->value.type = desc->type;
+    v->type_info = ti;
+    ecs_value_init(world, desc->type, v->value.ptr);
+    ecs_value_copy(world, desc->type, v->value.ptr, desc->value);
+    ecs_modified(world, result, EcsScriptConstVar);
+
+    return result;
+error:
+    return 0;
+}
+
+ecs_entity_t ecs_function_init(
+    ecs_world_t *world,
+    const ecs_function_desc_t *desc)
+{
+    flecs_poly_assert(world, ecs_world_t);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->name != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->return_type != 0, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_entity_t result = ecs_entity(world, { 
+        .name = desc->name,
+        .parent = desc->parent
+    });
+
+    if (!result) {
+        goto error;
+    }
+
+    EcsScriptFunction *f = ecs_ensure(world, result, EcsScriptFunction);
+    f->return_type = desc->return_type;
+    f->callback = desc->callback;
+    f->ctx = desc->ctx;
+
+    int32_t i;
+    for (i = 0; i < FLECS_SCRIPT_FUNCTION_ARGS_MAX; i ++) {
+        if (!desc->params[i].name) {
+            break;
+        }
+
+        if (!i) {
+            ecs_vec_init_t(NULL, &f->params, ecs_script_parameter_t, 0);
+        }
+
+        ecs_script_parameter_t *p = ecs_vec_append_t(
+            NULL, &f->params, ecs_script_parameter_t);
+        p->type = desc->params[i].type;
+        p->name = ecs_os_strdup(desc->params[i].name);
+    }
+
+    ecs_modified(world, result, EcsScriptFunction);
+
+    return result;
+error:
+    return 0;
+}
+
+ecs_entity_t ecs_method_init(
+    ecs_world_t *world,
+    const ecs_function_desc_t *desc)
+{
+    flecs_poly_assert(world, ecs_world_t);
+    ecs_check(desc != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->name != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->callback != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->parent != 0, ECS_INVALID_PARAMETER, NULL);
+    ecs_check(desc->return_type != 0, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_entity_t result = ecs_entity(world, { 
+        .name = desc->name,
+        .parent = desc->parent
+    });
+
+    if (!result) {
+        goto error;
+    }
+
+    EcsScriptMethod *f = ecs_ensure(world, result, EcsScriptMethod);
+    f->return_type = desc->return_type;
+    f->callback = desc->callback;
+    f->ctx = desc->ctx;
+
+    int32_t i;
+    for (i = 0; i < FLECS_SCRIPT_FUNCTION_ARGS_MAX; i ++) {
+        if (!desc->params[i].name) {
+            break;
+        }
+
+        if (!i) {
+            ecs_vec_init_t(NULL, &f->params, ecs_script_parameter_t, 0);
+        }
+
+        ecs_script_parameter_t *p = ecs_vec_append_t(
+            NULL, &f->params, ecs_script_parameter_t);
+        p->type = desc->params[i].type;
+        p->name = ecs_os_strdup(desc->params[i].name);
+    }
+
+    ecs_modified(world, result, EcsScriptMethod);
+
+    return result;
+error:
+    return 0;
+}
+
+void flecs_function_import(
+    ecs_world_t *world)
+{
+    ecs_set_name_prefix(world, "EcsScript");
+    ECS_COMPONENT_DEFINE(world, EcsScriptConstVar);
+    ECS_COMPONENT_DEFINE(world, EcsScriptFunction);
+    ECS_COMPONENT_DEFINE(world, EcsScriptMethod);
+
+    ecs_struct(world, {
+        .entity = ecs_id(EcsScriptFunction),
+        .members = {
+            { .name = "return_type", .type = ecs_id(ecs_entity_t) }
+        }
+    });
+
+    ecs_struct(world, {
+        .entity = ecs_id(EcsScriptMethod),
+        .members = {
+            { .name = "return_type", .type = ecs_id(ecs_entity_t) }
+        }
+    });
+
+    ecs_set_hooks(world, EcsScriptConstVar, {
+        .ctor = flecs_default_ctor,
+        .dtor = ecs_dtor(EcsScriptConstVar),
+        .move = ecs_move(EcsScriptConstVar),
+        .flags = ECS_TYPE_HOOK_COPY_ILLEGAL
+    });
+
+    ecs_set_hooks(world, EcsScriptFunction, {
+        .ctor = flecs_default_ctor,
+        .dtor = ecs_dtor(EcsScriptFunction),
+        .move = ecs_move(EcsScriptFunction),
+        .flags = ECS_TYPE_HOOK_COPY_ILLEGAL
+    });
+
+    ecs_set_hooks(world, EcsScriptMethod, {
+        .ctor = flecs_default_ctor,
+        .dtor = ecs_dtor(EcsScriptMethod),
+        .move = ecs_move(EcsScriptMethod),
+        .flags = ECS_TYPE_HOOK_COPY_ILLEGAL
+    });
+
+    flecs_script_register_builtin_functions(world);
+}
+
+#endif
+
+/**
+ * @file addons/script/builtin_functions.c
+ * @brief Flecs functions for flecs script.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+void flecs_meta_entity_name(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result) 
+{
+    (void)argc;
+    ecs_entity_t entity = *(ecs_entity_t*)argv[0].ptr;
+    *(char**)result->ptr = ecs_os_strdup(ecs_get_name(ctx->world, entity));
+}
+
+static
+void flecs_meta_entity_path(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result) 
+{
+    (void)argc;
+    ecs_entity_t entity = *(ecs_entity_t*)argv[0].ptr;
+    *(char**)result->ptr = ecs_get_path(ctx->world, entity);
+}
+
+static
+void flecs_meta_entity_parent(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result) 
+{
+    (void)argc;
+    ecs_entity_t entity = *(ecs_entity_t*)argv[0].ptr;
+    *(ecs_entity_t*)result->ptr = ecs_get_parent(ctx->world, entity);
+}
+
+static
+void flecs_meta_entity_has(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result) 
+{
+    (void)argc;
+    ecs_entity_t entity = *(ecs_entity_t*)argv[0].ptr;
+    ecs_id_t id = *(ecs_id_t*)argv[1].ptr;
+    *(ecs_bool_t*)result->ptr = ecs_has_id(ctx->world, entity, id);
+}
+
+static
+void flecs_meta_core_pair(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result) 
+{
+    (void)argc;
+    (void)ctx;
+    ecs_entity_t first = *(ecs_entity_t*)argv[0].ptr;
+    ecs_entity_t second = *(ecs_entity_t*)argv[1].ptr;
+    *(ecs_id_t*)result->ptr = ecs_pair(first, second);
+}
+
+#ifdef FLECS_DOC
+
+#define FLECS_DOC_FUNC(name)\
+    static\
+    void flecs_meta_entity_doc_##name(\
+        const ecs_function_ctx_t *ctx,\
+        int32_t argc,\
+        const ecs_value_t *argv,\
+        ecs_value_t *result)\
+    {\
+        (void)argc;\
+        ecs_entity_t entity = *(ecs_entity_t*)argv[0].ptr;\
+        *(char**)result->ptr = \
+            ecs_os_strdup(ecs_doc_get_##name(ctx->world, entity));\
+    }
+
+FLECS_DOC_FUNC(name)
+FLECS_DOC_FUNC(uuid)
+FLECS_DOC_FUNC(brief)
+FLECS_DOC_FUNC(detail)
+FLECS_DOC_FUNC(link)
+FLECS_DOC_FUNC(color)
+
+#undef FLECS_DOC_FUNC
+
+static
+void flecs_script_register_builtin_doc_functions(
+    ecs_world_t *world)
+{
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_name",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_name
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc name");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_uuid",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_uuid
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc uuid");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_brief",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_brief
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc brief description");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_detail",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_detail
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc detailed description");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_link",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_link
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc link");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "doc_color",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_doc_color
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity doc color");
+    }
+}
+
+#else
+
+static
+void flecs_script_register_builtin_doc_functions(
+    ecs_world_t *world)
+{
+    (void)world;
+}
+
+#endif
+
+void flecs_script_register_builtin_functions(
+    ecs_world_t *world)
+{
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "name",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_name
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity name");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "path",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_string_t),
+            .callback = flecs_meta_entity_path
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity path");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "parent",
+            .parent = ecs_id(ecs_entity_t),
+            .return_type = ecs_id(ecs_entity_t),
+            .callback = flecs_meta_entity_parent
+        });
+
+        ecs_doc_set_brief(world, m, "Returns entity parent");
+    }
+
+    {
+        ecs_entity_t m = ecs_method(world, {
+            .name = "has",
+            .parent = ecs_id(ecs_entity_t),
+            .params = {
+                { .name = "component", .type = ecs_id(ecs_id_t) }
+            },
+            .return_type = ecs_id(ecs_bool_t),
+            .callback = flecs_meta_entity_has
+        });
+
+        ecs_doc_set_brief(world, m, "Returns whether entity has component");
+    }
+
+    {
+        ecs_entity_t m = ecs_function(world, {
+            .name = "pair",
+            .parent = ecs_entity(world, { .name = "core"}),
+            .params = {
+                { .name = "first", .type = ecs_id(ecs_entity_t) },
+                { .name = "second", .type = ecs_id(ecs_entity_t) }
+            },
+            .return_type = ecs_id(ecs_id_t),
+            .callback = flecs_meta_core_pair
+        });
+
+        ecs_doc_set_brief(world, m, "Returns a pair identifier");
+    }
+
+    flecs_script_register_builtin_doc_functions(world);
+}
+
+#endif
+
+/**
+ * @file addons/script/functions_math.c
+ * @brief Math functions for flecs script.
+ */
+
+
+#ifdef FLECS_SCRIPT_MATH
 #include <math.h>
 
-/* String deserializer for script expressions */
-
-/* Order in enumeration is important, as it is used for precedence */
-typedef enum ecs_expr_oper_t {
-    EcsExprOperUnknown,
-    EcsLeftParen,
-    EcsCondAnd,
-    EcsCondOr,
-    EcsCondEq,
-    EcsCondNeq,
-    EcsCondGt,
-    EcsCondGtEq,
-    EcsCondLt,
-    EcsCondLtEq,
-    EcsShiftLeft,
-    EcsShiftRight,
-    EcsAdd,
-    EcsSub,
-    EcsMul,
-    EcsDiv,
-    EcsMin
-} ecs_expr_oper_t;
-
-/* Used to track temporary values */
-#define FLECS_EXPR_MAX_STACK_SIZE (256)
-
-typedef struct ecs_expr_value_t {
-    const ecs_type_info_t *ti;
-    void *ptr;
-} ecs_expr_value_t;
-
-typedef struct ecs_value_stack_t {
-    ecs_expr_value_t values[FLECS_EXPR_MAX_STACK_SIZE];
-    ecs_stack_cursor_t *cursor;
-    ecs_stack_t *stack;
-    ecs_stage_t *stage;
-    int32_t count;
-} ecs_value_stack_t;
+typedef struct ecs_script_rng_t {
+    uint64_t x; /* Current state (initialize with seed) */
+    uint64_t w; /* Weyl sequence increment */
+    uint64_t s; /* Constant for Weyl sequence */
+    int32_t refcount; /* Necessary as flecs script doesn't have ref types */
+    bool initialized;
+} ecs_script_rng_t;
 
 static
-const char* flecs_script_expr_run(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *ptr,
-    ecs_value_t *value,
-    ecs_expr_oper_t op,
-    const ecs_script_expr_run_desc_t *desc);
-
-#define TOK_VARIABLE '$'
-
-/* -- Private functions -- */
-
-static
-bool flecs_isident(
-    char ch)
-{
-    return isalpha(ch) || (ch == '_');
-}
-
-static
-bool flecs_valid_identifier_start_char(
-    char ch)
-{
-    if (ch && (flecs_isident(ch) || (ch == '*') ||
-        (ch == '0') || (ch == TOK_VARIABLE) || isdigit(ch))) 
-    {
-        return true;
-    }
-
-    return false;
-}
-
-static
-bool flecs_valid_token_start_char(
-    char ch)
-{
-    if ((ch == '"') || (ch == '{') || (ch == '}') || (ch == ',') || (ch == '-')
-        || (ch == '[') || (ch == ']') || (ch == '`') || 
-        flecs_valid_identifier_start_char(ch))
-    {
-        return true;
-    }
-
-    return false;
-}
-
-static
-bool flecs_valid_token_char(
-    char ch)
-{
-    if (ch && (flecs_isident(ch) || isdigit(ch) || ch == '.' || ch == '"')) {
-        return true;
-    }
-
-    return false;
-}
-
-static
-const char* flecs_parse_ws(
-    const char *ptr)
-{
-    while ((*ptr != '\n') && isspace(*ptr)) {
-        ptr ++;
-    }
-
-    return ptr;
-}
-
-static
-const char* flecs_parse_expr_token(
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    char *token_out,
-    char delim)
-{
-    int64_t column = ptr - expr;
-
-    ptr = flecs_parse_ws(ptr);
-    char *tptr = token_out, ch = ptr[0];
-
-    if (!flecs_valid_token_start_char(ch)) {
-        if (ch == '\0' || ch == '\n') {
-            ecs_parser_error(name, expr, column, 
-                "unexpected end of expression");
-        } else {
-            ecs_parser_error(name, expr, column, 
-                "invalid start of token '%s'", ptr);
-        }
-        return NULL;
-    }
-
-    bool isDigit = isdigit(ch) || (ch == '-');
-
-    if (ch == '-') {
-        if (!isdigit(ptr[1]) && ptr[1] != '$' && ptr[1] != '(') {
-            ecs_parser_error(name, expr, column,
-                "invalid number token");
-            return NULL;
-        }
-        if (ptr[1] == '$' || ptr[1] == '(') {
-            isDigit = false; /* -$var */
-        }
-    }
-
-    bool hasDot = false;
-    bool hasE = false;
-
-    tptr[0] = ch;
-    tptr ++;
-    ptr ++;
-
-    if (ch == '{' || ch == '}' || ch == '[' || ch == ']' || ch == ',' || ch == '`') {
-        tptr[0] = 0;
-        return ptr;
-    }
-
-    int tmpl_nesting = 0;
-    bool in_str = ch == '"';
-
-    for (; (ch = *ptr); ptr ++) {
-        if (ch == '<') {
-            tmpl_nesting ++;
-        } else if (ch == '>') {
-            if (!tmpl_nesting) {
-                break;
-            }
-            tmpl_nesting --;
-        } else if (ch == '"') {
-            in_str = !in_str;
-        } else if (ch == '\\') {
-            ptr ++;
-            tptr[0] = ptr[0];
-            tptr ++;
-            continue;
-        } else if (!flecs_valid_token_char(ch) && !in_str) {
-            break;
-        }
-
-        if (isDigit) {
-            if (!isdigit(ch) && (ch != '.') && (ch != 'e')) {
-                ecs_parser_error(name, expr, column, "invalid token");
-                return NULL;
-            }
-            if (ch == '.') {
-                if (hasDot) {
-                    ecs_parser_error(name, expr, column, "invalid token");
-                    return NULL;
-                }
-                hasDot = true;
-            }
-            if (ch == 'e') {
-                if (hasE) {
-                    ecs_parser_error(name, expr, column, "invalid token");
-                    return NULL;
-                }
-                hasE = true;
-            }
-        }
-
-        if (delim && (ch == delim)) {
-            break;
-        }
-
-        tptr[0] = ch;
-        tptr ++;
-    }
-
-    tptr[0] = '\0';
-
-    if (tmpl_nesting != 0) {
-        ecs_parser_error(name, expr, column, 
-            "identifier '%s' has mismatching < > pairs", ptr);
-        return NULL;
-    }
-
-    const char *next_ptr = flecs_parse_ws(ptr);
-    if (next_ptr[0] == ':' && next_ptr != ptr) {
-        /* Whitespace between token and : is significant */
-        ptr = next_ptr - 1;
-    } else {
-        ptr = next_ptr;
-    }
-
-    return ptr;
-}
-
-static
-void* flecs_expr_value_new(
-    ecs_value_stack_t *stack,
-    ecs_entity_t type)
-{
-    ecs_stage_t *stage = stack->stage;
-    ecs_world_t *world = stage->world;
-    ecs_id_record_t *idr = flecs_id_record_get(world, type);
-    if (!idr) {
-        return NULL;
-    }
-
-    const ecs_type_info_t *ti = idr->type_info;
-    if (!ti) {
-        return NULL;
-    }
-
-    ecs_assert(ti->size != 0, ECS_INTERNAL_ERROR, NULL);
-    void *result = flecs_stack_alloc(stack->stack, ti->size, ti->alignment);
-    if (ti->hooks.ctor) {
-        ti->hooks.ctor(result, 1, ti);
-    } else {
-        ecs_os_memset(result, 0, ti->size);
-    }
-    if (ti->hooks.dtor) {
-        /* Track values that have destructors */
-        stack->values[stack->count].ti = ti;
-        stack->values[stack->count].ptr = result;
-        stack->count ++;
-    }
-
+ecs_script_rng_t* flecs_script_rng_new(void) {
+    ecs_script_rng_t *result = ecs_os_calloc_t(ecs_script_rng_t);
+    result->x = 0;
+    result->w = 0;
+    result->s = 0xb5ad4eceda1ce2a9; /* Constant for the Weyl sequence */
+    result->refcount = 1;
+    result->initialized = false;
     return result;
 }
 
 static
-const char* flecs_str_to_expr_oper(
-    const char *str,
-    ecs_expr_oper_t *op)
-{
-    if (!ecs_os_strncmp(str, "+", 1)) {
-        *op = EcsAdd;
-        return str + 1;
-    } else if (!ecs_os_strncmp(str, "-", 1)) {
-        *op = EcsSub;
-        return str + 1;
-    } else if (!ecs_os_strncmp(str, "*", 1)) {
-        *op = EcsMul;
-        return str + 1;
-    } else if (!ecs_os_strncmp(str, "/", 1)) {
-        *op = EcsDiv;
-        return str + 1;
-    } else if (!ecs_os_strncmp(str, "&&", 2)) {
-        *op = EcsCondAnd;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, "||", 2)) {
-        *op = EcsCondOr;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, "==", 2)) {
-        *op = EcsCondEq;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, "!=", 2)) {
-        *op = EcsCondNeq;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, ">=", 2)) {
-        *op = EcsCondGtEq;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, "<=", 2)) {
-        *op = EcsCondLtEq;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, ">>", 2)) {
-        *op = EcsShiftRight;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, "<<", 2)) {
-        *op = EcsShiftLeft;
-        return str + 2;
-    } else if (!ecs_os_strncmp(str, ">", 1)) {
-        *op = EcsCondGt;
-        return str + 1;
-    } else if (!ecs_os_strncmp(str, "<", 1)) {
-        *op = EcsCondLt;
-        return str + 1;
-    }
-
-    *op = EcsExprOperUnknown;
-    return NULL;
-}
-
-static
-const char *flecs_script_expr_parse_token(
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    char *token)
-{
-    char *token_ptr = token;
-
-    if (ptr[0] == '/') {
-        char ch;
-        if (ptr[1] == '/') {
-            // Single line comment
-            for (ptr = &ptr[2]; (ch = ptr[0]) && (ch != '\n'); ptr ++) {}
-            token[0] = 0;
-            return flecs_parse_ws_eol(ptr);
-        } else if (ptr[1] == '*') {
-            // Multi line comment
-            for (ptr = &ptr[2]; (ch = ptr[0]); ptr ++) {
-                if (ch == '*' && ptr[1] == '/') {
-                    token[0] = 0;
-                    return flecs_parse_ws_eol(ptr + 2);
-                }
-            }
-
-            ecs_parser_error(name, expr, ptr - expr, 
-                "missing */ for multiline comment");
-            return NULL;
-        }
-    }
-
-    ecs_expr_oper_t op;
-    if (ptr[0] == '(') {
-        token[0] = '(';
-        token[1] = 0;
-        return ptr + 1;
-    } else if (ptr[0] != '-') {
-        const char *tptr = flecs_str_to_expr_oper(ptr, &op);
-        if (tptr) {
-            ecs_os_strncpy(token, ptr, tptr - ptr);
-            return tptr;
-        }
-    }
-
-    while ((ptr = flecs_parse_expr_token(name, expr, ptr, token_ptr, 0))) {
-        if (ptr[0] == '|' && ptr[1] != '|') {
-            token_ptr = &token_ptr[ecs_os_strlen(token_ptr)];
-            token_ptr[0] = '|';
-            token_ptr[1] = '\0';
-            token_ptr ++;
-            ptr ++;
-        } else {
-            break;
-        }
-    }
-
-    return ptr;
-}
-
-static
-const char* flecs_parse_multiline_string(
-    ecs_meta_cursor_t *cur,
-    const char *name,
-    const char *expr,
-    const char *ptr)
-{
-    /* Multiline string */
-    ecs_strbuf_t str = ECS_STRBUF_INIT;
-    char ch;
-    while ((ch = ptr[0]) && (ch != '`')) {
-        if (ch == '\\' && ptr[1] == '`') {
-            ch = '`';
-            ptr ++;
-        }
-        ecs_strbuf_appendch(&str, ch);
-        ptr ++;
-    }
-    
-    if (ch != '`') {
-        ecs_parser_error(name, expr, ptr - expr, 
-            "missing '`' to close multiline string");
-        goto error;
-    }
-
-    char *strval = ecs_strbuf_get(&str);
-    if (ecs_meta_set_string(cur, strval) != 0) {
-        ecs_os_free(strval);
-        goto error;
-    }
-    ecs_os_free(strval);
-
-    return ptr + 1;
-error:
-    return NULL;
-}
-
-static
-bool flecs_parse_is_float(
-    const char *ptr)
-{
-    ecs_assert(isdigit(ptr[0]), ECS_INTERNAL_ERROR, NULL);
-    char ch;
-    while ((ch = (++ptr)[0])) {
-        if (ch == '.' || ch == 'e') {
-            return true;
-        }
-        if (!isdigit(ch)) {
-            return false;
-        }
-    }
-    return false;
-}
-
-/* Attempt to resolve variable dotexpression to value (foo.bar) */
-static
-ecs_value_t flecs_dotresolve_var(
-    ecs_world_t *world,
-    ecs_script_vars_t *vars,
-    char *token)
-{
-    char *dot = strchr(token, '.');
-    if (!dot) {
-        return (ecs_value_t){ .type = ecs_id(ecs_entity_t) };
-    }
-
-    dot[0] = '\0';
-
-    const ecs_script_var_t *var = ecs_script_vars_lookup(vars, token);
-    if (!var) {
-        return (ecs_value_t){0};
-    }
-
-    ecs_meta_cursor_t cur = ecs_meta_cursor(
-        world, var->value.type, var->value.ptr);
-    ecs_meta_push(&cur);
-    if (ecs_meta_dotmember(&cur, dot + 1) != 0) {
-        return (ecs_value_t){0};
-    }
-
-    return (ecs_value_t){ 
-        .ptr = ecs_meta_get_ptr(&cur),
-        .type = ecs_meta_get_type(&cur)
-    };
-}
-
-static
-int flecs_meta_call(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    ecs_meta_cursor_t *cur, 
-    const char *function) 
-{
-    ecs_entity_t type = ecs_meta_get_type(cur);
-    void *value_ptr = ecs_meta_get_ptr(cur);
-
-    if (!ecs_os_strcmp(function, "parent")) {
-        if (type != ecs_id(ecs_entity_t)) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "parent() can only be called on entity");
-            return -1;
-        }
-
-        *(ecs_entity_t*)value_ptr = ecs_get_parent(
-            world, *(ecs_entity_t*)value_ptr);
-    } else if (!ecs_os_strcmp(function, "name")) {
-        if (type != ecs_id(ecs_entity_t)) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "name() can only be called on entity");
-            return -1;
-        }
-
-        char **result = flecs_expr_value_new(stack, ecs_id(ecs_string_t));
-        *result = ecs_os_strdup(ecs_get_name(world, *(ecs_entity_t*)value_ptr));
-        *cur = ecs_meta_cursor(world, ecs_id(ecs_string_t), result);
-    } else if (!ecs_os_strcmp(function, "doc_name")) {
-#ifdef FLECS_DOC
-        if (type != ecs_id(ecs_entity_t)) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "name() can only be called on entity");
-            return -1;
-        }
-
-        char **result = flecs_expr_value_new(stack, ecs_id(ecs_string_t));
-        *result = ecs_os_strdup(ecs_doc_get_name(world, *(ecs_entity_t*)value_ptr));
-        *cur = ecs_meta_cursor(world, ecs_id(ecs_string_t), result);
-#else
-        ecs_parser_error(name, expr, ptr - expr, 
-            "doc_name() is not available without FLECS_DOC addon");
-        return -1;
-#endif
-    } else {
-        ecs_parser_error(name, expr, ptr - expr, 
-            "unknown function '%s'", function);
-        return -1;
-    }
-
-    return 0;
-}
-
-/* Determine the type of an expression from the first character(s). This allows
- * us to initialize a storage for a type if none was provided. */
-static
-ecs_entity_t flecs_parse_discover_type(
-    ecs_world_t *world,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    ecs_entity_t input_type,
-    const ecs_script_expr_run_desc_t *desc)
-{
-    /* String literal */
-    if (ptr[0] == '"' || ptr[0] == '`') {
-        if (input_type == ecs_id(ecs_char_t)) {
-            return input_type;
-        }
-        return ecs_id(ecs_string_t);
-    }
-
-    /* Negative number literal */
-    if (ptr[0] == '-') {
-        if (!isdigit(ptr[1])) {
-            ecs_parser_error(name, expr, ptr - expr, "invalid literal");
-            return 0;
-        }
-        if (flecs_parse_is_float(ptr + 1)) {
-            return ecs_id(ecs_f64_t);
-        } else {
-            return ecs_id(ecs_i64_t);
-        }
-    }
-
-    /* Positive number literal */
-    if (isdigit(ptr[0])) {
-        if (flecs_parse_is_float(ptr)) {
-            return ecs_id(ecs_f64_t);
-        } else {
-            return ecs_id(ecs_u64_t);
-        }
-    }
-
-    /* Variable */
-    if (ptr[0] == '$') {
-        if (!desc || !desc->vars) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "unresolved variable (no variable scope)");
-            return 0;
-        }
-
-        char token[ECS_MAX_TOKEN_SIZE];
-        if (flecs_script_expr_parse_token(name, expr, &ptr[1], token) == NULL) {
-            return 0;
-        }
-
-        const ecs_script_var_t *var = ecs_script_vars_lookup(desc->vars, token);
-        if (!var) {
-            ecs_size_t len = ecs_os_strlen(token);
-            if (ptr[len + 1] == '(') {
-                while ((len > 0) && (token[len] != '.')) {
-                    len --;
-                }
-                if (token[len] == '.') {
-                    token[len] = '\0';
-                }
-
-                return ecs_id(ecs_entity_t);
-            }
-
-            ecs_value_t v = flecs_dotresolve_var(world, desc->vars, token);
-            if (v.type) {
-                return v.type;
-            }
-
-            ecs_parser_error(name, expr, ptr - expr, 
-                "unresolved variable '%s'", token);
-            return 0;
-        }
-        return var->value.type;
-    }
-
-    /* Boolean */
-    if (ptr[0] == 't' && !ecs_os_strncmp(ptr, "true", 4)) {
-        if (!isalpha(ptr[4]) && ptr[4] != '_') {
-            return ecs_id(ecs_bool_t);
-        }
-    }
-
-    if (ptr[0] == 'f' && !ecs_os_strncmp(ptr, "false", 5)) {
-        if (!isalpha(ptr[5]) && ptr[5] != '_') {
-            return ecs_id(ecs_bool_t);
-        }
-    }
-
-    /* Entity identifier */
-    if (isalpha(ptr[0])) {
-        if (!input_type) { /* Identifier could also be enum/bitmask constant */
-            char token[ECS_MAX_TOKEN_SIZE];
-            const char *tptr = flecs_script_expr_parse_token(
-                name, expr, ptr, token);
-            if (!tptr) {
-                return 0;
-            }
-
-            if (tptr[0] != '[') {
-                return ecs_id(ecs_entity_t);
-            }
-
-            tptr = flecs_script_expr_parse_token(
-                name, expr, tptr + 1, token);
-            if (!tptr) {
-                return 0;
-            }
-
-            ecs_assert(desc != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_assert(desc->lookup_action != NULL, ECS_INTERNAL_ERROR, NULL);
-            ecs_entity_t type = desc->lookup_action(
-                world, token, desc->lookup_ctx);
-            if (!type) {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "unresolved type '%s'", token);
-                return 0;
-            }
-
-            if (tptr[0] != ']') {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "missing ']' after '%s'", token);
-                return 0;
-            }
-
-            if (tptr[1] != '.') {
-                return type;
-            }
-
-            ecs_meta_cursor_t cur = ecs_meta_cursor(world, type, NULL);
-            ecs_meta_push(&cur);
-
-            tptr = flecs_script_expr_parse_token(
-                name, expr, tptr + 2, token);
-            if (!tptr) {
-                return 0;
-            }
-
-            if (ecs_meta_dotmember(&cur, token) != 0) {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "failed to assign member '%s'", token);
-                return 0;
-            }
-
-            return ecs_meta_get_type(&cur);
-        }
-    }
-
-    /* If no default type was provided we can't automatically deduce the type of
-     * composite/collection expressions. */
-    if (!input_type) {
-        if (ptr[0] == '{') {
-            ecs_parser_error(name, expr, ptr - expr,
-                "unknown type for composite literal");
-            return 0;
-        }
-
-        if (ptr[0] == '[') {
-            ecs_parser_error(name, expr, ptr - expr,
-                "unknown type for collection literal");
-            return 0;
-        }
-
-        ecs_parser_error(name, expr, ptr - expr, "invalid expression");
-    }
-
-    return input_type;
-}
-
-/* Normalize types to their largest representation.
- * Rather than taking the original type of a value, use the largest 
- * representation of the type so we don't have to worry about overflowing the
- * original type in the operation. */
-static
-ecs_entity_t flecs_largest_type(
-    const EcsPrimitive *type)
-{
-    switch(type->kind) {
-    case EcsBool:   return ecs_id(ecs_bool_t);
-    case EcsChar:   return ecs_id(ecs_char_t);
-    case EcsByte:   return ecs_id(ecs_u8_t);
-    case EcsU8:     return ecs_id(ecs_u64_t);
-    case EcsU16:    return ecs_id(ecs_u64_t);
-    case EcsU32:    return ecs_id(ecs_u64_t);
-    case EcsU64:    return ecs_id(ecs_u64_t);
-    case EcsI8:     return ecs_id(ecs_i64_t);
-    case EcsI16:    return ecs_id(ecs_i64_t);
-    case EcsI32:    return ecs_id(ecs_i64_t);
-    case EcsI64:    return ecs_id(ecs_i64_t);
-    case EcsF32:    return ecs_id(ecs_f64_t);
-    case EcsF64:    return ecs_id(ecs_f64_t);
-    case EcsUPtr:   return ecs_id(ecs_u64_t);
-    case EcsIPtr:   return ecs_id(ecs_i64_t);
-    case EcsString: return ecs_id(ecs_string_t);
-    case EcsEntity: return ecs_id(ecs_entity_t);
-    case EcsId:     return ecs_id(ecs_id_t);
-    default: ecs_throw(ECS_INTERNAL_ERROR, NULL);
-    }
-error:
-    return 0;
-}
-
-/** Test if a normalized type can promote to another type in an expression */
-static
-bool flecs_is_type_number(
-    ecs_entity_t type)
-{
-    if      (type == ecs_id(ecs_bool_t)) return false;
-    else if (type == ecs_id(ecs_char_t)) return false;
-    else if (type == ecs_id(ecs_u8_t)) return false;
-    else if (type == ecs_id(ecs_u64_t)) return true;
-    else if (type == ecs_id(ecs_i64_t)) return true;
-    else if (type == ecs_id(ecs_f64_t)) return true;
-    else if (type == ecs_id(ecs_string_t)) return false;
-    else if (type == ecs_id(ecs_entity_t)) return false;
-    else return false;
-}
-
-static
-bool flecs_oper_valid_for_type(
-    ecs_entity_t type,
-    ecs_expr_oper_t op)
-{
-    switch(op) {
-    case EcsAdd:
-    case EcsSub:
-    case EcsMul:
-    case EcsDiv:
-        return flecs_is_type_number(type);
-    case EcsCondEq:
-    case EcsCondNeq:
-    case EcsCondAnd:
-    case EcsCondOr:
-    case EcsCondGt:
-    case EcsCondGtEq:
-    case EcsCondLt:
-    case EcsCondLtEq:
-        return flecs_is_type_number(type) ||
-            (type == ecs_id(ecs_bool_t)) ||
-            (type == ecs_id(ecs_char_t)) ||
-            (type == ecs_id(ecs_entity_t));
-    case EcsShiftLeft:
-    case EcsShiftRight:
-        return (type == ecs_id(ecs_u64_t));
-    case EcsExprOperUnknown:
-    case EcsLeftParen:
-    case EcsMin:
-        return false;
-    default: 
-        ecs_abort(ECS_INTERNAL_ERROR, NULL);
-    }
-}
-
-/** Promote type to most expressive (f64 > i64 > u64) */
-static
-ecs_entity_t flecs_promote_type(
-    ecs_entity_t type,
-    ecs_entity_t promote_to)
-{
-    if (type == ecs_id(ecs_u64_t)) {
-        return promote_to;
-    }
-    if (promote_to == ecs_id(ecs_u64_t)) {
-        return type;
-    }
-    if (type == ecs_id(ecs_f64_t)) {
-        return type;
-    }
-    if (promote_to == ecs_id(ecs_f64_t)) {
-        return promote_to;
-    }
-    return ecs_id(ecs_i64_t);
-}
-
-static
-int flecs_oper_precedence(
-    ecs_expr_oper_t left,
-    ecs_expr_oper_t right)
-{
-    return (left > right) - (left < right);
-}
-
-static
-void flecs_value_cast(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    ecs_value_t *value,
-    ecs_entity_t type)
-{
-    if (value->type == type) {
+void flecs_script_rng_keep(ecs_script_rng_t *rng) {
+    if (!rng) {
         return;
     }
-
-    ecs_value_t result;
-    result.type = type;
-    result.ptr = flecs_expr_value_new(stack, type);
-
-    if (value->ptr) {
-        ecs_meta_cursor_t cur = ecs_meta_cursor(world, type, result.ptr);
-        ecs_meta_set_value(&cur, value);
-    }
-
-    *value = result;
+    rng->refcount ++;
 }
 
 static
-bool flecs_expr_op_is_equality(
-    ecs_expr_oper_t op)
-{
-    switch(op) {
-    case EcsCondEq:
-    case EcsCondNeq:
-    case EcsCondGt:
-    case EcsCondGtEq:
-    case EcsCondLt:
-    case EcsCondLtEq:
-        return true;
-    case EcsCondAnd:
-    case EcsCondOr:
-    case EcsShiftLeft:
-    case EcsShiftRight:
-    case EcsAdd:
-    case EcsSub:
-    case EcsMul:
-    case EcsDiv:
-    case EcsExprOperUnknown:
-    case EcsLeftParen:
-    case EcsMin:
-        return false;
-    default:
-        ecs_throw(ECS_INTERNAL_ERROR, "invalid operator");
+void flecs_script_rng_free(ecs_script_rng_t *rng) {
+    if (!rng) {
+        return;
     }
-error:
-    return false;
+    ecs_assert(rng->refcount > 0, ECS_INTERNAL_ERROR, NULL);
+    if (!--rng->refcount) {
+        ecs_os_free(rng);
+    }
 }
 
 static
-ecs_entity_t flecs_binary_expr_type(
-    ecs_world_t *world,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    ecs_value_t *lvalue,
-    ecs_value_t *rvalue,
-    ecs_expr_oper_t op,
-    ecs_entity_t *operand_type_out)
-{
-    ecs_entity_t result_type = 0, operand_type = 0;
-
-    switch(op) {
-    case EcsDiv: 
-        /* Result type of a division is always a float */
-        *operand_type_out = ecs_id(ecs_f64_t);
-        return ecs_id(ecs_f64_t);
-    case EcsCondAnd:
-    case EcsCondOr:
-        /* Result type of a condition operator is always a bool */
-        *operand_type_out = ecs_id(ecs_bool_t);
-        return ecs_id(ecs_bool_t);
-    case EcsCondEq:
-    case EcsCondNeq:
-    case EcsCondGt:
-    case EcsCondGtEq:
-    case EcsCondLt:
-    case EcsCondLtEq:
-        /* Result type of equality operator is always bool, but operand types
-         * should not be casted to bool */
-        result_type = ecs_id(ecs_bool_t);
-        break;
-    case EcsShiftLeft:
-    case EcsShiftRight:
-    case EcsAdd:
-    case EcsSub:
-    case EcsMul:
-    case EcsExprOperUnknown:
-    case EcsLeftParen:
-    case EcsMin:
-        break;
-    default:
-        ecs_throw(ECS_INTERNAL_ERROR, "invalid operator");
-    }
-
-    /* Result type for arithmetic operators is determined by operands */
-    const EcsPrimitive *ltype_ptr = ecs_get(world, lvalue->type, EcsPrimitive);
-    const EcsPrimitive *rtype_ptr = ecs_get(world, rvalue->type, EcsPrimitive);
-    if (!ltype_ptr || !rtype_ptr) {
-        char *lname = ecs_get_path(world, lvalue->type);
-        char *rname = ecs_get_path(world, rvalue->type);
-        ecs_parser_error(name, expr, ptr - expr, 
-            "invalid non-primitive type in binary expression (%s, %s)",
-                lname, rname);
-        ecs_os_free(lname);
-        ecs_os_free(rname);
-        return 0;
-    }
-
-    ecs_entity_t ltype = flecs_largest_type(ltype_ptr);
-    ecs_entity_t rtype = flecs_largest_type(rtype_ptr);
-    if (ltype == rtype) {
-        operand_type = ltype;
-        goto done;
-    }
-
-    if (flecs_expr_op_is_equality(op)) {
-        char *lstr = ecs_id_str(world, ltype);
-        char *rstr = ecs_id_str(world, rtype);
-        ecs_parser_error(name, expr, ptr - expr, 
-            "mismatching types in equality expression (%s vs %s)",
-                lstr, rstr);
-        ecs_os_free(rstr);
-        ecs_os_free(lstr);
-        return 0;
-    }
-
-    if (!flecs_is_type_number(ltype) || !flecs_is_type_number(rtype)) {
-        ecs_parser_error(name, expr, ptr - expr, 
-            "incompatible types in binary expression");
-        return 0;
-    }
-
-    operand_type = flecs_promote_type(ltype, rtype);
-
-done:
-    if (op == EcsSub && operand_type == ecs_id(ecs_u64_t)) {
-        /* Result of subtracting two unsigned ints can be negative */
-        operand_type = ecs_id(ecs_i64_t);
-    }
-
-    if (!result_type) {
-        result_type = operand_type;
-    }
-
-    *operand_type_out = operand_type;
-    return result_type;
-error:
-    return 0;
+uint64_t flecs_script_rng_next(ecs_script_rng_t *rng) {
+    rng->x *= rng->x;
+    rng->x += (rng->w += rng->s);
+    rng->x = (rng->x >> 32) | (rng->x << 32);
+    return rng->x;
 }
 
-/* Macro's to let the compiler do the operations & conversion work for us */
-
-#define ECS_VALUE_GET(value, T) (*(T*)value->ptr)
-
-#define ECS_BINARY_OP_T(left, right, result, op, R, T)\
-    ECS_VALUE_GET(result, R) = ECS_VALUE_GET(left, T) op ECS_VALUE_GET(right, T)
-
-#define ECS_BINARY_OP(left, right, result, op)\
-    if (left->type == ecs_id(ecs_u64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_u64_t, ecs_u64_t);\
-    } else if (left->type == ecs_id(ecs_i64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_i64_t, ecs_i64_t);\
-    } else if (left->type == ecs_id(ecs_f64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_f64_t, ecs_f64_t);\
-    } else {\
-        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
-    }
-
-#define ECS_BINARY_COND_EQ_OP(left, right, result, op)\
-    if (left->type == ecs_id(ecs_u64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u64_t);\
-    } else if (left->type == ecs_id(ecs_i64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_i64_t);\
-    } else if (left->type == ecs_id(ecs_f64_t)) { \
-        ecs_parser_error(name, expr, ptr - expr, "unsupported operator for floating point");\
-        return -1;\
-    } else if (left->type == ecs_id(ecs_u8_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u8_t);\
-    } else if (left->type == ecs_id(ecs_char_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_char_t);\
-    } else if (left->type == ecs_id(ecs_bool_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_bool_t);\
-    } else {\
-        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
-    }
-
-#define ECS_BINARY_COND_OP(left, right, result, op)\
-    if (left->type == ecs_id(ecs_u64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u64_t);\
-    } else if (left->type == ecs_id(ecs_i64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_i64_t);\
-    } else if (left->type == ecs_id(ecs_f64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_f64_t);\
-    } else if (left->type == ecs_id(ecs_u8_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_u8_t);\
-    } else if (left->type == ecs_id(ecs_char_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_char_t);\
-    } else if (left->type == ecs_id(ecs_bool_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_bool_t);\
-    } else {\
-        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
-    }
-
-#define ECS_BINARY_BOOL_OP(left, right, result, op)\
-    if (left->type == ecs_id(ecs_bool_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_bool_t, ecs_bool_t);\
-    } else {\
-        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
-    }
-
-#define ECS_BINARY_UINT_OP(left, right, result, op)\
-    if (left->type == ecs_id(ecs_u64_t)) { \
-        ECS_BINARY_OP_T(left, right, result, op, ecs_u64_t, ecs_u64_t);\
-    } else {\
-        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
-    }
+ECS_COMPONENT_DECLARE(EcsScriptRng);
 
 static
-int flecs_binary_expr_do(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    ecs_value_t *lvalue,
-    ecs_value_t *rvalue,
-    ecs_value_t *result,
-    ecs_expr_oper_t op)
-{
-    /* Find expression type */
-    ecs_entity_t operand_type, type = flecs_binary_expr_type(
-        world, name, expr, ptr, lvalue, rvalue, op, &operand_type);
-    if (!type) {
-        goto error;
-    }
-
-    if (!flecs_oper_valid_for_type(type, op)) {
-        ecs_parser_error(name, expr, ptr - expr, "invalid operator for type");
-        goto error;
-    }
-
-    flecs_value_cast(world, stack, lvalue, operand_type);
-    flecs_value_cast(world, stack, rvalue, operand_type);
-
-    ecs_value_t *storage = result;
-    ecs_value_t tmp_storage = {0};
-    if (result->type != type) {
-        storage = &tmp_storage;
-        storage->type = type;
-        storage->ptr = flecs_expr_value_new(stack, type);
-    }
-
-    switch(op) {
-    case EcsAdd:
-        ECS_BINARY_OP(lvalue, rvalue, storage, +);
-        break;
-    case EcsSub:
-        ECS_BINARY_OP(lvalue, rvalue, storage, -);
-        break;
-    case EcsMul:
-        ECS_BINARY_OP(lvalue, rvalue, storage, *);
-        break;
-    case EcsDiv:
-        ECS_BINARY_OP(lvalue, rvalue, storage, /);
-        break;
-    case EcsCondEq:
-        ECS_BINARY_COND_EQ_OP(lvalue, rvalue, storage, ==);
-        break;
-    case EcsCondNeq:
-        ECS_BINARY_COND_EQ_OP(lvalue, rvalue, storage, !=);
-        break;
-    case EcsCondGt:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, >);
-        break;
-    case EcsCondGtEq:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, >=);
-        break;
-    case EcsCondLt:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, <);
-        break;
-    case EcsCondLtEq:
-        ECS_BINARY_COND_OP(lvalue, rvalue, storage, <=);
-        break;
-    case EcsCondAnd:
-        ECS_BINARY_BOOL_OP(lvalue, rvalue, storage, &&);
-        break;
-    case EcsCondOr:
-        ECS_BINARY_BOOL_OP(lvalue, rvalue, storage, ||);
-        break;
-    case EcsShiftLeft:
-        ECS_BINARY_UINT_OP(lvalue, rvalue, storage, <<);
-        break;
-    case EcsShiftRight:
-        ECS_BINARY_UINT_OP(lvalue, rvalue, storage, >>);
-        break;
-    case EcsExprOperUnknown:
-    case EcsLeftParen:
-    case EcsMin:
-        ecs_parser_error(name, expr, ptr - expr, "unsupported operator");
-        goto error;
-    default:
-        ecs_throw(ECS_INTERNAL_ERROR, NULL);
-    }
-
-    if (storage->ptr != result->ptr) {
-        if (!result->ptr) {
-            *result = *storage;
-        } else {
-            ecs_meta_cursor_t cur = ecs_meta_cursor(world, 
-                result->type, result->ptr);
-            ecs_meta_set_value(&cur, storage);
-        }
-    }
-
-    return 0;
-error:
-    return -1;
-}
+ECS_CTOR(EcsScriptRng, ptr, {
+    ptr->seed = 0;
+    ptr->impl = flecs_script_rng_new();
+})
 
 static
-const char* flecs_binary_expr_parse(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    ecs_value_t *lvalue,
-    ecs_value_t *result,
-    ecs_expr_oper_t left_op,
-    const ecs_script_expr_run_desc_t *desc)
-{
-    ecs_entity_t result_type = result->type;
-    do {
-        ecs_expr_oper_t op;
-
-        ptr = flecs_str_to_expr_oper(ptr, &op);
-        if (!ptr) {
-            ecs_parser_error(name, expr, ptr - expr, "invalid operator");
-            return NULL;
-        }
-
-        ptr = flecs_parse_ws_eol(ptr);
-
-        ecs_value_t rvalue = {0};
-        const char *rptr = flecs_script_expr_run(world, stack, ptr, &rvalue, op, desc);
-        if (!rptr) {
-            return NULL;
-        }
-
-        if (flecs_binary_expr_do(world, stack, name, expr, ptr, 
-            lvalue, &rvalue, result, op)) 
-        {
-            return NULL;
-        }
-
-        ptr = rptr;
-
-        ecs_expr_oper_t right_op;
-        flecs_str_to_expr_oper(rptr, &right_op);
-        if (right_op > left_op) {
-            if (result_type) {
-                /* If result was initialized, preserve its value */
-                lvalue->type = result->type;
-                lvalue->ptr = flecs_expr_value_new(stack, lvalue->type);
-                ecs_value_copy(world, lvalue->type, lvalue->ptr, result->ptr);
-                continue;
-            } else {
-                /* Otherwise move result to lvalue */
-                *lvalue = *result;
-                ecs_os_zeromem(result);
-                continue;
-            }
-        }
-
-        break;
-    } while (true);
-
-    return ptr;
-}
+ECS_COPY(EcsScriptRng, dst, src, {
+    flecs_script_rng_keep(src->impl);
+    if (dst->impl != src->impl) {
+        flecs_script_rng_free(dst->impl);
+    }
+    dst->seed = src->seed;
+    dst->impl = src->impl;
+})
 
 static
-const char* flecs_funccall_parse(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *name,
-    const char *expr,
-    const char *ptr,
-    char *token,
-    ecs_meta_cursor_t *cur,
-    ecs_value_t *value,
-    bool isvar,
-    const ecs_script_expr_run_desc_t *desc)
-{
-    char *sep = strrchr(token, '.');
-    if (!sep) {
-        ecs_parser_error(name, expr, ptr - expr, 
-            "missing object for function call '%s'", token);
-        return NULL;
-    }
-
-    sep[0] = '\0';
-    const char *function = sep + 1;
-
-    if (!isvar) {
-        if (ecs_meta_set_string(cur, token) != 0) {
-            goto error;
-        }
-    } else {
-        const ecs_script_var_t *var = ecs_script_vars_lookup(desc->vars, token);
-        ecs_meta_set_value(cur, &var->value);
-    }
-
-    do {
-        if (!function[0]) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "missing function name for function call '%s'", token);
-            return NULL;
-        }
-
-        if (flecs_meta_call(world, stack, name, expr, ptr, cur, 
-            function) != 0) 
-        {
-            goto error;
-        }
-
-        ecs_entity_t type = ecs_meta_get_type(cur);
-        value->ptr = ecs_meta_get_ptr(cur);
-        value->type = type;
-
-        ptr += 2;
-        if (ptr[0] != '.') {
-            break;
-        }
-
-        ptr ++;
-        char *paren = strchr(ptr, '(');
-        if (!paren) {
-            break;
-        }
-
-        ecs_size_t len = flecs_ito(int32_t, paren - ptr);
-        if (len >= ECS_MAX_TOKEN_SIZE) {
-            ecs_parser_error(name, expr, ptr - expr, 
-                "token exceeds maximum token size");
-            goto error;
-        }
-
-        ecs_os_strncpy(token, ptr, len);
-        token[len] = '\0';
-        function = token;
-
-        ptr = paren;
-    } while (true);
-
-    return ptr;
-error:
-    return NULL;
-}
+ECS_MOVE(EcsScriptRng, dst, src, {
+    flecs_script_rng_free(dst->impl);
+    dst->seed = src->seed;
+    dst->impl = src->impl;
+    src->impl = NULL;
+})
 
 static
-ecs_entity_t flecs_script_default_lookup(
-    const ecs_world_t *world,
-    const char *name,
-    void *ctx)
+ECS_DTOR(EcsScriptRng, ptr, {
+    flecs_script_rng_free(ptr->impl);
+})
+
+void flecs_script_rng_get_float(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result)
 {
     (void)ctx;
-    return ecs_lookup(world, name);
+    (void)argc;
+    EcsScriptRng *rng = argv[0].ptr;
+    ecs_assert(rng->impl != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_script_rng_t *impl = rng->impl;
+    if (!impl->initialized) {
+        impl->x = rng->seed;
+        impl->initialized = true;
+    }
+    uint64_t x = flecs_script_rng_next(rng->impl);
+    double max = *(double*)argv[1].ptr;
+    double *r = result->ptr;
+
+    if (ECS_EQZERO(max)) {
+        ecs_err("flecs.script.math.Rng.f(): invalid division by zero");
+    } else {
+        *r = (double)x / ((double)UINT64_MAX / max);
+    }
 }
 
-static
-const char* flecs_script_expr_run(
-    ecs_world_t *world,
-    ecs_value_stack_t *stack,
-    const char *ptr,
-    ecs_value_t *value,
-    ecs_expr_oper_t left_op,
-    const ecs_script_expr_run_desc_t *desc)
+void flecs_script_rng_get_uint(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result)
 {
-    ecs_assert(value != NULL, ECS_INTERNAL_ERROR, NULL);
-    char token[ECS_MAX_TOKEN_SIZE];
-    int depth = 0;
-    ecs_value_t result = {0};
-    ecs_meta_cursor_t cur = {0};
-    const char *name = desc ? desc->name : NULL;
-    const char *expr = desc ? desc->expr : NULL;
-    token[0] = '\0';
-    expr = expr ? expr : ptr;
-
-    ptr = flecs_parse_ws_eol(ptr);
-
-    /* Check for postfix operators */
-    ecs_expr_oper_t unary_op = EcsExprOperUnknown;
-    if (ptr[0] == '-' && !isdigit(ptr[1])) {
-        unary_op = EcsMin;
-        ptr = flecs_parse_ws_eol(ptr + 1);
+    (void)ctx;
+    (void)argc;
+    EcsScriptRng *rng = argv[0].ptr;
+    ecs_assert(rng->impl != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_script_rng_t *impl = rng->impl;
+    if (!impl->initialized) {
+        impl->x = rng->seed;
+        impl->initialized = true;
     }
-
-    /* Initialize storage and cursor. If expression starts with a '(' storage
-     * will be initialized by a nested expression */
-    if (ptr[0] != '(') {
-        ecs_entity_t type = flecs_parse_discover_type(
-            world, name, expr, ptr, value->type, desc);
-        if (!type) {
-            return NULL;
-        }
-
-        result.type = type;
-        if (type != value->type) {
-            result.ptr = flecs_expr_value_new(stack, type);
-        } else {
-            result.ptr = value->ptr;
-        }
-
-        cur = ecs_meta_cursor(world, result.type, result.ptr);
-        if (!cur.valid) {
-            return NULL;
-        }
-
-        cur.lookup_action = desc ? desc->lookup_action : NULL;
-        cur.lookup_ctx = desc ? desc->lookup_ctx : NULL;
+    uint64_t x = flecs_script_rng_next(rng->impl);
+    uint64_t max = *(uint64_t*)argv[1].ptr;
+    uint64_t *r = result->ptr;
+    if (!max) {
+        ecs_err("flecs.script.math.Rng.u(): invalid division by zero");
+    } else {
+        *r = x % max;
     }
-
-    /* Loop that parses all values in a value scope */
-    while ((ptr = flecs_script_expr_parse_token(name, expr, ptr, token))) {
-        /* Used to track of the result of the parsed token can be used as the
-         * lvalue for a binary expression */
-        bool is_lvalue = false;
-        bool newline = false;
-
-        if (!token[0]) {
-            /* Comment */
-            continue;
-        }
-
-        if (!ecs_os_strcmp(token, "(")) {
-            ecs_value_t temp_result, *out;
-            if (!depth) {
-                out = &result;
-            } else {
-                temp_result.type = ecs_meta_get_type(&cur);
-                temp_result.ptr = ecs_meta_get_ptr(&cur);
-                out = &temp_result;
-            }
-
-            /* Parenthesis, parse nested expression */
-            ptr = flecs_script_expr_run(
-                world, stack, ptr, out, EcsLeftParen, desc);
-            if (ptr[0] != ')') {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "missing closing parenthesis");
-                return NULL;
-            }
-            ptr = flecs_parse_ws(ptr + 1);
-            is_lvalue = true;
-
-        } else if (!ecs_os_strcmp(token, "{")) {
-            /* Parse nested value scope */
-            ecs_entity_t scope_type = ecs_meta_get_type(&cur);
-
-            depth ++; /* Keep track of depth so we know when parsing is done */
-            if (ecs_meta_push(&cur) != 0) {
-                goto error;
-            }
-
-            if (ecs_meta_is_collection(&cur)) {
-                char *path = ecs_get_path(world, scope_type);
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "expected '[' for collection type '%s'", path);
-                ecs_os_free(path);
-                return NULL;
-            }
-        }
-
-        else if (!ecs_os_strcmp(token, "}")) {
-            depth --;
-
-            if (ecs_meta_is_collection(&cur)) {
-                ecs_parser_error(name, expr, ptr - expr, "expected ']'");
-                return NULL;
-            }
-
-            if (ecs_meta_pop(&cur) != 0) {
-                goto error;
-            }
-        }
-
-        else if (!ecs_os_strcmp(token, "[")) {
-            /* Open collection value scope */
-            depth ++;
-            if (ecs_meta_push(&cur) != 0) {
-                goto error;
-            }
-
-            if (!ecs_meta_is_collection(&cur)) {
-                ecs_parser_error(name, expr, ptr - expr, "unexpected '['");
-                return NULL;
-            }
-        }
-
-        else if (!ecs_os_strcmp(token, "]")) {
-            depth --;
-
-            if (!ecs_meta_is_collection(&cur)) {
-                ecs_parser_error(name, expr, ptr - expr, "expected '}'");
-                return NULL;
-            }
-
-            if (ecs_meta_pop(&cur) != 0) {
-                goto error;
-            }
-        }
-
-        else if (!ecs_os_strcmp(token, "-")) {
-            if (unary_op != EcsExprOperUnknown) {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "unexpected unary operator");
-                return NULL;
-            }
-            unary_op = EcsMin;
-        }
-
-        else if (!ecs_os_strcmp(token, ",")) {
-            /* Move to next field */
-            if (ecs_meta_next(&cur) != 0) {
-                goto error;
-            }
-        }
-
-        else if (!ecs_os_strcmp(token, "null")) {
-            if (ecs_meta_set_null(&cur) != 0) {
-                goto error;
-            }
-
-            is_lvalue = true;
-        }
-
-        else if (token[0] == '\"') {
-            /* Regular string */
-            if (ecs_meta_set_string_literal(&cur, token) != 0) {
-                goto error;
-            }
-
-            is_lvalue = true;
-        }
-
-        else if (!ecs_os_strcmp(token, "`")) {
-            /* Multiline string */
-            if (!(ptr = flecs_parse_multiline_string(&cur, name, expr, ptr))) {
-                goto error;
-            }
-
-            is_lvalue = true;
-
-        } else if (token[0] == '$') {
-            /* Variable */
-            if (!desc || !desc->vars) {
-                ecs_parser_error(name, expr, ptr - expr, 
-                    "unresolved variable '%s' (no variable scope)", token);
-                return NULL;
-            }
-
-            if (!token[1]) {
-                /* Empty name means default to assigned member */
-                const char *member = ecs_meta_get_member(&cur);
-                if (!member) {
-                    ecs_parser_error(name, expr, ptr - expr, 
-                        "invalid default variable outside member assignment");
-                    return NULL;
-                }
-                ecs_os_strcpy(&token[1], member);
-            }
-
-            const ecs_script_var_t *var = ecs_script_vars_lookup(desc->vars, &token[1]);
-            if (!var) {
-                if (ptr[0] == '(') {
-                    /* Function */
-                    ptr = flecs_funccall_parse(world, stack, name, expr, ptr, 
-                        &token[1], &cur, &result, true, desc);
-                    if (!ptr) {
-                        goto error;
-                    }
-                } else {
-                    ecs_value_t v = flecs_dotresolve_var(world, desc->vars, &token[1]);
-                    if (!v.ptr) {
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "unresolved variable '%s'", token);
-                        return NULL;
-                    } else {
-                        ecs_meta_set_value(&cur, &v);
-                    }
-                }
-            } else {
-                ecs_meta_set_value(&cur, &var->value);
-            }
-
-            is_lvalue = true;
-        } else {
-            const char *tptr = flecs_parse_ws(ptr);
-            for (; ptr != tptr; ptr ++) {
-                if (ptr[0] == '\n') {
-                    newline = true;
-                }
-            }
-
-            if (ptr[0] == ':') {
-                /* Member assignment */
-                ptr ++;
-                if (ecs_meta_dotmember(&cur, token) != 0) {
-                    goto error;
-                }
-            } else if (ptr[0] == '(') {
-                /* Function */
-                ptr = flecs_funccall_parse(world, stack, name, expr, ptr, 
-                    token, &cur, &result, false, desc);
-                if (!ptr) {
-                    goto error;
-                }
-            } else {
-                if (ptr[0] != '[') {
-                    /* Entity id expression */
-                    if (ecs_meta_set_string(&cur, token) != 0) {
-                        goto error;
-                    }
-                } else {
-                    /* Component expression */
-                    ecs_assert(desc != NULL, ECS_INTERNAL_ERROR, NULL);
-                    ecs_assert(desc->lookup_action != NULL, ECS_INTERNAL_ERROR, NULL);
-                    ecs_entity_t e = desc->lookup_action(
-                        world, token, desc->lookup_ctx);
-                    if (!e) {
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "entity '%s' not found", token);
-                        goto error;
-                    }
-
-                    ptr = flecs_script_expr_parse_token(
-                        name, expr, ptr + 1, token);
-                    if (!ptr) {
-                        goto error;
-                    }
-
-                    ecs_entity_t component = desc->lookup_action(
-                        world, token, desc->lookup_ctx);
-                    if (!component) {
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "unresolved component '%s'", token);
-                        goto error;
-                    }
-
-                    ecs_entity_t type = ecs_get_typeid(world, component);
-                    if (!type) {
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "entity '%s' is not a component", token);
-                        goto error;
-                    }
-
-                    result.type = type;
-                    result.ptr = ECS_CONST_CAST(void*, 
-                        ecs_get_id(world, e, component));
-                    if (!result.ptr) {
-                        char *entitystr = ecs_id_str(world, e);
-                        char *idstr = ecs_id_str(world, component);
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "entity '%s' does not have component '%s'", 
-                            entitystr, idstr);
-                        ecs_os_free(idstr);
-                        ecs_os_free(entitystr);
-                        goto error;
-                    }
-
-                    if (ptr[0] != ']') {
-                        ecs_parser_error(name, expr, ptr - expr, 
-                            "missing ] for component operator");
-                        goto error;
-                    }
-
-                    ptr ++;
-
-                    if (ptr[0] == '.') {
-                        ecs_meta_cursor_t member_cur = ecs_meta_cursor(
-                            world, result.type, result.ptr);
-
-                        ptr = flecs_script_expr_parse_token(
-                            name, expr, ptr + 1, token);
-                        if (!ptr) {
-                            goto error;
-                        }
-
-                        ecs_meta_push(&member_cur);
-                        if (ecs_meta_dotmember(&member_cur, token) != 0) {
-                            ecs_parser_error(name, expr, ptr - expr, 
-                                "failed to assign member '%s'", token);
-                            goto error;
-                        }
-
-                        result.type = ecs_meta_get_type(&member_cur);
-                        result.ptr = ecs_meta_get_ptr(&member_cur);
-                    }
-                }
-            }
-
-            is_lvalue = true;
-        }
-
-        /* If lvalue was parsed, apply operators. Expressions cannot start
-         * directly after a newline character. */
-        if (is_lvalue && !newline) {
-            if (unary_op != EcsExprOperUnknown) {
-                if (unary_op == EcsMin) {
-                    int64_t v = -1;
-                    ecs_value_t lvalue = {.type = ecs_id(ecs_i64_t), .ptr = &v};
-                    ecs_value_t *out, rvalue, temp_out = {0};
-
-                    if (!depth) {
-                        rvalue = result;
-                        ecs_os_zeromem(&result);
-                        out = &result;
-                    } else {
-                        ecs_entity_t cur_type = ecs_meta_get_type(&cur);
-                        void *cur_ptr = ecs_meta_get_ptr(&cur);
-                        rvalue.type = cur_type;
-                        rvalue.ptr = cur_ptr;
-                        temp_out.type = cur_type;
-                        temp_out.ptr = cur_ptr;
-                        out = &temp_out;
-                    }
-
-                    flecs_binary_expr_do(world, stack, name, expr, ptr, &lvalue,
-                        &rvalue, out, EcsMul);
-                }
-                unary_op = 0;
-            }
-
-            ecs_expr_oper_t right_op;
-            flecs_str_to_expr_oper(ptr, &right_op);
-            if (right_op) {
-                /* This is a binary expression, test precedence to determine if
-                 * it should be evaluated here */
-                if (flecs_oper_precedence(left_op, right_op) < 0) {
-                    ecs_value_t lvalue;
-                    ecs_value_t *op_result = &result;
-                    ecs_value_t temp_storage;
-                    if (!depth) {
-                        /* Root level value, move result to lvalue storage */
-                        lvalue = result;
-                        ecs_os_zeromem(&result);
-                    } else {
-                        /* Not a root level value. Move the parsed lvalue to a
-                         * temporary storage, and initialize the result value
-                         * for the binary operation with the current cursor */
-                        ecs_entity_t cur_type = ecs_meta_get_type(&cur);
-                        void *cur_ptr = ecs_meta_get_ptr(&cur);
-                        lvalue.type = cur_type;
-                        lvalue.ptr = flecs_expr_value_new(stack, cur_type);
-                        ecs_value_copy(world, cur_type, lvalue.ptr, cur_ptr);
-                        temp_storage.type = cur_type;
-                        temp_storage.ptr = cur_ptr;
-                        op_result = &temp_storage;
-                    }
-
-                    /* Do the binary expression */
-                    ptr = flecs_binary_expr_parse(world, stack, name, expr, ptr, 
-                        &lvalue, op_result, left_op, desc);
-                    if (!ptr) {
-                        return NULL;
-                    }
-                }
-            }
-        }
-
-        if (!depth) {
-            /* Reached the end of the root scope */
-            break;
-        }
-
-        ptr = flecs_parse_ws_eol(ptr);
-    }
-
-    if (!value->ptr) {
-        value->type = result.type;
-        value->ptr = flecs_expr_value_new(stack, result.type);
-    }
-
-    if (value->ptr != result.ptr) {
-        cur = ecs_meta_cursor(world, value->type, value->ptr);
-        ecs_meta_set_value(&cur, &result);
-    }
-
-    ecs_assert(value->type != 0, ECS_INTERNAL_ERROR, NULL);
-    ecs_assert(value->ptr != NULL, ECS_INTERNAL_ERROR, NULL);
-
-    return ptr;
-error:
-    return NULL;
 }
 
-const char* ecs_script_expr_run(
-    ecs_world_t *world,
-    const char *ptr,
-    ecs_value_t *value,
-    const ecs_script_expr_run_desc_t *desc)
+#define FLECS_MATH_FUNC_F64(name, ...)\
+    static\
+    void flecs_math_##name(\
+        const ecs_function_ctx_t *ctx,\
+        int32_t argc,\
+        const ecs_value_t *argv,\
+        ecs_value_t *result)\
+    {\
+        (void)ctx;\
+        (void)argc;\
+        ecs_assert(argc == 1, ECS_INTERNAL_ERROR, NULL);\
+        double x = *(double*)argv[0].ptr;\
+        *(double*)result->ptr = __VA_ARGS__;\
+    }
+
+#define FLECS_MATH_FUNC_F64_F64(name, ...)\
+    static\
+    void flecs_math_##name(\
+        const ecs_function_ctx_t *ctx,\
+        int32_t argc,\
+        const ecs_value_t *argv,\
+        ecs_value_t *result)\
+    {\
+        (void)ctx;\
+        (void)argc;\
+        ecs_assert(argc == 2, ECS_INTERNAL_ERROR, NULL);\
+        double x = *(double*)argv[0].ptr;\
+        double y = *(double*)argv[1].ptr;\
+        *(double*)result->ptr = __VA_ARGS__;\
+    }
+
+#define FLECS_MATH_FUNC_F64_I32(name, ...)\
+    static\
+    void flecs_math_##name(\
+        const ecs_function_ctx_t *ctx,\
+        int32_t argc,\
+        const ecs_value_t *argv,\
+        ecs_value_t *result)\
+    {\
+        (void)ctx;\
+        (void)argc;\
+        ecs_assert(argc == 2, ECS_INTERNAL_ERROR, NULL);\
+        double x = *(double*)argv[0].ptr;\
+        ecs_i32_t y = *(ecs_i32_t*)argv[1].ptr;\
+        *(double*)result->ptr = __VA_ARGS__;\
+    }
+
+#define FLECS_MATH_FUNC_DEF_F64(_name, brief)\
+    {\
+        ecs_entity_t f = ecs_function(world, {\
+            .name = #_name,\
+            .parent = ecs_id(FlecsScriptMath),\
+            .return_type = ecs_id(ecs_f64_t),\
+            .params = {{ .name = "x", .type = ecs_id(ecs_f64_t) }},\
+            .callback = flecs_math_##_name\
+        });\
+        ecs_doc_set_brief(world, f, brief);\
+    }
+
+#define FLECS_MATH_FUNC_DEF_F64_F64(_name, brief)\
+    {\
+        ecs_entity_t f = ecs_function(world, {\
+            .name = #_name,\
+            .parent = ecs_id(FlecsScriptMath),\
+            .return_type = ecs_id(ecs_f64_t),\
+            .params = {\
+                { .name = "x", .type = ecs_id(ecs_f64_t) },\
+                { .name = "y", .type = ecs_id(ecs_f64_t) }\
+            },\
+            .callback = flecs_math_##_name\
+        });\
+        ecs_doc_set_brief(world, f, brief);\
+    }
+
+#define FLECS_MATH_FUNC_DEF_F64_F32(_name, brief)\
+    {\
+        ecs_entity_t f = ecs_function(world, {\
+            .name = #_name,\
+            .parent = ecs_id(FlecsScriptMath),\
+            .return_type = ecs_id(ecs_f64_t),\
+            .params = {\
+                { .name = "x", .type = ecs_id(ecs_f64_t) },\
+                { .name = "y", .type = ecs_id(ecs_i32_t) }\
+            },\
+            .callback = flecs_math_##_name\
+        });\
+        ecs_doc_set_brief(world, f, brief);\
+    }
+
+/* Trigonometric functions */
+FLECS_MATH_FUNC_F64(cos, cos(x))
+FLECS_MATH_FUNC_F64(sin, sin(x))
+FLECS_MATH_FUNC_F64(tan, tan(x))
+FLECS_MATH_FUNC_F64(acos, acos(x))
+FLECS_MATH_FUNC_F64(asin, asin(x))
+FLECS_MATH_FUNC_F64(atan, atan(x))
+FLECS_MATH_FUNC_F64_F64(atan2, atan2(x, y))
+
+/* Hyperbolic functions */
+FLECS_MATH_FUNC_F64(cosh, cosh(x))
+FLECS_MATH_FUNC_F64(sinh, sinh(x))
+FLECS_MATH_FUNC_F64(tanh, tanh(x))
+FLECS_MATH_FUNC_F64(acosh, acosh(x))
+FLECS_MATH_FUNC_F64(asinh, asinh(x))
+FLECS_MATH_FUNC_F64(atanh, atanh(x))
+
+/* Exponential and logarithmic functions */
+FLECS_MATH_FUNC_F64(exp, exp(x))
+FLECS_MATH_FUNC_F64_I32(ldexp, ldexp(x, y))
+FLECS_MATH_FUNC_F64(log, log(x))
+FLECS_MATH_FUNC_F64(log10, log10(x))
+FLECS_MATH_FUNC_F64(exp2, exp2(x))
+FLECS_MATH_FUNC_F64(log2, log2(x))
+
+/* Power functions */
+FLECS_MATH_FUNC_F64_F64(pow, pow(x, y))
+FLECS_MATH_FUNC_F64(sqrt, sqrt(x))
+FLECS_MATH_FUNC_F64(sqr, x * x)
+
+/* Rounding functions */
+FLECS_MATH_FUNC_F64(ceil, ceil(x))
+FLECS_MATH_FUNC_F64(floor, floor(x))
+FLECS_MATH_FUNC_F64(round, round(x))
+
+FLECS_MATH_FUNC_F64(abs, fabs(x))
+
+FLECS_API
+void FlecsScriptMathImport(
+    ecs_world_t *world)
 {
-    ecs_script_expr_run_desc_t priv_desc = {0};
-    if (desc) {
-        priv_desc = *desc;
-    }
+    ECS_MODULE(world, FlecsScriptMath);
 
-    if (!priv_desc.lookup_action) {
-        priv_desc.lookup_action = flecs_script_default_lookup;
-    }
+    ECS_IMPORT(world, FlecsScript);
 
-    /* Prepare storage for temporary values */
-    ecs_stage_t *stage = flecs_stage_from_world(&world);
-    ecs_value_stack_t stack;
-    stack.count = 0;
-    stack.stage = stage;
-    stack.stack = &stage->allocators.deser_stack;
-    stack.cursor = flecs_stack_get_cursor(stack.stack);
+    /* Constants */
+    double E = 2.71828182845904523536028747135266250;
+    ecs_const_var(world, {
+        .name = "E",
+        .parent = ecs_id(FlecsScriptMath),
+        .type = ecs_id(ecs_f64_t),
+        .value = &E
+    });
 
-    /* Parse expression */
-    bool storage_provided = value->ptr != NULL;
-    ptr = flecs_script_expr_run(
-        world, &stack, ptr, value, EcsExprOperUnknown, &priv_desc);
+    double PI = 3.14159265358979323846264338327950288;
+    ecs_const_var(world, {
+        .name = "PI",
+        .parent = ecs_id(FlecsScriptMath),
+        .type = ecs_id(ecs_f64_t),
+        .value = &PI
+    });
 
-    /* If no result value was provided, allocate one as we can't return a 
-     * pointer to a temporary storage */
-    if (!storage_provided && value->ptr) {
-        ecs_assert(value->type != 0, ECS_INTERNAL_ERROR, NULL);
-        void *temp_storage = value->ptr;
-        value->ptr = ecs_value_new(world, value->type);
-        ecs_value_move_ctor(world, value->type, value->ptr, temp_storage);
-    }
-    
-    /* Cleanup temporary values */
-    int i;
-    for (i = 0; i < stack.count; i ++) {
-        const ecs_type_info_t *ti = stack.values[i].ti;
-        ecs_assert(ti->hooks.dtor != NULL, ECS_INTERNAL_ERROR, NULL);
-        ti->hooks.dtor(stack.values[i].ptr, 1, ti);
-    }
-    flecs_stack_restore_cursor(stack.stack, stack.cursor);
+    /* Trigonometric functions */
+    FLECS_MATH_FUNC_DEF_F64(cos, "Compute cosine");
+    FLECS_MATH_FUNC_DEF_F64(sin, "Compute sine");
+    FLECS_MATH_FUNC_DEF_F64(tan, "Compute tangent");
+    FLECS_MATH_FUNC_DEF_F64(acos, "Compute arc cosine");
+    FLECS_MATH_FUNC_DEF_F64(asin, "Compute arc sine");
+    FLECS_MATH_FUNC_DEF_F64(atan, "Compute arc tangent");
+    FLECS_MATH_FUNC_DEF_F64_F64(atan2, "Compute arc tangent with two parameters");
 
-    return ptr;
-}
+    /* Hyperbolic functions */
+    FLECS_MATH_FUNC_DEF_F64(cosh, "Compute hyperbolic cosine");
+    FLECS_MATH_FUNC_DEF_F64(sinh, "Compute hyperbolic sine");
+    FLECS_MATH_FUNC_DEF_F64(tanh, "Compute hyperbolic tangent");
+    FLECS_MATH_FUNC_DEF_F64(acosh, "Compute area hyperbolic cosine");
+    FLECS_MATH_FUNC_DEF_F64(asinh, "Compute area hyperbolic sine");
+    FLECS_MATH_FUNC_DEF_F64(atanh, "Compute area hyperbolic tangent");
 
-#endif
+    /* Exponential and logarithmic functions */
+    FLECS_MATH_FUNC_DEF_F64(exp, "Compute exponential function");
+    FLECS_MATH_FUNC_DEF_F64_F32(ldexp, "Generate value from significant and exponent");
+    FLECS_MATH_FUNC_DEF_F64(log, "Compute natural logarithm");
+    FLECS_MATH_FUNC_DEF_F64(log10, "Compute common logarithm");
+    FLECS_MATH_FUNC_DEF_F64(exp2, "Compute binary exponential function");
+    FLECS_MATH_FUNC_DEF_F64(log2, "Compute binary logarithm");
 
-/**
- * @file addons/script/interpolate.c
- * @brief String interpolation.
- */
+    /* Power functions */
+    FLECS_MATH_FUNC_DEF_F64_F64(pow, "Raise to power");
+    FLECS_MATH_FUNC_DEF_F64(sqrt, "Compute square root");
+    FLECS_MATH_FUNC_DEF_F64(sqr, "Compute square");
 
+    /* Rounding functions */
+    FLECS_MATH_FUNC_DEF_F64(ceil, "Round up value");
+    FLECS_MATH_FUNC_DEF_F64(floor, "Round down value");
+    FLECS_MATH_FUNC_DEF_F64(round, "Round to nearest");
 
-#ifdef FLECS_SCRIPT
-#include <ctype.h>
+    FLECS_MATH_FUNC_DEF_F64(abs, "Compute absolute value");
 
-static
-const char* flecs_parse_var_name(
-    const char *ptr,
-    char *token_out)
-{
-    char ch, *bptr = token_out;
+    ecs_set_name_prefix(world, "EcsScript");
 
-    while ((ch = *ptr)) {
-        if (bptr - token_out > ECS_MAX_TOKEN_SIZE) {
-            goto error;
+    ECS_COMPONENT_DEFINE(world, EcsScriptRng);
+
+    ecs_set_hooks(world, EcsScriptRng, {
+        .ctor = ecs_ctor(EcsScriptRng),
+        .move = ecs_move(EcsScriptRng),
+        .copy = ecs_copy(EcsScriptRng),
+        .dtor = ecs_dtor(EcsScriptRng),
+    });
+
+    ecs_struct(world, {
+        .entity = ecs_id(EcsScriptRng),
+        .members = {
+            { .name = "seed", .type = ecs_id(ecs_u64_t) }
         }
+    });
 
-        if (isalpha(ch) || isdigit(ch) || ch == '_') {
-            *bptr = ch;
-            bptr ++;
-            ptr ++;
-        } else {
-            break;
-        }
-    }
+    ecs_method(world, {
+        .parent = ecs_id(EcsScriptRng),
+        .name = "f",
+        .return_type = ecs_id(ecs_f64_t),
+        .params = {
+            { .name = "max", .type = ecs_id(ecs_f64_t) }
+        },
+        .callback = flecs_script_rng_get_float
+    });
 
-    if (bptr == token_out) {
-        goto error;
-    }
-
-    *bptr = '\0';
-
-    return ptr;
-error:
-    return NULL;
-}
-
-static
-const char* flecs_parse_interpolated_str(
-    const char *ptr,
-    char *token_out)
-{
-    char ch, *bptr = token_out;
-
-    while ((ch = *ptr)) {
-        if (bptr - token_out > ECS_MAX_TOKEN_SIZE) {
-            goto error;
-        }
-
-        if (ch == '\\') {
-            if (ptr[1] == '}') {
-                *bptr = '}';
-                bptr ++;
-                ptr += 2;
-                continue;
-            }
-        }
-
-        if (ch != '}') {
-            *bptr = ch;
-            bptr ++;
-            ptr ++;
-        } else {
-            ptr ++;
-            break;
-        }
-    }
-
-    if (bptr == token_out) {
-        goto error;
-    }
-
-    *bptr = '\0';
-
-    return ptr;
-error:
-    return NULL;
-}
-
-char* ecs_script_string_interpolate(
-    ecs_world_t *world,
-    const char *str,
-    const ecs_script_vars_t *vars)
-{
-    char token[ECS_MAX_TOKEN_SIZE];
-    ecs_strbuf_t result = ECS_STRBUF_INIT;
-    const char *ptr;
-    char ch;
-
-    for(ptr = str; (ch = *ptr); ptr++) {
-        if (ch == '\\') {
-            ptr ++;
-            if (ptr[0] == '$') {
-                ecs_strbuf_appendch(&result, '$');
-                continue;
-            }
-            if (ptr[0] == '\\') {
-                ecs_strbuf_appendch(&result, '\\');
-                continue;
-            }
-            if (ptr[0] == '{') {
-                ecs_strbuf_appendch(&result, '{');
-                continue;
-            }
-            if (ptr[0] == '}') {
-                ecs_strbuf_appendch(&result, '}');
-                continue;
-            }
-            ptr --;
-        }
-
-        if (ch == '$') {
-            ptr = flecs_parse_var_name(ptr + 1, token);
-            if (!ptr) {
-                ecs_parser_error(NULL, str, ptr - str, 
-                    "invalid variable name '%s'", ptr);
-                goto error;
-            }
-
-            ecs_script_var_t *var = ecs_script_vars_lookup(vars, token);
-            if (!var) {
-                ecs_parser_error(NULL, str, ptr - str, 
-                    "unresolved variable '%s'", token);
-                goto error;
-            }
-
-            if (ecs_ptr_to_str_buf(
-                world, var->value.type, var->value.ptr, &result)) 
-            {
-                goto error;
-            }
-
-            ptr --;
-        } else if (ch == '{') {
-            ptr = flecs_parse_interpolated_str(ptr + 1, token);
-            if (!ptr) {
-                ecs_parser_error(NULL, str, ptr - str, 
-                    "invalid interpolated expression");
-                goto error;
-            }
-
-            ecs_script_expr_run_desc_t expr_desc = { 
-                .vars = ECS_CONST_CAST(ecs_script_vars_t*, vars) 
-            };
-
-            ecs_value_t expr_result = {0};
-            if (!ecs_script_expr_run(world, token, &expr_result, &expr_desc)) {
-                goto error;
-            }
-
-            if (ecs_ptr_to_str_buf(
-                world, expr_result.type, expr_result.ptr, &result)) 
-            {
-                goto error;
-            }
-
-            ecs_value_free(world, expr_result.type, expr_result.ptr);
-
-            ptr --;
-        } else {
-            ecs_strbuf_appendch(&result, ch);
-        }
-    }
-
-    return ecs_strbuf_get(&result);
-error:
-    return NULL;
+    ecs_method(world, {
+        .parent = ecs_id(EcsScriptRng),
+        .name = "u",
+        .return_type = ecs_id(ecs_u64_t),
+        .params = {
+            { .name = "max", .type = ecs_id(ecs_u64_t) }
+        },
+        .callback = flecs_script_rng_get_uint
+    });
 }
 
 #endif
@@ -56324,9 +56325,10 @@ error:
 
 /* Definitions for parser functions */
 #define ParserBegin\
-    ecs_script_tokens_t token_stack = {0};\
-    ecs_script_token_t *tokens = token_stack.tokens;\
-    (void)tokens
+    ecs_script_tokenizer_t _tokenizer;\
+    ecs_os_zeromem(&_tokenizer);\
+    _tokenizer.tokens = _tokenizer.stack.tokens;\
+    ecs_script_tokenizer_t *tokenizer = &_tokenizer;
 
 #define ParserEnd\
         Error("unexpected end of rule (parser error)");\
@@ -56334,7 +56336,14 @@ error:
         return NULL
 
 /* Get token */
-#define Token(n) (tokens[n].value)
+#define Token(n) (tokenizer->tokens[n].value)
+
+/* Push/pop token frame (allows token stack reuse in recursive functions) */
+#define TokenFramePush() \
+    tokenizer->tokens = &tokenizer->stack.tokens[tokenizer->stack.count];
+
+#define TokenFramePop() \
+    tokenizer->tokens = tokenizer->stack.tokens;
 
 /* Error */
 #define Error(...)\
@@ -56342,26 +56351,60 @@ error:
         (pos - parser->script->pub.code) - 1, __VA_ARGS__);\
     goto error
 
+/* Warning */
+#define Warning(...)\
+    ecs_parser_warning(parser->script->pub.name, parser->script->pub.code,\
+        (pos - parser->script->pub.code) - 1, __VA_ARGS__);\
+
 /* Parse expression */
 #define Expr(until, ...)\
     {\
-        ecs_assert(token_stack.count < 256, ECS_INTERNAL_ERROR, NULL);\
-        ecs_script_token_t *t = &token_stack.tokens[token_stack.count ++];\
-        if (!(pos = flecs_script_expr(parser, pos, t, until))) {\
+        ecs_expr_node_t *EXPR = NULL;\
+        if (until == '}' || until == ']') {\
+            pos --;\
+            if (until == '}') {\
+                ecs_assert(pos[0] == '{', ECS_INTERNAL_ERROR, NULL);\
+            } else if (until == ']') {\
+                ecs_assert(pos[0] == '[', ECS_INTERNAL_ERROR, NULL);\
+            }\
+        }\
+        parser->significant_newline = false;\
+        if (!(pos = flecs_script_parse_expr(parser, pos, 0, &EXPR))) {\
             goto error;\
         }\
-        if (!t->value[0] && (until == '\n' || until == '{')) {\
-            pos ++;\
-            Error("empty expression");\
+        parser->significant_newline = true;\
+        __VA_ARGS__\
+    }
+
+/* Parse initializer */
+#define Initializer(until, ...)\
+    {\
+        ecs_expr_node_t *INITIALIZER = NULL;\
+        ecs_expr_initializer_t *_initializer = NULL;\
+        if (until != '\n') {\
+            parser->significant_newline = false;\
         }\
-    }\
-    Parse_1(until, __VA_ARGS__)
+        if (!(pos = flecs_script_parse_initializer(\
+            parser, pos, until, &_initializer))) \
+        {\
+            flecs_expr_visit_free(\
+                &parser->script->pub, (ecs_expr_node_t*)_initializer);\
+            goto error;\
+        }\
+        parser->significant_newline = true;\
+        if (pos[0] != until) {\
+            Error("expected '%c'", until);\
+        }\
+        INITIALIZER = (ecs_expr_node_t*)_initializer;\
+        pos ++;\
+        __VA_ARGS__\
+    }
 
 /* Parse token until character */
 #define Until(until, ...)\
     {\
-        ecs_assert(token_stack.count < 256, ECS_INTERNAL_ERROR, NULL);\
-        ecs_script_token_t *t = &token_stack.tokens[token_stack.count ++];\
+        ecs_assert(tokenizer->stack.count < 256, ECS_INTERNAL_ERROR, NULL);\
+        ecs_script_token_t *t = &tokenizer->stack.tokens[tokenizer->stack.count ++];\
         if (!(pos = flecs_script_until(parser, pos, t, until))) {\
             goto error;\
         }\
@@ -56371,8 +56414,8 @@ error:
 /* Parse next token */
 #define Parse(...)\
     {\
-        ecs_assert(token_stack.count < 256, ECS_INTERNAL_ERROR, NULL);\
-        ecs_script_token_t *t = &token_stack.tokens[token_stack.count ++];\
+        ecs_assert(tokenizer->stack.count < 256, ECS_INTERNAL_ERROR, NULL);\
+        ecs_script_token_t *t = &tokenizer->stack.tokens[tokenizer->stack.count ++];\
         if (!(pos = flecs_script_token(parser, pos, t, false))) {\
             goto error;\
         }\
@@ -56443,11 +56486,11 @@ error:
     ecs_script_token_t lookahead_token;\
     const char *old_lh_token_cur = parser->token_cur;\
     if ((lookahead = flecs_script_token(parser, pos, &lookahead_token, true))) {\
-        token_stack.tokens[token_stack.count ++] = lookahead_token;\
+        tokenizer->stack.tokens[tokenizer->stack.count ++] = lookahead_token;\
         switch(lookahead_token.kind) {\
             __VA_ARGS__\
         default:\
-            token_stack.count --;\
+            tokenizer->stack.count --;\
             break;\
         }\
         if (old_lh_token_cur > parser->token_keep) {\
@@ -56474,7 +56517,9 @@ error:
                 __VA_ARGS__\
             }\
         )\
-        pos = old_ptr;\
+        if (pos != lookahead) {\
+            pos = old_ptr;\
+        }\
     )
 
 #define LookAhead_3(tok1, tok2, tok3, ...)\
@@ -56486,7 +56531,9 @@ error:
                 __VA_ARGS__\
             }\
         )\
-        pos = old_ptr;\
+        if (pos != lookahead) {\
+            pos = old_ptr;\
+        }\
     )
 
 /* Open scope */
@@ -56499,9 +56546,9 @@ error:
 
 /* Parser loop */
 #define Loop(...)\
-    int32_t token_stack_count = token_stack.count;\
+    int32_t token_stack_count = tokenizer->stack.count;\
     do {\
-        token_stack.count = token_stack_count;\
+        tokenizer->stack.count = token_stack_count;\
         __VA_ARGS__\
     } while (true);
 
@@ -56581,7 +56628,7 @@ const char* flecs_script_comma_expr(
                 if (is_base_list) {
                     flecs_script_insert_pair_tag(parser, "IsA", Token(0));
                 } else {
-                    flecs_script_insert_entity(parser, Token(0));
+                    flecs_script_insert_entity(parser, Token(0), false);
                 }
 
                 LookAhead_1(',',
@@ -56612,11 +56659,11 @@ const char* flecs_script_with_expr(
                 pos = lookahead;
 
                 // Position ( expr )
-                Expr(')',
+                Initializer(')',
                     ecs_script_component_t *component =
                         flecs_script_insert_component(parser, Token(0));
                     component->node.kind = EcsAstWithComponent;
-                    component->expr = Token(2);
+                    component->expr = INITIALIZER;
                     EndOfRule;
                 )
             )
@@ -56643,12 +56690,12 @@ const char* flecs_script_with_expr(
                     pos = lookahead;
 
                     // (Eats, Apples) ( expr )
-                    Expr(')',
+                    Initializer(')',
                         ecs_script_component_t *component =
                             flecs_script_insert_pair_component(parser, 
                                 Token(1), Token(3));
                         component->node.kind = EcsAstWithComponent;
-                        component->expr = Token(6);
+                        component->expr = INITIALIZER;
                         EndOfRule;
                     )
                 )
@@ -56706,13 +56753,13 @@ const char* flecs_script_paren_expr(
 {
     ParserBegin;
 
-    Expr(')',
+    Initializer(')',
         entity->kind_w_expr = true;
 
         Scope(entity->scope, 
             ecs_script_component_t *component = 
                 flecs_script_insert_component(parser, kind);
-            component->expr = Token(0);
+            component->expr = INITIALIZER;
         )
 
         Parse(
@@ -56733,16 +56780,136 @@ const char* flecs_script_paren_expr(
 
 /* Parse a single statement */
 static
+const char* flecs_script_if_stmt(
+    ecs_script_parser_t *parser,
+    const char *pos)
+{
+    ParserBegin;
+
+    // if expr
+    Expr('\0',
+        // if expr {
+        Parse_1('{', {
+            ecs_script_if_t *stmt = flecs_script_insert_if(parser);
+            stmt->expr = EXPR;
+            pos = flecs_script_scope(parser, stmt->if_true, pos);
+            if (!pos) {
+                goto error;
+            }
+
+            // if expr { } else
+            LookAhead_1(EcsTokKeywordElse, 
+                pos = lookahead;
+
+                Parse(
+                    // if expr { } else if
+                    case EcsTokKeywordIf: {
+                        Scope(stmt->if_false, 
+                            return flecs_script_if_stmt(parser, pos);
+                        )
+                    }
+
+                    // if expr { } else\n if
+                    case EcsTokNewline: {
+                        Parse_1(EcsTokKeywordIf,
+                            Scope(stmt->if_false, 
+                                return flecs_script_if_stmt(parser, pos);
+                            )
+                        )
+                    }
+
+                    // if expr { } else {
+                    case '{': {
+                        return flecs_script_scope(parser, stmt->if_false, pos);
+                    }
+                )
+            )
+
+            EndOfRule;
+        });
+    )
+
+    ParserEnd;
+}
+
+static
+const char* flecs_script_parse_var(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_tokenizer_t *tokenizer,
+    bool is_prop)
+{
+    Parse_1(EcsTokIdentifier,
+        ecs_script_var_node_t *var = flecs_script_insert_var(
+            parser, Token(1));
+        var->node.kind = is_prop ? EcsAstProp : EcsAstConst;
+
+        Parse(
+            // const color =
+            case '=': {
+                // const color = Color :
+                LookAhead_2(EcsTokIdentifier, ':',
+                    pos = lookahead;
+
+                    var->type = Token(3);
+
+                    // const color = Color: {
+                    LookAhead_1('{',
+                        // const color = Color: {expr}
+                        pos = lookahead;
+                        Initializer('}',
+                            var->expr = INITIALIZER;
+                            EndOfRule;
+                        )
+                    )
+
+                    // const color = Color: expr\n
+                    Initializer('\n',
+                        var->expr = INITIALIZER;
+                        EndOfRule;
+                    )
+                )
+
+                // const PI = expr\n
+                Expr('\n',
+                    Warning("'%s var = expr' syntax is deprecated"
+                        ", use '%s var: expr' instead", 
+                            is_prop ? "prop" : "const",
+                            is_prop ? "prop" : "const");
+                    var->expr = EXPR;
+                    EndOfRule;
+                )
+            }
+
+            case ':': {
+                // const PI: expr\n
+                Expr('\n',
+                    var->expr = EXPR;
+                    EndOfRule;
+                )
+            }
+        )
+    )
+
+error:
+    return NULL;
+}
+
+/* Parse a single statement */
+static
 const char* flecs_script_stmt(
     ecs_script_parser_t *parser,
     const char *pos) 
 {
     ParserBegin;
 
+    bool name_is_expr_0 = false;
+    bool name_is_expr_1 = false;
+
     Parse(
         case EcsTokIdentifier:        goto identifier;
-        case '{':                     return flecs_script_scope(parser, 
-                                        flecs_script_insert_scope(parser), pos);
+        case EcsTokString:            goto string_name;
+        case '{':                     goto anonymous_entity;
         case '(':                     goto paren;
         case '@':                     goto annotation;
         case EcsTokKeywordWith:       goto with_stmt;
@@ -56752,8 +56919,23 @@ const char* flecs_script_stmt(
         case EcsTokKeywordProp:       goto prop_var;
         case EcsTokKeywordConst:      goto const_var;
         case EcsTokKeywordIf:         goto if_stmt;
+        case EcsTokKeywordFor:        goto for_stmt;
         EcsTokEndOfStatement:         EndOfRule;
     );
+
+anonymous_entity: {
+    return flecs_script_scope(parser, 
+        flecs_script_insert_entity(parser, "_", false)->scope, pos);
+}
+
+string_name:
+    /* If this is an interpolated string, we need to evaluate it as expression
+     * at evaluation time. Otherwise we can just use the string as name. The 
+     * latter is useful if an entity name contains special characters that are
+     * not allowed in identifier tokens. */
+    if (flecs_string_is_interpolated(Token(0))) {
+        name_is_expr_0 = true;
+    }
 
 identifier: {
     // enterprise } (end of scope)
@@ -56766,12 +56948,16 @@ identifier: {
         case '{': {
             return flecs_script_scope(parser, 
                 flecs_script_insert_entity(
-                    parser, Token(0))->scope, pos);
+                    parser, Token(0), name_is_expr_0)->scope, pos);
         }
 
         // Red,
         case ',': {
-            flecs_script_insert_entity(parser, Token(0));
+            if (name_is_expr_0) {
+                Error("expression not allowed as entity name here");
+            }
+
+            flecs_script_insert_entity(parser, Token(0), false);
             pos = flecs_script_comma_expr(parser, pos, false);
             EndOfRule;
         }
@@ -56783,7 +56969,7 @@ identifier: {
                 pos = lookahead;
                 return flecs_script_scope(parser, 
                     flecs_script_insert_entity(
-                        parser, Token(0))->scope, pos);
+                        parser, Token(0), name_is_expr_0)->scope, pos);
             )
 
             goto insert_tag;
@@ -56813,6 +56999,11 @@ identifier: {
         case EcsTokIdentifier: {
             goto identifier_identifier;
         }
+
+        // Spaceship "enterprise"
+        case EcsTokString: {
+            goto identifier_string;
+        }
     )
 }
 
@@ -56821,13 +57012,13 @@ insert_tag: {
         if (!flecs_script_insert_var_component(parser, &Token(0)[1])) {
             Error(
                 "invalid context for variable component '%s': must be "
-                    "part of entity", tokens[0].value);
+                    "part of entity", tokenizer->tokens[0].value);
         }
     } else {
         if (!flecs_script_insert_tag(parser, Token(0))) {
             Error(
                 "invalid context for tag '%s': must be part of entity", 
-                tokens[0].value);
+                tokenizer->tokens[0].value);
         }
     }
 
@@ -56897,97 +57088,43 @@ template_stmt: {
 // prop
 prop_var: {
     // prop color = Color:
-    Parse_4(EcsTokIdentifier, '=', EcsTokIdentifier, ':',
-        ecs_script_var_node_t *var = flecs_script_insert_var(
-            parser, Token(1));
-        var->node.kind = EcsAstProp;
-        var->type = Token(3);
-
-        // prop color = Color : {
-        LookAhead_1('{',
-            // prop color = Color: {expr}
-            pos = lookahead;
-            Expr('}',
-                var->expr = Token(6);
-                EndOfRule;
-            )
-        )
-
-        // prop color = Color : expr\n
-        Expr('\n',
-            var->expr = Token(5);
-            EndOfRule;
-        )
-    )
+    return flecs_script_parse_var(parser, pos, tokenizer, true);
 }
 
 // const
 const_var: {
     // const color
-    Parse_1(EcsTokIdentifier,
-        ecs_script_var_node_t *var = flecs_script_insert_var(
-            parser, Token(1));
-        var->node.kind = EcsAstConst;
-
-        Parse(
-            // const color =
-            case '=': {
-                // const color = Color :
-                LookAhead_2(EcsTokIdentifier, ':',
-                    pos = lookahead;
-
-                    var->type = Token(3);
-
-                    // const color = Color: {
-                    LookAhead_1('{',
-                        // const color = Color: {expr}
-                        pos = lookahead;
-                        Expr('}',
-                            var->expr = Token(6);
-                            EndOfRule;
-                        )
-                    )
-
-                    // const color = Color: expr\n
-                    Expr('\n',
-                        var->expr = Token(5);
-                        EndOfRule;
-                    )
-                )
-
-                // const PI = expr\n
-                Expr('\n',
-                    var->expr = Token(3);
-                    EndOfRule;
-                )
-            }
-        )
-    )
+    return flecs_script_parse_var(parser, pos, tokenizer, false);
 }
 
 // if
 if_stmt: {
-    // if expr {
-    Expr('{',
-        ecs_script_if_t *stmt = flecs_script_insert_if(parser);
-        stmt->expr = Token(1);
-        pos = flecs_script_scope(parser, stmt->if_true, pos);
-        if (!pos) {
-            goto error;
-        }
+    return flecs_script_if_stmt(parser, pos);
+}
 
-        // if expr { } else
-        LookAhead_1(EcsTokKeywordElse, 
-            pos = lookahead;
+// for
+for_stmt: {
+    // for i
+    Parse_2(EcsTokIdentifier, EcsTokKeywordIn, {
+        Expr(0, {
+            ecs_expr_node_t *from = EXPR;
+            Parse_1(EcsTokRange, {
+                Expr(0, {
+                    ecs_expr_node_t *to = EXPR;
+                    ecs_script_for_range_t *stmt = 
+                        flecs_script_insert_for_range(parser);
+                    stmt->loop_var = Token(1);
+                    stmt->from = from;
+                    stmt->to = to;
 
-            // if expr { } else {
-            Parse_1('{',
-                return flecs_script_scope(parser, stmt->if_false, pos);
-            )
-        )
+                    Parse_1('{', {
+                        return flecs_script_scope(parser, stmt->scope, pos);
+                    });
+                });
+            });
+        });
 
-        EndOfRule;
-    )
+    });
 }
 
 // (
@@ -57015,16 +57152,29 @@ pair: {
 
         // (Eats, Apples):
         case ':': {
-            // (Eats, Apples): {
-            Parse_1('{',
-                // (Eats, Apples): { expr }
-                Expr('}',
+            // Use lookahead so that expression parser starts at "match"
+            LookAhead_1(EcsTokKeywordMatch, {
+                // (Eats, Apples): match expr
+                Expr('\n', {
                     ecs_script_component_t *comp = 
                         flecs_script_insert_pair_component(
                             parser, Token(1), Token(3));
-                    comp->expr = Token(7);
-                    EndOfRule;
-                )
+                    comp->expr = EXPR;
+                    EndOfRule; 
+                })
+            })
+
+            // (Eats, Apples): {
+            Parse_1('{', {
+                    // (Eats, Apples): { expr }
+                    Initializer('}',
+                        ecs_script_component_t *comp = 
+                            flecs_script_insert_pair_component(
+                                parser, Token(1), Token(3));
+                        comp->expr = INITIALIZER;
+                        EndOfRule;
+                    )
+                }
             )
         }
 
@@ -57069,7 +57219,7 @@ identifier_flag: {
                                 ecs_script_component_t *comp = 
                                     flecs_script_insert_pair_component(
                                         parser, Token(3), Token(5));
-                                comp->expr = Token(9);
+                                comp->expr = EXPR;
                                 EndOfRule; 
                             })
                         )
@@ -57094,9 +57244,10 @@ identifier_flag: {
                     Parse_1('{',
                         // auto_override | Position: {expr}
                         Expr('}', {
-                            ecs_script_component_t *comp = flecs_script_insert_component(
-                                parser, Token(2));
-                            comp->expr = Token(5);
+                            ecs_script_component_t *comp = 
+                                flecs_script_insert_component(
+                                    parser, Token(2));
+                            comp->expr = EXPR;
                             EndOfRule; 
                         })
                     )
@@ -57124,10 +57275,17 @@ identifier_colon: {
         )
     }
 
+    {
+        // Position: match
+        LookAhead_1(EcsTokKeywordMatch,
+            goto component_expr_match;
+        )
+    }
+
     // enterprise : SpaceShip
     Parse_1(EcsTokIdentifier, {
         ecs_script_entity_t *entity = flecs_script_insert_entity(
-            parser, Token(0));
+            parser, Token(0), name_is_expr_0);
 
         Scope(entity->scope, 
             flecs_script_insert_pair_tag(parser, "IsA", Token(2));
@@ -57153,20 +57311,32 @@ identifier_colon: {
 // x =
 identifier_assign: {
     ecs_script_entity_t *entity = flecs_script_insert_entity(
-        parser, Token(0));
+        parser, Token(0), name_is_expr_0);
 
     // x = Position:
     LookAhead_2(EcsTokIdentifier, ':',
         pos = lookahead;
 
+        // Use lookahead so that expression parser starts at "match"
+        LookAhead_1(EcsTokKeywordMatch, {
+            // (Eats, Apples): match expr
+            Expr('\n', {
+                ecs_script_component_t *comp = 
+                    flecs_script_insert_pair_component(
+                        parser, Token(1), Token(3));
+                comp->expr = EXPR;
+                EndOfRule; 
+            })
+        })
+
         // x = Position: {
         Parse_1('{', {
             // x = Position: {expr}
-            Expr('}', 
+            Expr('}',
                 Scope(entity->scope, 
                     ecs_script_component_t *comp = 
                         flecs_script_insert_component(parser, Token(2));
-                    comp->expr = Token(5);
+                    comp->expr = EXPR;
                 )
 
                 // x = Position: {expr}\n
@@ -57179,11 +57349,11 @@ identifier_assign: {
     )
 
     // x = f32\n
-    Expr('\n',
+    Initializer('\n',
         Scope(entity->scope, 
             ecs_script_default_component_t *comp = 
                 flecs_script_insert_default_component(parser);
-            comp->expr = Token(2);
+            comp->expr = INITIALIZER;
         )
         
         EndOfRule;
@@ -57191,9 +57361,15 @@ identifier_assign: {
 }
 
 // Spaceship enterprise
+identifier_string: {
+    if (flecs_string_is_interpolated(Token(1))) {
+        name_is_expr_1 = true;
+    }
+}
+
 identifier_identifier: {
     ecs_script_entity_t *entity = flecs_script_insert_entity(
-        parser, Token(1));
+        parser, Token(1), name_is_expr_1);
     entity->kind = Token(0);
 
     // Spaceship enterprise :
@@ -57236,17 +57412,17 @@ identifier_identifier_x:
 // SpaceShip(
 identifier_paren: {
     // SpaceShip()
-    Expr(')', 
+    Initializer(')',
         Parse(
             // SpaceShip(expr)\n
             EcsTokEndOfStatement: {
                 ecs_script_entity_t *entity = flecs_script_insert_entity(
-                    parser, NULL);
+                    parser, NULL, false);
 
                 Scope(entity->scope, 
                     ecs_script_component_t *comp = 
                         flecs_script_insert_component(parser, Token(0)); 
-                    comp->expr = Token(2);
+                    comp->expr = INITIALIZER;
                 )
 
                 EndOfRule;
@@ -57255,12 +57431,12 @@ identifier_paren: {
             // SpaceShip(expr) {
             case '{': {
                 ecs_script_entity_t *entity = flecs_script_insert_entity(
-                    parser, NULL);
+                    parser, NULL, false);
 
                 Scope(entity->scope, 
                     ecs_script_component_t *comp = 
                         flecs_script_insert_component(parser, Token(0)); 
-                    comp->expr = Token(2);
+                    comp->expr = INITIALIZER;
                 )
 
                 return flecs_script_scope(parser, entity->scope, pos);
@@ -57276,7 +57452,7 @@ component_expr_scope: {
     Expr('}', {
         ecs_script_component_t *comp = flecs_script_insert_component(
             parser, Token(0));
-        comp->expr = Token(3);
+        comp->expr = EXPR;
         EndOfRule; 
     })
 }
@@ -57287,8 +57463,20 @@ component_expr_collection: {
     Expr(']', {
         ecs_script_component_t *comp = flecs_script_insert_component(
             parser, Token(0));
-        comp->expr = Token(3);
+        comp->expr = EXPR;
         comp->is_collection = true;
+        EndOfRule; 
+    })
+}
+
+// Position: match
+component_expr_match: {
+
+    // Position: match expr
+    Expr('\n', {
+        ecs_script_component_t *comp = flecs_script_insert_component(
+            parser, Token(0));
+        comp->expr = EXPR;
         EndOfRule; 
     })
 }
@@ -57300,8 +57488,11 @@ component_expr_collection: {
 ecs_script_t* ecs_script_parse(
     ecs_world_t *world,
     const char *name,
-    const char *code) 
+    const char *code,
+    const ecs_script_eval_desc_t *desc) 
 {
+    (void)desc; /* Will be used in future to expand type checking features */
+
     if (!code) {
         code = "";
     }
@@ -57325,8 +57516,8 @@ ecs_script_t* ecs_script_parse(
      * ensures that AST nodes don't need to do separate allocations for the data
      * they contain. */
     impl->token_buffer_size = ecs_os_strlen(code) * 2 + 1;
-    impl->token_buffer = flecs_alloc(
-        &impl->allocator, impl->token_buffer_size);
+    impl->token_buffer = flecs_alloc_w_dbg_info(
+        &impl->allocator, impl->token_buffer_size, "token buffer");
     parser.token_cur = impl->token_buffer;
 
     /* Start parsing code */
@@ -57344,6 +57535,8 @@ ecs_script_t* ecs_script_parse(
             break;
         }
     } while (true);
+
+    impl->token_remaining = parser.token_cur;
 
     return script;
 error:
@@ -57529,25 +57722,27 @@ const char* flecs_term_parse_arg(
 
                 // Position(src|
                 //          ^
-                LookAhead_1('|',
-                    pos = lookahead;
-                    pos = flecs_term_parse_trav(parser, ref, pos);
-                    if (!pos) {
-                        goto error;
-                    }
-
-                    // Position(src|up IsA
-                    //          ^
-                    LookAhead_1(EcsTokIdentifier,
+                {
+                    LookAhead_1('|',
                         pos = lookahead;
-                        parser->term->trav = ecs_lookup(
-                            parser->script->pub.world, Token(1));
-                        if (!parser->term->trav) {
-                            Error(
-                                "unresolved trav identifier '%s'", Token(1));
+                        pos = flecs_term_parse_trav(parser, ref, pos);
+                        if (!pos) {
+                            goto error;
                         }
+
+                        // Position(src|up IsA
+                        //          ^
+                        LookAhead_1(EcsTokIdentifier,
+                            pos = lookahead;
+                            parser->term->trav = ecs_lookup(
+                                parser->script->pub.world, Token(1));
+                            if (!parser->term->trav) {
+                                Error(
+                                    "unresolved trav identifier '%s'", Token(1));
+                            }
+                        )
                     )
-                )
+                }
 
                 break;
             }
@@ -57829,7 +58024,7 @@ const char* flecs_query_term_parse(
     Parse(
         case '[':
             return flecs_term_parse_inout(parser, pos);
-        case EcsTokTermIdentifier:   
+        case EcsTokTermIdentifier: 
             return flecs_term_parse_flags(parser, Token(0), pos);
         case '(':
             return flecs_term_parse_pair(parser, pos);
@@ -57872,7 +58067,8 @@ int flecs_terms_parse(
 
     ecs_script_parser_t parser = {
         .script = flecs_script_impl(script),
-        .pos = script->code
+        .pos = script->code,
+        .merge_variable_members = true
     };
 
     parser.token_cur = flecs_script_impl(script)->token_buffer;
@@ -58142,6 +58338,9 @@ error:
 #ifdef FLECS_SCRIPT
 
 ECS_COMPONENT_DECLARE(EcsScript);
+ECS_COMPONENT_DECLARE(EcsScriptConstVar);
+ECS_COMPONENT_DECLARE(EcsScriptFunction);
+ECS_COMPONENT_DECLARE(EcsScriptMethod);
 
 static
 ECS_MOVE(EcsScript, dst, src, {
@@ -58198,7 +58397,21 @@ void ecs_script_clear(
     ecs_entity_t script,
     ecs_entity_t instance)
 {
-    ecs_delete_with(world, flecs_script_tag(script, instance));
+    if (!instance) {
+        ecs_delete_with(world, ecs_pair_t(EcsScript, script));
+    } else {
+        ecs_defer_begin(world);
+        ecs_iter_t it = ecs_children(world, instance);
+        while (ecs_children_next(&it)) {
+            if (ecs_table_has_id(world, it.table, ecs_pair(EcsScriptTemplate, script))) {
+                int32_t i, count = it.count;
+                for (i = 0; i < count; i ++) {
+                    ecs_delete(world, it.entities[i]);
+                }
+            }
+        }
+        ecs_defer_end(world);
+    }
 }
 
 int ecs_script_run(
@@ -58206,14 +58419,14 @@ int ecs_script_run(
     const char *name,
     const char *code)
 {
-    ecs_script_t *script = ecs_script_parse(world, name, code);
+    ecs_script_t *script = ecs_script_parse(world, name, code, NULL);
     if (!script) {
         goto error;
     }
 
     ecs_entity_t prev_scope = ecs_set_scope(world, 0);
 
-    if (ecs_script_eval(script)) {
+    if (ecs_script_eval(script, NULL)) {
         goto error_free;
     }
 
@@ -58248,6 +58461,7 @@ void ecs_script_free(
     ecs_check(impl->refcount > 0, ECS_INVALID_OPERATION, NULL);
     if (!--impl->refcount) {
         flecs_script_visit_free(script);
+        flecs_expr_visit_free(script, impl->expr);
         flecs_free(&impl->allocator, 
             impl->token_buffer_size, impl->token_buffer);
         flecs_allocator_fini(&impl->allocator);
@@ -58283,7 +58497,7 @@ int ecs_script_update(
         ecs_script_free(s->script);
     }
 
-    s->script = ecs_script_parse(world, name, code);
+    s->script = ecs_script_parse(world, name, code, NULL);
     if (!s->script) {
         return -1;
     }
@@ -58302,7 +58516,9 @@ int ecs_script_update(
 
     ecs_entity_t prev = ecs_set_with(world, flecs_script_tag(e, instance));
 
-    if (ecs_script_eval(s->script)) {
+    if (ecs_script_eval(s->script, NULL)) {
+        ecs_script_free(s->script);
+        s->script = NULL;
         ecs_delete_with(world, ecs_pair_t(EcsScript, e));
         result = -1;
     }
@@ -58363,8 +58579,56 @@ error:
     return 0;
 }
 
+ecs_script_runtime_t* ecs_script_runtime_new(void) 
+{
+    ecs_script_runtime_t *r = ecs_os_calloc_t(ecs_script_runtime_t);
+    flecs_expr_stack_init(&r->expr_stack);
+    flecs_allocator_init(&r->allocator);
+    flecs_stack_init(&r->stack);
+    ecs_vec_init_t(&r->allocator, &r->using, ecs_entity_t, 0);
+    ecs_vec_init_t(&r->allocator, &r->with, ecs_value_t, 0);
+    ecs_vec_init_t(&r->allocator, &r->with_type_info, ecs_type_info_t*, 0);
+    ecs_vec_init_t(&r->allocator, &r->annot, ecs_script_annot_t*, 0);
+    return r;
+}
+
+void ecs_script_runtime_free(
+    ecs_script_runtime_t *r)
+{
+    flecs_expr_stack_fini(&r->expr_stack);
+    ecs_vec_fini_t(&r->allocator, &r->annot, ecs_script_annot_t*);
+    ecs_vec_fini_t(&r->allocator, &r->with, ecs_value_t);
+    ecs_vec_fini_t(&r->allocator, &r->with_type_info, ecs_type_info_t*);
+    ecs_vec_fini_t(&r->allocator, &r->using, ecs_entity_t);
+    flecs_allocator_fini(&r->allocator);
+    flecs_stack_fini(&r->stack);
+    ecs_os_free(r);
+}
+
+ecs_script_runtime_t* flecs_script_runtime_get(
+    ecs_world_t *world)
+{
+    ecs_stage_t *stage;
+    if (flecs_poly_is(world, ecs_stage_t)) {
+        stage = (ecs_stage_t*)world;
+    } else {
+        stage = world->stages[0];
+    }
+
+    ecs_assert(stage != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    if (!stage->runtime) {
+        stage->runtime = ecs_script_runtime_new();
+    }
+
+    return stage->runtime;
+}
+
 static
-int EcsScript_serialize(const ecs_serializer_t *ser, const void *ptr) {
+int EcsScript_serialize(
+    const ecs_serializer_t *ser, 
+    const void *ptr) 
+{
     const EcsScript *data = ptr;
     if (data->script) {
         ser->member(ser, "name");
@@ -58372,7 +58636,7 @@ int EcsScript_serialize(const ecs_serializer_t *ser, const void *ptr) {
         ser->member(ser, "code");
         ser->value(ser, ecs_id(ecs_string_t), &data->script->code);
 
-        char *ast = ecs_script_ast_to_str(data->script);
+        char *ast = ecs_script_ast_to_str(data->script, true);
         ser->member(ser, "ast");
         ser->value(ser, ecs_id(ecs_string_t), &ast);
         ecs_os_free(ast);
@@ -58405,7 +58669,8 @@ void FlecsScriptImport(
     ecs_set_hooks(world, EcsScript, {
         .ctor = flecs_default_ctor,
         .move = ecs_move(EcsScript),
-        .dtor = ecs_dtor(EcsScript)
+        .dtor = ecs_dtor(EcsScript),
+        .flags = ECS_TYPE_HOOK_COPY_ILLEGAL
     });
 
     ECS_COMPONENT(world, ecs_script_t);
@@ -58428,6 +58693,9 @@ void FlecsScriptImport(
     ecs_add_id(world, ecs_id(EcsScript), EcsPairIsTag);
     ecs_add_id(world, ecs_id(EcsScript), EcsPrivate);
     ecs_add_pair(world, ecs_id(EcsScript), EcsOnInstantiate, EcsDontInherit);
+
+    flecs_script_template_import(world);
+    flecs_function_import(world);
 }
 
 #endif
@@ -58648,6 +58916,8 @@ int flecs_expr_ser_type_op(
     ecs_strbuf_t *str,
     bool is_expr)
 {
+    ecs_assert(ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+
     switch(op->kind) {
     case EcsOpPush:
     case EcsOpPop:
@@ -58896,6 +59166,42 @@ char* ecs_ptr_to_str(
 
 #ifdef FLECS_SCRIPT
 
+ECS_COMPONENT_DECLARE(EcsScriptTemplateSetEvent);
+ECS_DECLARE(EcsScriptTemplate);
+
+static
+void flecs_template_set_event_free(EcsScriptTemplateSetEvent *ptr) {
+    if (ptr->entities != &ptr->entity_storage) {
+        ecs_os_free(ptr->entities);
+    }
+    if (ptr->data != ptr->data_storage) {
+        ecs_os_free(ptr->data);
+    }
+}
+
+static
+ECS_MOVE(EcsScriptTemplateSetEvent, dst, src, {
+    flecs_template_set_event_free(dst);
+
+    *dst = *src;
+
+    if (src->entities == &src->entity_storage) {
+        dst->entities = &dst->entity_storage;
+    }
+
+    if (src->data == src->data_storage) {
+        dst->data = &dst->data_storage;
+    }
+
+    src->entities = NULL;
+    src->data = NULL;
+})
+
+static
+ECS_DTOR(EcsScriptTemplateSetEvent, ptr, {
+    flecs_template_set_event_free(ptr);
+})
+
 /* Template ctor to initialize with default property values */
 static
 void flecs_script_template_ctor(
@@ -58944,6 +59250,172 @@ void flecs_script_template_ctor(
     }
 }
 
+/* Defer template instantiation if we're in deferred mode. */
+static
+void flecs_script_template_defer_on_set(
+    ecs_iter_t *it,
+    ecs_entity_t template_entity,
+    const ecs_type_info_t *ti,
+    void *data)
+{
+    EcsScriptTemplateSetEvent evt;
+
+    if ((it->count == 1) && ti->size <= ECS_TEMPLATE_SMALL_SIZE && !ti->hooks.dtor) {
+        /* This should be true for the vast majority of templates */
+        evt.entities = &evt.entity_storage;
+        evt.data = evt.data_storage;
+        evt.entity_storage = it->entities[0];
+        ecs_os_memcpy(evt.data, data, ti->size);
+    } else {
+        evt.entities = ecs_os_memdup_n(it->entities, ecs_entity_t, it->count);
+        evt.data = ecs_os_memdup(data, ti->size * it->count);
+    }
+
+    evt.count = it->count;
+    evt.template_entity = template_entity;
+
+    ecs_enqueue(it->world, &(ecs_event_desc_t){
+        .event = ecs_id(EcsScriptTemplateSetEvent),
+        .entity = EcsAny,
+        .param = &evt
+    });
+}
+
+static
+void flecs_script_template_instantiate(
+    ecs_world_t *world,
+    ecs_entity_t template_entity,
+    const ecs_entity_t *entities,
+    void *data,
+    int32_t count)
+{
+    ecs_assert(!ecs_is_deferred(world), ECS_INTERNAL_ERROR, NULL);
+
+    ecs_record_t *r = ecs_record_find(world, template_entity);
+    if (!r) {
+        ecs_err("template entity is empty (should never happen)");
+        return;
+    }
+
+    const EcsScript *script = ecs_record_get(world, r, EcsScript);
+    if (!script) {
+        ecs_err("template is missing script component");
+        return;
+    }
+
+    ecs_script_template_t *template = script->template_;
+    ecs_assert(template != NULL, ECS_INTERNAL_ERROR, NULL);
+    const ecs_type_info_t *ti = template->type_info;
+    ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
+    const EcsStruct *st = ecs_record_get(world, r, EcsStruct);
+
+    ecs_script_eval_visitor_t v;
+    ecs_script_eval_desc_t desc = {
+        .runtime = flecs_script_runtime_get(world)
+    };
+
+    flecs_script_eval_visit_init(flecs_script_impl(script->script), &v, &desc);
+    ecs_vec_t prev_using = v.r->using;
+    ecs_vec_t prev_with = desc.runtime->with;
+    ecs_vec_t prev_with_type_info = desc.runtime->with_type_info;
+    v.r->using = template->using_;
+    v.template_entity = template_entity;
+    ecs_vec_init_t(NULL, &desc.runtime->with, ecs_value_t, 0);
+    ecs_vec_init_t(NULL, &desc.runtime->with_type_info, ecs_type_info_t*, 0);
+
+    ecs_script_scope_t *scope = template->node->scope;
+
+    /* Dummy entity node for instance */
+    ecs_script_entity_t instance_node = {
+        .node = {
+            .kind = EcsAstEntity,
+            .pos = template->node->node.pos
+        },
+        .scope = scope
+    };
+
+    v.entity = &instance_node;
+
+    int32_t i, m;
+    for (i = 0; i < count; i ++) {
+        v.parent = entities[i];
+        ecs_assert(ecs_is_alive(world, v.parent), ECS_INTERNAL_ERROR, NULL);
+
+        instance_node.eval = entities[i];
+
+        /* Create variables to hold template properties */
+        ecs_script_vars_t *vars = flecs_script_vars_push(
+            NULL, &v.r->stack, &v.r->allocator);
+        vars->parent = template->vars; /* Include hoisted variables */
+        vars->sp = ecs_vec_count(&template->vars->vars);
+
+        /* Allocate enough space for variables */
+        ecs_script_vars_set_size(vars, (st ? st->members.count : 0) + 1);
+
+        /* Populate $this variable with instance entity */
+        ecs_entity_t instance = entities[i];
+        ecs_script_var_t *this_var = ecs_script_vars_declare(
+            vars, NULL /* $this */);
+        this_var->value.type = ecs_id(ecs_entity_t);
+        this_var->value.ptr = &instance;
+
+        /* Populate properties from template members */
+        if (st) {
+            const ecs_member_t *members = st->members.array;
+            for (m = 0; m < st->members.count; m ++) {
+                const ecs_member_t *member = &members[m];
+
+                /* Assign template property from template instance. Don't 
+                 * set name as variables will be resolved by frame offset. */
+                ecs_script_var_t *var = ecs_script_vars_declare(
+                    vars, NULL /* member->name */);
+                var->value.type = member->type;
+                var->value.ptr = ECS_OFFSET(data, member->offset);
+            }
+        }
+
+        ecs_script_clear(world, template_entity, instance);
+
+        /* Run template code */
+        v.vars = vars;
+
+        flecs_script_eval_scope(&v, scope);
+
+        /* Pop variable scope */
+        ecs_script_vars_pop(vars);
+
+        data = ECS_OFFSET(data, ti->size);
+    }
+
+    ecs_vec_fini_t(&desc.runtime->allocator, 
+        &desc.runtime->with, ecs_value_t);
+    ecs_vec_fini_t(&desc.runtime->allocator, 
+        &desc.runtime->with_type_info, ecs_type_info_t*);
+
+    v.r->with = prev_with;
+    v.r->with_type_info = prev_with_type_info;
+    v.r->using = prev_using;
+    flecs_script_eval_visit_fini(&v, &desc);
+}
+
+static
+void flecs_on_template_set_event(
+    ecs_iter_t *it)
+{
+    ecs_assert(ecs_is_deferred(it->world), ECS_INTERNAL_ERROR, NULL);
+
+    EcsScriptTemplateSetEvent *evt = it->param;
+    ecs_world_t *world = it->real_world;
+    ecs_assert(flecs_poly_is(world, ecs_world_t), ECS_INTERNAL_ERROR, NULL);
+
+    ecs_defer_suspend(world);
+
+    flecs_script_template_instantiate(
+        world, evt->template_entity, evt->entities, evt->data, evt->count);
+
+    ecs_defer_resume(world);
+}
+
 /* Template on_set handler to update contents for new property values */
 static
 void flecs_script_template_on_set(
@@ -58972,84 +59444,16 @@ void flecs_script_template_on_set(
     ecs_assert(template != NULL, ECS_INTERNAL_ERROR, NULL);
     const ecs_type_info_t *ti = template->type_info;
     ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
-    const EcsStruct *st = ecs_record_get(world, r, EcsStruct);
-
     void *data = ecs_field_w_size(it, flecs_ito(size_t, ti->size), 0);
 
-    ecs_script_eval_visitor_t v;
-    flecs_script_eval_visit_init(flecs_script_impl(script->script), &v);
-    ecs_vec_t prev_using = v.using;
-    v.using = template->using_;
-
-    ecs_script_scope_t *scope = template->node->scope;
-
-    /* Dummy entity node for instance */
-    ecs_script_entity_t instance_node = {
-        .node = {
-            .kind = EcsAstEntity,
-            .pos = template->node->node.pos
-        },
-        .scope = scope
-    };
-
-    v.entity = &instance_node;
-
-    int32_t i, m;
-    for (i = 0; i < it->count; i ++) {
-        v.parent = it->entities[i];
-        instance_node.eval = it->entities[i];
-
-        /* Create variables to hold template properties */
-        ecs_script_vars_t *vars = flecs_script_vars_push(
-            NULL, &v.stack, v.allocator);
-        vars->parent = template->vars; /* Include hoisted variables */
-
-        /* Populate properties from template members */
-        if (st) {
-            const ecs_member_t *members = st->members.array;
-            for (m = 0; m < st->members.count; m ++) {
-                const ecs_member_t *member = &members[m];
-
-                /* Assign template property from template instance */
-                ecs_script_var_t *var = ecs_script_vars_declare(vars, member->name);
-                var->value.type = member->type;
-                var->value.ptr = ECS_OFFSET(data, member->offset);
-            }
-        }
-
-        /* Populate $this variable with instance entity */
-        ecs_entity_t instance = it->entities[i];
-        ecs_script_var_t *var = ecs_script_vars_declare(vars, "this");
-        var->value.type = ecs_id(ecs_entity_t);
-        var->value.ptr = &instance;
-
-        bool is_defer = ecs_is_deferred(world);
-        ecs_suspend_readonly_state_t srs;
-        ecs_world_t *real_world = NULL;
-        if (is_defer) {
-            ecs_assert(flecs_poly_is(world, ecs_world_t), ECS_INTERNAL_ERROR, NULL);
-            real_world = flecs_suspend_readonly(world, &srs);
-            ecs_assert(real_world != NULL, ECS_INTERNAL_ERROR, NULL);
-        }
-
-        ecs_script_clear(world, template_entity, instance);
-
-        /* Run template code */
-        v.vars = vars;
-        ecs_script_visit_scope(&v, scope);
-
-        if (is_defer) {
-            flecs_resume_readonly(real_world, &srs);
-        }
-
-        /* Pop variable scope */
-        ecs_script_vars_pop(vars);
-
-        data = ECS_OFFSET(data, ti->size);
+    if (ecs_is_deferred(it->world)) {
+        flecs_script_template_defer_on_set(it, template_entity, ti, data);
+        return;
     }
 
-    v.using = prev_using;
-    flecs_script_eval_visit_fini(&v);
+    flecs_script_template_instantiate(
+        world, template_entity, it->entities, data, it->count);
+    return;
 }
 
 static
@@ -59058,6 +59462,15 @@ int flecs_script_template_eval_prop(
     ecs_script_var_node_t *node)
 {
     ecs_script_template_t *template = v->template;
+    if (ecs_vec_count(&v->vars->vars) > 
+        ecs_vec_count(&template->prop_defaults)) 
+    {
+        flecs_script_eval_error(v, node, 
+            "const variables declared before prop '%s' (props must come first)", 
+                node->name);
+        return -1;
+    }
+
     ecs_script_var_t *var = ecs_script_vars_declare(v->vars, node->name);
     if (!var) {
         flecs_script_eval_error(v, node, 
@@ -59065,43 +59478,74 @@ int flecs_script_template_eval_prop(
         return -1;
     }
 
+    ecs_entity_t type;
+    const ecs_type_info_t *ti;
+
     if (node->type) {
-        ecs_entity_t type = flecs_script_find_entity(v, 0, node->type);
-        if (!type) {
+        if (flecs_script_find_entity(v, 0, node->type, NULL, &type) || !type) {
             flecs_script_eval_error(v, node,
-                "unresolved type '%s' for const variable '%s'", 
+                "unresolved type '%s' for prop '%s'", 
                     node->type, node->name);
             return -1;
         }
 
-        const ecs_type_info_t *ti = flecs_script_get_type_info(v, node, type);
+        ti = flecs_script_get_type_info(v, node, type);
         if (!ti) {
             return -1;
         }
 
         var->value.type = type;
-        var->value.ptr = flecs_stack_alloc(&v->stack, ti->size, ti->alignment);
+        var->value.ptr = flecs_stack_alloc(
+            &v->r->stack, ti->size, ti->alignment);
         var->type_info = ti;
 
-        if (flecs_script_eval_expr(v, node->expr, &var->value)) {
+        if (flecs_script_eval_expr(v, &node->expr, &var->value)) {
+            return -1;
+        }
+    } else {
+        /* We don't know the type yet, so we can't create a storage for it yet.
+         * Run the expression first to deduce the type. */
+        ecs_value_t value = {0};
+        if (flecs_script_eval_expr(v, &node->expr, &value)) {
+            flecs_script_eval_error(v, node,
+                "failed to evaluate expression for const variable '%s'", 
+                    node->name);
             return -1;
         }
 
-        ecs_script_var_t *value = ecs_vec_append_t(&v->base.script->allocator, 
-            &template->prop_defaults, ecs_script_var_t);
-        value->value.ptr = flecs_calloc(&v->base.script->allocator, ti->size);
-        value->value.type = type;
-        value->type_info = ti;
-        ecs_value_copy_w_type_info(
-            v->world, ti, value->value.ptr, var->value.ptr);
+        ecs_assert(value.type != 0, ECS_INTERNAL_ERROR, NULL);
+        ti = ecs_get_type_info(v->world, value.type);
+        ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        ecs_entity_t mbr = ecs_entity(v->world, {
-            .name = node->name,
-            .parent = template->entity
-        });
+        var->value.ptr = flecs_stack_calloc(
+            &v->r->stack, ti->size, ti->alignment);
+        type = var->value.type = value.type;
+        var->type_info = ti;
 
-        ecs_set(v->world, mbr, EcsMember, { .type = var->value.type });
+        if (ti->hooks.ctor) {
+            ti->hooks.ctor(var->value.ptr, 1, ti);
+        }
+
+        ecs_value_copy_w_type_info(v->world, ti, var->value.ptr, value.ptr);
+        ecs_value_fini_w_type_info(v->world, ti, value.ptr);
+        flecs_free(&v->world->allocator, ti->size, value.ptr);
     }
+
+    ecs_script_var_t *value = ecs_vec_append_t(&v->base.script->allocator, 
+        &template->prop_defaults, ecs_script_var_t);
+    value->value.ptr = flecs_calloc_w_dbg_info(
+        &v->base.script->allocator, ti->size, ti->name);
+    value->value.type = type;
+    value->type_info = ti;
+    ecs_value_copy_w_type_info(
+        v->world, ti, value->value.ptr, var->value.ptr);
+
+    ecs_entity_t mbr = ecs_entity(v->world, {
+        .name = node->name,
+        .parent = template->entity
+    });
+
+    ecs_set(v->world, mbr, EcsMember, { .type = var->value.type });
 
     return 0;
 }
@@ -59112,10 +59556,11 @@ int flecs_script_template_eval(
     ecs_script_node_t *node)
 {
     switch(node->kind) {
-    case EcsAstScope:
     case EcsAstTag:
     case EcsAstComponent:
     case EcsAstVarComponent:
+    case EcsAstEntity:
+    case EcsAstScope:
     case EcsAstDefaultComponent:
     case EcsAstWithVar:
     case EcsAstWithTag:
@@ -59124,33 +59569,19 @@ int flecs_script_template_eval(
     case EcsAstModule:
     case EcsAstAnnotation:
     case EcsAstConst:
-    case EcsAstEntity:
     case EcsAstPairScope:
-    case EcsAstTemplate:
+    case EcsAstWith:
+    case EcsAstIf:
+    case EcsAstFor:
         break;
+    case EcsAstTemplate:
+        flecs_script_eval_error(v, node, "nested templates are not allowed");
+        return -1;
     case EcsAstProp:
         return flecs_script_template_eval_prop(v, (ecs_script_var_node_t*)node);
-    case EcsAstWith:
-        if (ecs_script_visit_scope(v, ((ecs_script_with_t*)node)->expressions)) {
-            return -1;
-        }
-        if (ecs_script_visit_scope(v, ((ecs_script_with_t*)node)->scope)) {
-            return -1;
-        }
-        return 0;
-    case EcsAstIf:
-        if (ecs_script_visit_scope(v, ((ecs_script_if_t*)node)->if_true)) {
-            return -1;
-        }
-        if (((ecs_script_if_t*)node)->if_false) {
-            if (ecs_script_visit_scope(v, ((ecs_script_if_t*)node)->if_false)) {
-                return -1;
-            }
-        }
-        return 0;
     }
 
-    return flecs_script_eval_node(v, node);
+    return flecs_script_check_node(v, node);
 }
 
 static
@@ -59160,12 +59591,27 @@ int flecs_script_template_preprocess(
 {
     ecs_visit_action_t prev_visit = v->base.visit;
     v->template = template;
+
+    /* Dummy entity node for instance */
+    ecs_script_entity_t instance_node = {
+        .node = {
+            .kind = EcsAstEntity,
+            .pos = template->node->node.pos
+        }
+    };
+
+    v->entity = &instance_node;
+
     v->base.visit = (ecs_visit_action_t)flecs_script_template_eval;
-    v->vars = flecs_script_vars_push(v->vars, &v->stack, v->allocator);
-    int result = ecs_script_visit_scope(v, template->node->scope);
+    v->vars = flecs_script_vars_push(v->vars, &v->r->stack, &v->r->allocator);
+    ecs_script_var_t *var = ecs_script_vars_declare(v->vars, "this");
+    var->value.type = ecs_id(ecs_entity_t);
+    int result = flecs_script_check_scope(v, template->node->scope);
     v->vars = ecs_script_vars_pop(v->vars);
     v->base.visit = prev_visit;
     v->template = NULL;
+    v->entity = NULL;
+
     return result;
 }
 
@@ -59174,15 +59620,15 @@ int flecs_script_template_hoist_using(
     ecs_script_eval_visitor_t *v,
     ecs_script_template_t *template)
 {
+    ecs_allocator_t *a = &v->base.script->allocator;
     if (v->module) {
-        ecs_vec_append_t(
-            v->allocator, &template->using_, ecs_entity_t)[0] = v->module;
+        ecs_vec_append_t(a, &template->using_, ecs_entity_t)[0] = v->module;
     }
 
-    int i, count = ecs_vec_count(&v->using);
+    int i, count = ecs_vec_count(&v->r->using);
     for (i = 0; i < count; i ++) {
-        ecs_vec_append_t(v->allocator, &template->using_, ecs_entity_t)[0] = 
-            ecs_vec_get_t(&v->using, ecs_entity_t, i)[0];
+        ecs_vec_append_t(a, &template->using_, ecs_entity_t)[0] = 
+            ecs_vec_get_t(&v->r->using, ecs_entity_t, i)[0];
     }
 
     return 0;
@@ -59194,18 +59640,23 @@ int flecs_script_template_hoist_vars(
     ecs_script_template_t *template,
     ecs_script_vars_t *vars)
 {
-    if (vars->parent) {
-        flecs_script_template_hoist_vars(v, template, vars);
-    }
-
     int32_t i, count = ecs_vec_count(&vars->vars);
     ecs_script_var_t *src_vars = ecs_vec_first(&vars->vars);
     for (i = 0; i < count; i ++) {
         ecs_script_var_t *src = &src_vars[i];
+        if (ecs_script_vars_lookup(template->vars, src->name)) {
+            /* If variable is masked, don't declare it twice */
+            continue;
+        }
         ecs_script_var_t *dst = ecs_script_vars_define_id(
             template->vars, src->name, src->value.type);
-        ecs_value_copy(v->world, 
+        ecs_assert(dst != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_value_copy(v->world,
             src->value.type, dst->value.ptr, src->value.ptr);
+    }
+
+    if (vars->parent) {
+        flecs_script_template_hoist_vars(v, template, vars->parent);
     }
 
     return 0;
@@ -59241,6 +59692,7 @@ void flecs_script_template_fini(
     }
 
     ecs_vec_fini_t(a, &template->prop_defaults, ecs_script_var_t);
+
     ecs_vec_fini_t(a, &template->using_, ecs_entity_t);
     ecs_script_vars_fini(template->vars);
     flecs_free_t(a, ecs_script_template_t, template);
@@ -59251,11 +59703,6 @@ int flecs_script_eval_template(
     ecs_script_eval_visitor_t *v,
     ecs_script_template_node_t *node)
 {
-    if (v->template) {
-        flecs_script_eval_error(v, node, "nested templates are not allowed");
-        return -1;        
-    }
-
     ecs_entity_t template_entity = flecs_script_create_entity(v, node->name);
     if (!template_entity) {
         return -1;
@@ -59264,6 +59711,11 @@ int flecs_script_eval_template(
     ecs_script_template_t *template = flecs_script_template_init(v->base.script);
     template->entity = template_entity;
     template->node = node;
+
+    /* Variables are always presented to a template in a well defined order, so
+     * we don't need dynamic variable binding. */
+    bool old_dynamic_variable_binding = v->dynamic_variable_binding;
+    v->dynamic_variable_binding = false;
 
     if (flecs_script_template_preprocess(v, template)) {
         goto error;
@@ -59276,6 +59728,8 @@ int flecs_script_eval_template(
     if (flecs_script_template_hoist_vars(v, template, v->vars)) {
         goto error;
     }
+
+    v->dynamic_variable_binding = old_dynamic_variable_binding;
 
     /* If template has no props, give template dummy size so we can register
      * hooks for it. */
@@ -59315,6 +59769,29 @@ error:
     return -1;
 }
 
+void flecs_script_template_import(
+    ecs_world_t *world)
+{
+    ECS_COMPONENT_DEFINE(world, EcsScriptTemplateSetEvent);
+    ECS_TAG_DEFINE(world, EcsScriptTemplate);
+
+    ecs_add_id(world, EcsScriptTemplate, EcsPairIsTag);
+
+    ecs_set_hooks(world, EcsScriptTemplateSetEvent, {
+        .ctor = flecs_default_ctor,
+        .move = ecs_move(EcsScriptTemplateSetEvent),
+        .dtor = ecs_dtor(EcsScriptTemplateSetEvent),
+        .flags = ECS_TYPE_HOOK_COPY_ILLEGAL
+    });
+
+    ecs_observer(world, {
+        .entity = ecs_entity(world, { .name = "TemplateSetObserver" }),
+        .query.terms = {{ .id = EcsAny }},
+        .events = { ecs_id(EcsScriptTemplateSetEvent) },
+        .callback = flecs_on_template_set_event
+    });
+}
+
 #endif
 
 /**
@@ -59327,6 +59804,10 @@ error:
 
 #define Keyword(keyword, _kind)\
     } else if (!ecs_os_strncmp(pos, keyword " ", ecs_os_strlen(keyword) + 1)) {\
+        out->value = keyword;\
+        out->kind = _kind;\
+        return pos + ecs_os_strlen(keyword);\
+    } else if (!ecs_os_strncmp(pos, keyword "\n", ecs_os_strlen(keyword) + 1)) {\
         out->value = keyword;\
         out->kind = _kind;\
         return pos + ecs_os_strlen(keyword);
@@ -59359,24 +59840,42 @@ const char* flecs_script_token_kind_str(
     case EcsTokAnnotation:
     case EcsTokComma:
     case EcsTokSemiColon:
-    case EcsTokMul:
     case EcsTokAssign:
+    case EcsTokAdd:
+    case EcsTokSub:
+    case EcsTokMul:
+    case EcsTokDiv:
+    case EcsTokMod:
     case EcsTokBitwiseOr:
+    case EcsTokBitwiseAnd:
     case EcsTokNot:
     case EcsTokOptional:
     case EcsTokEq:
     case EcsTokNeq:
-    case EcsTokMatch:
+    case EcsTokGt:
+    case EcsTokGtEq:
+    case EcsTokLt:
+    case EcsTokLtEq:
+    case EcsTokAnd:
     case EcsTokOr:
+    case EcsTokMatch:
+    case EcsTokRange:
+    case EcsTokShiftLeft:
+    case EcsTokShiftRight:
+    case EcsTokAddAssign:
+    case EcsTokMulAssign:
         return "";
     case EcsTokKeywordWith:
     case EcsTokKeywordUsing:
-    case EcsTokKeywordTemplate:
     case EcsTokKeywordProp:
     case EcsTokKeywordConst:
     case EcsTokKeywordIf:
     case EcsTokKeywordElse:
+    case EcsTokKeywordFor:
+    case EcsTokKeywordIn:
+    case EcsTokKeywordTemplate:
     case EcsTokKeywordModule:
+    case EcsTokKeywordMatch:
         return "keyword ";
     case EcsTokIdentifier:
         return "identifier ";
@@ -59386,8 +59885,71 @@ const char* flecs_script_token_kind_str(
         return "number ";
     case EcsTokNewline:
         return "newline";
+    case EcsTokMember:
+        return "member";
     case EcsTokEnd:
         return "end of script";
+    default:
+        return "<corrupt>";
+    }
+}
+
+const char* flecs_script_token_str(
+    ecs_script_token_kind_t kind)
+{
+    switch(kind) {
+    case EcsTokUnknown: return "unknown token";
+    case EcsTokColon: return ":";
+    case EcsTokScopeOpen: return "{";
+    case EcsTokScopeClose: return "}";
+    case EcsTokParenOpen: return "(";
+    case EcsTokParenClose: return ")";
+    case EcsTokBracketOpen: return "[";
+    case EcsTokBracketClose: return "]";
+    case EcsTokAnnotation: return "@";
+    case EcsTokComma: return ",";
+    case EcsTokSemiColon: return ";";
+    case EcsTokAssign: return "=";
+    case EcsTokAdd: return "+";
+    case EcsTokSub: return "-";
+    case EcsTokMul: return "*";
+    case EcsTokDiv: return "/";
+    case EcsTokMod: return "%%";
+    case EcsTokBitwiseOr: return "|";
+    case EcsTokBitwiseAnd: return "&";
+    case EcsTokNot: return "!";
+    case EcsTokOptional: return "?";
+    case EcsTokEq: return "==";
+    case EcsTokNeq: return "!=";
+    case EcsTokGt: return ">";
+    case EcsTokGtEq: return ">=";
+    case EcsTokLt: return "<";
+    case EcsTokLtEq: return "<=";
+    case EcsTokAnd: return "&&";
+    case EcsTokOr: return "||";
+    case EcsTokMatch: return "~=";
+    case EcsTokRange: return "..";
+    case EcsTokShiftLeft: return "<<";
+    case EcsTokShiftRight: return ">>";
+    case EcsTokAddAssign: return "+=";
+    case EcsTokMulAssign: return "*=";
+    case EcsTokKeywordWith: return "with";
+    case EcsTokKeywordUsing: return "using";
+    case EcsTokKeywordProp: return "prop";
+    case EcsTokKeywordConst: return "const";
+    case EcsTokKeywordMatch: return "match";
+    case EcsTokKeywordIf: return "if";
+    case EcsTokKeywordElse: return "else";
+    case EcsTokKeywordFor: return "for";
+    case EcsTokKeywordIn: return "in";
+    case EcsTokKeywordTemplate: return "template";
+    case EcsTokKeywordModule: return "module";
+    case EcsTokIdentifier: return "identifier";
+    case EcsTokString: return "string";
+    case EcsTokNumber: return "number";
+    case EcsTokNewline: return "newline";
+    case EcsTokMember: return "member";
+    case EcsTokEnd: return "end of script";
     default:
         return "<corrupt>";
     }
@@ -59450,25 +60012,45 @@ bool flecs_script_is_identifier(
     return isalpha(c) || (c == '_') || (c == '$') || (c == '#');
 }
 
-static
 const char* flecs_script_identifier(
     ecs_script_parser_t *parser,
     const char *pos,
     ecs_script_token_t *out) 
 {
-    out->kind = EcsTokIdentifier;
-    out->value = parser->token_cur;
+    if (out) {
+        out->kind = EcsTokIdentifier;
+        out->value = parser->token_cur;
+    }
 
     ecs_assert(flecs_script_is_identifier(pos[0]), ECS_INTERNAL_ERROR, NULL);
-    char *outpos = parser->token_cur;
+    bool is_var = pos[0] == '$';
+    char *outpos = NULL;
+    const char *start = pos;
+    if (parser) {
+        outpos = parser->token_cur;
+        if (parser->merge_variable_members) {
+            is_var = false;
+        }
+    }
+
     do {
         char c = pos[0];
-        bool is_ident = flecs_script_is_identifier(c) || 
-            isdigit(c) || (c == '.') || (c == '*');
+        bool is_ident = flecs_script_is_identifier(c) || isdigit(c);
+
+        if (!is_var) {
+            is_ident = is_ident || (c == '.');
+        }
 
         /* Retain \. for name lookup operation */
         if (!is_ident && c == '\\' && pos[1] == '.') {
             is_ident = true;
+        }
+
+        /* Retain .* for using wildcard expressions */
+        if (!is_ident && c == '*') {
+            if (pos != start && pos[-1] == '.') {
+                is_ident = true;
+            }
         }
 
         if (!is_ident) {
@@ -59485,13 +60067,16 @@ const char* flecs_script_identifier(
                         indent --;
                     } else if (!c) {
                         ecs_parser_error(parser->script->pub.name, 
-                            parser->script->pub.code, pos - parser->script->pub.code, 
-                                "< without > in identifier");
+                            parser->script->pub.code, 
+                                pos - parser->script->pub.code, 
+                                    "< without > in identifier");
                         return NULL;
                     }
 
-                    *outpos = c;
-                    outpos ++;
+                    if (outpos) {
+                        *outpos = c;
+                        outpos ++;
+                    }
                     pos ++;
 
                     if (!indent) {
@@ -59499,22 +60084,31 @@ const char* flecs_script_identifier(
                     }
                 } while (true);
 
-                *outpos = '\0';
-                parser->token_cur = outpos + 1;
+                if (outpos && parser) {
+                    *outpos = '\0';
+                    parser->token_cur = outpos + 1;
+                }
                 return pos;
             } else if (c == '>') {
-                ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                    pos - parser->script->pub.code, "> without < in identifier");
+                ecs_parser_error(parser->script->pub.name, 
+                    parser->script->pub.code,
+                        pos - parser->script->pub.code, 
+                            "> without < in identifier");
                 return NULL;
             } else {
-                *outpos = '\0';
-                parser->token_cur = outpos + 1;
+                if (outpos && parser) {
+                    *outpos = '\0';
+                    parser->token_cur = outpos + 1;
+                }
                 return pos;
             }
         }
 
-        *outpos = *pos;
-        outpos ++;
+        if (outpos) {
+            *outpos = *pos;
+            outpos ++;
+        }
+
         pos ++;
     } while (true);
 }
@@ -59522,9 +60116,9 @@ const char* flecs_script_identifier(
 // Number token static
 static
 bool flecs_script_is_number(
-    char c)
+    const char *c)
 {
-    return isdigit(c) || (c == '-');
+    return isdigit(c[0]) || ((c[0] == '-') && isdigit(c[1]));
 }
 
 static
@@ -59535,12 +60129,42 @@ const char* flecs_script_number(
 {
     out->kind = EcsTokNumber;
     out->value = parser->token_cur;
+    
+    bool dot_parsed = false;
+    bool e_parsed = false;
 
-    ecs_assert(flecs_script_is_number(pos[0]), ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(flecs_script_is_number(pos), ECS_INTERNAL_ERROR, NULL);
     char *outpos = parser->token_cur;
+
+    if (pos[0] == '-') {
+        outpos[0] = pos[0];
+        pos ++;
+        outpos ++;
+    }
+
     do {
         char c = pos[0];
-        if (!isdigit(c)) {
+        bool valid_number = false;
+
+        if (c == '.') {
+            if (!dot_parsed && !e_parsed) {
+                if (isdigit(pos[1])) {
+                    dot_parsed = true;
+                    valid_number = true;
+                }
+            }
+        } else if (c == 'e') {
+            if (!e_parsed) {
+                if (isdigit(pos[1])) {
+                    e_parsed = true;
+                    valid_number = true;
+                }
+            }
+        } else if (isdigit(c)) {
+            valid_number = true;
+        }
+
+        if (!valid_number) {
             *outpos = '\0';
             parser->token_cur = outpos + 1;
             break;
@@ -59600,124 +60224,35 @@ const char* flecs_script_string(
     return end + 2;
 }
 
-const char* flecs_script_expr(
+static
+const char* flecs_script_multiline_string(
     ecs_script_parser_t *parser,
     const char *pos,
-    ecs_script_token_t *out,
-    char until)
+    ecs_script_token_t *out) 
 {
-    parser->pos = pos;
-
-    int32_t scope_depth = until == '}' ? 1 : 0;
-    int32_t paren_depth = until == ')' ? 1 : 0;
-    
-    const char *start = pos = flecs_scan_whitespace(parser, pos);
     char ch;
-
-    for (; (ch = pos[0]); pos ++) {
-        if (ch == '{') {
-            if (ch == until) {
-                break;
-            }
-            scope_depth ++;
-        } else 
-        if (ch == '}') {
-            scope_depth --;
-            if (!scope_depth && until == '}') {
-                break;
-            }
-            if (scope_depth < 0) {
-                ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                    pos - parser->script->pub.code, "mismatching { }");
-                return NULL;
-            }
-        } else
-        if (ch == '(') {
-            paren_depth ++;
-        } else
-        if (ch == ')') {
-            paren_depth --;
-            if (!paren_depth && until == ')') {
-                break;
-            }
-            if (paren_depth < 0) {
-                ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                    pos - parser->script->pub.code, "mismatching ( )");
-                return NULL;
-            }
-        } else
-        if (ch == '"') {
-            pos = flecs_script_skip_string(parser, pos + 1, '"');
-            if (!pos) {
-                return NULL;
-            }
-        } else
-        if (ch == '`') {
-            pos = flecs_script_skip_string(parser, pos + 1, '`');
-            if (!pos) {
-                return NULL;
-            }
-        } else
-        if (ch == until) {
-            break;
+    const char *end = pos + 1;
+    while ((ch = end[0]) && (ch != '`')) {
+        if (ch == '\\' && end[1] == '`') {
+            end ++;
         }
+        end ++;
     }
 
-    if (!pos[0]) {
-        if (until == '\0') {
-            ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                pos - parser->script->pub.code, "expected end of script");
-            return NULL;
-        } else
-        if (until == '\n') {
-            ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                pos - parser->script->pub.code, "expected newline");
-            return NULL;
-        } else {
-            ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-                pos - parser->script->pub.code, "expected '%c'", until);
-            return NULL;
-        }
-    }
-
-    if (scope_depth) {
-        ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-            pos - parser->script->pub.code, "mismatching { }");
-        return NULL;
-    }
-    if (paren_depth) {
-        ecs_parser_error(parser->script->pub.name, parser->script->pub.code,
-            pos - parser->script->pub.code, "mismatching ( )");
+    if (ch != '`') {
         return NULL;
     }
 
-    if (until != ']') {
-        parser->token_cur[0] = '{';
-    } else {
-        parser->token_cur[0] = '[';
-    }
-    
-    int32_t len = flecs_ito(int32_t, pos - start);
-    ecs_os_memcpy(parser->token_cur + 1, start, len);
+    end --;
+
+    int32_t len = flecs_ito(int32_t, end - pos);
+    ecs_os_memcpy(parser->token_cur, pos + 1, len);
+    parser->token_cur[len] = '\0';
+
+    out->kind = EcsTokString;
     out->value = parser->token_cur;
     parser->token_cur += len + 1;
-
-    while (isspace(parser->token_cur[-1])) {
-        parser->token_cur --;
-    }
-
-    if (until != ']') {
-        parser->token_cur[0] = '}';
-    } else {
-        parser->token_cur[0] = ']';
-    }
-
-    parser->token_cur ++;
-
-    parser->token_cur[0] = '\0';
-    parser->token_cur ++;
-
-    return pos;
+    return end + 2;
 }
 
 const char* flecs_script_until(
@@ -59796,6 +60331,11 @@ const char* flecs_script_token(
         }
         return pos;
 
+    } else if (flecs_script_is_number(pos)) {
+        return flecs_script_number(parser, pos, out);
+
+    OperatorMultiChar ("+=",       EcsTokAddAssign)
+    OperatorMultiChar ("*=",       EcsTokMulAssign)
     Operator          (":",        EcsTokColon)
     Operator          ("{",        EcsTokScopeOpen)
     Operator          ("}",        EcsTokScopeClose)
@@ -59806,17 +60346,33 @@ const char* flecs_script_token(
     Operator          ("@",        EcsTokAnnotation)
     Operator          (",",        EcsTokComma)
     Operator          (";",        EcsTokSemiColon)
+    Operator          ("+",        EcsTokAdd)
+    Operator          ("-",        EcsTokSub)
     Operator          ("*",        EcsTokMul)
+    Operator          ("/",        EcsTokDiv)
+    Operator          ("%%",       EcsTokMod)
     Operator          ("?",        EcsTokOptional)
+    
+    OperatorMultiChar ("..",       EcsTokRange)
+    Operator          (".",        EcsTokMember)
 
     OperatorMultiChar ("==",       EcsTokEq)
     OperatorMultiChar ("!=",       EcsTokNeq)
-    OperatorMultiChar ("~=",       EcsTokMatch)
+    OperatorMultiChar ("<<",       EcsTokShiftLeft)
+    OperatorMultiChar (">>",       EcsTokShiftRight)
+    OperatorMultiChar (">=",       EcsTokGtEq)
+    OperatorMultiChar ("<=",       EcsTokLtEq)
+    
+    OperatorMultiChar ("&&",       EcsTokAnd)
     OperatorMultiChar ("||",       EcsTokOr)
+    OperatorMultiChar ("~=",       EcsTokMatch)
 
-    OperatorMultiChar ("!",        EcsTokNot)
-    OperatorMultiChar ("=",        EcsTokAssign)
-    OperatorMultiChar ("|",        EcsTokBitwiseOr)
+    Operator          ("!",        EcsTokNot)
+    Operator          ("=",        EcsTokAssign)
+    Operator          ("&",        EcsTokBitwiseAnd)
+    Operator          ("|",        EcsTokBitwiseOr)
+    Operator          (">",        EcsTokGt)
+    Operator          ("<",        EcsTokLt)
 
     Keyword           ("with",     EcsTokKeywordWith)
     Keyword           ("using",    EcsTokKeywordUsing)
@@ -59825,13 +60381,16 @@ const char* flecs_script_token(
     Keyword           ("const",    EcsTokKeywordConst)
     Keyword           ("if",       EcsTokKeywordIf)
     Keyword           ("else",     EcsTokKeywordElse)
+    Keyword           ("for",      EcsTokKeywordFor)
+    Keyword           ("in",       EcsTokKeywordIn)
+    Keyword           ("match",    EcsTokKeywordMatch)
     Keyword           ("module",   EcsTokKeywordModule)
 
     } else if (pos[0] == '"') {
         return flecs_script_string(parser, pos, out);
 
-    } else if (flecs_script_is_number(pos[0])) {
-        return flecs_script_number(parser, pos, out);
+    } else if (pos[0] == '`') {
+        return flecs_script_multiline_string(parser, pos, out);
 
     } else if (flecs_script_is_identifier(pos[0])) {
         return flecs_script_identifier(parser, pos, out);
@@ -59884,6 +60443,10 @@ ecs_script_vars_t* flecs_script_vars_push(
     result->parent = parent;
     if (parent) {
         result->world = parent->world;
+        result->sp =
+            parent->sp + ecs_vec_count(&parent->vars);
+    } else {
+        result->sp = 0;
     }
     result->stack = stack;
     result->allocator = allocator;
@@ -59959,11 +60522,13 @@ ecs_script_var_t* ecs_script_vars_declare(
     ecs_script_vars_t *vars,
     const char *name)
 {
-    if (!ecs_vec_count(&vars->vars)) {
-        flecs_name_index_init(&vars->var_index, vars->allocator);
-    } else {
-        if (flecs_name_index_find(&vars->var_index, name, 0, 0) != 0) {
-            goto error;
+    if (name) {
+        if (flecs_name_index_is_init(&vars->var_index)) {
+            if (flecs_name_index_find(&vars->var_index, name, 0, 0) != 0) {
+                goto error;
+            }
+        } else {
+            flecs_name_index_init(&vars->var_index, vars->allocator);
         }
     }
 
@@ -59973,13 +60538,26 @@ ecs_script_var_t* ecs_script_vars_declare(
     var->value.ptr = NULL;
     var->value.type = 0;
     var->type_info = NULL;
+    var->sp = ecs_vec_count(&vars->vars) + vars->sp - 1;
+    var->is_const = false;
 
-    flecs_name_index_ensure(&vars->var_index,
-        flecs_ito(uint64_t, ecs_vec_count(&vars->vars)), name, 0, 0);
+    if (name) {
+        flecs_name_index_ensure(&vars->var_index,
+            flecs_ito(uint64_t, ecs_vec_count(&vars->vars)), name, 0, 0);
+    }
 
     return var;
 error:
     return NULL;
+}
+
+void ecs_script_vars_set_size(
+    ecs_script_vars_t *vars,
+    int32_t count)
+{
+    ecs_assert(!ecs_vec_count(&vars->vars), ECS_INVALID_OPERATION, 
+        "variable scope must be empty for resize operation");
+    ecs_vec_set_size_t(vars->allocator, &vars->vars, ecs_script_var_t, count);
 }
 
 ecs_script_var_t* ecs_script_vars_define_id(
@@ -60016,9 +60594,15 @@ ecs_script_var_t* ecs_script_vars_lookup(
     const ecs_script_vars_t *vars,
     const char *name)
 {
+    if (!vars) {
+        return NULL;
+    }
+
     uint64_t var_id = 0;
     if (ecs_vec_count(&vars->vars)) {
-        var_id = flecs_name_index_find(&vars->var_index, name, 0, 0);
+        if (flecs_name_index_is_init(&vars->var_index)) {
+            var_id = flecs_name_index_find(&vars->var_index, name, 0, 0);
+        }
     }
 
     if (!var_id) {
@@ -60030,6 +60614,47 @@ ecs_script_var_t* ecs_script_vars_lookup(
 
     return ecs_vec_get_t(&vars->vars, ecs_script_var_t, 
         flecs_uto(int32_t, var_id - 1));
+}
+
+ecs_script_var_t* ecs_script_vars_from_sp(
+    const ecs_script_vars_t *vars,
+    int32_t sp)
+{
+    ecs_check(sp >= 0, ECS_INVALID_PARAMETER, NULL);
+
+    if (sp < vars->sp) {
+        ecs_assert(vars->parent != NULL, ECS_INTERNAL_ERROR, NULL);
+        return ecs_script_vars_from_sp(vars->parent, sp);
+    }
+
+    sp -= vars->sp;
+    ecs_check(sp < ecs_vec_count(&vars->vars), 
+        ECS_INVALID_PARAMETER, NULL);
+
+    return ecs_vec_get_t(&vars->vars, ecs_script_var_t, sp);
+error:
+    return NULL;
+}
+
+void ecs_script_vars_print(
+    const ecs_script_vars_t *vars)
+{
+    if (vars->parent) {
+        ecs_script_vars_print(vars->parent);
+    }
+
+    int32_t i, count = ecs_vec_count(&vars->vars);
+    ecs_script_var_t *array = ecs_vec_first(&vars->vars);
+    for (i = 0; i < count; i ++) {
+        ecs_script_var_t *var = &array[i];
+        if (!i) {
+            printf("FRAME ");
+        } else {
+            printf("      ");
+        }
+
+        printf("%2d: %s\n", var->sp, var->name);
+    }
 }
 
 /* Static names for iterator fields */
@@ -60270,6 +60895,540 @@ int ecs_script_visit_(
 #endif
 
 /**
+ * @file addons/script/visit_validate.c
+ * @brief Script AST validation.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+int flecs_script_check_expr(
+    ecs_script_eval_visitor_t *v,
+    ecs_expr_node_t **expr_ptr,
+    ecs_entity_t *type)
+{
+    ecs_expr_node_t *expr = *expr_ptr;
+    ecs_script_impl_t *impl = v->base.script;
+    ecs_script_t *script = &impl->pub;
+
+    ecs_expr_eval_desc_t desc = {
+        .name = script->name,
+        .lookup_action = flecs_script_find_entity_action,
+        .lookup_ctx = v,
+        .vars = v->vars,
+        .type = type ? type[0] : 0,
+        .runtime = v->r,
+        .allow_unresolved_identifiers = true
+    };
+
+    ecs_assert(expr->type_info == NULL, ECS_INTERNAL_ERROR, NULL);
+
+    if (flecs_expr_visit_type(script, expr, &desc)) {
+        goto error;
+    }
+
+    if (flecs_expr_visit_fold(script, expr_ptr, &desc)) {
+        goto error;
+    }
+
+    if (type) {
+        type[0] = expr_ptr[0]->type;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+int flecs_script_check_scope(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_scope_t *node)
+{
+    int ret =  flecs_script_eval_scope(v, node);
+    if (ret) {
+        return -1;
+    }
+
+    /* Gather all resolved components in scope so we can add them in one bulk
+     * operation to entities. */
+    ecs_allocator_t *a = &v->base.script->allocator;
+    int32_t i, count = ecs_vec_count(&node->stmts);
+    ecs_script_node_t **stmts = ecs_vec_first(&node->stmts);
+    for (i = 0; i < count; i ++) {
+        ecs_script_node_t *stmt = stmts[i];
+        ecs_id_t id = 0;
+        if (stmt->kind == EcsAstComponent) {
+            ecs_script_component_t *cmp = (ecs_script_component_t*)stmt;
+            id = cmp->id.eval;
+        } else if (stmt->kind == EcsAstTag) {
+            ecs_script_tag_t *cmp = (ecs_script_tag_t*)stmt;
+            id = cmp->id.eval;
+        }
+
+        if (id) {
+            ecs_vec_append_t(a, &node->components, ecs_id_t)[0] = id;
+        }
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_entity(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_entity_t *node)
+{
+    if (node->kind) {
+        ecs_script_id_t id = {
+            .first = node->kind
+        };
+
+        if (!ecs_os_strcmp(node->kind, "prefab")) {
+            id.eval = EcsPrefab;
+        } else if (!ecs_os_strcmp(node->kind, "slot")) {
+        } else if (flecs_script_eval_id(v, node, &id)) {
+            return -1;
+        }
+
+        node->eval_kind = id.eval;
+    } else {
+        /* Inherit kind from parent kind's DefaultChildComponent, if it existst */
+        ecs_script_scope_t *scope = ecs_script_current_scope(v);
+        if (scope && scope->default_component_eval) {
+            node->eval_kind = scope->default_component_eval;
+        }
+    }
+
+    ecs_script_entity_t *old_entity = v->entity;
+    v->entity = node;
+
+    bool old_is_with_scope = v->is_with_scope;
+    v->is_with_scope = false;
+
+    if (ecs_script_visit_node(v, node->scope)) {
+        return -1;
+    }
+
+    v->is_with_scope = old_is_with_scope;
+    v->entity = old_entity;
+
+    return 0;
+}
+
+static
+int flecs_script_check_tag(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_tag_t *node)
+{
+    if (flecs_script_eval_id(v, node, &node->id)) {
+        return -1;
+    }
+
+    if (v->is_with_scope) {
+        flecs_script_eval_error(v, node, "invalid component in with scope"); 
+        return -1;
+    }
+
+    if (!v->entity) {
+        if (node->id.second) {
+            flecs_script_eval_error(
+                v, node, "missing entity for pair (%s, %s)",
+                node->id.first, node->id.second);
+        } else {
+            flecs_script_eval_error(v, node, "missing entity for tag %s", 
+                node->id.first);
+        }
+        return -1;
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_component(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_component_t *node)
+{
+    if (flecs_script_eval_id(v, node, &node->id)) {
+        return -1;
+    }
+
+    if (!v->entity) {
+        if (node->id.second) {
+            flecs_script_eval_error(v, node, "missing entity for pair (%s, %s)",
+                node->id.first, node->id.second);
+        } else {
+            flecs_script_eval_error(v, node, "missing entity for component %s", 
+                node->id.first);
+        }
+        return -1;
+    }
+
+    if (v->is_with_scope) {
+        flecs_script_eval_error(v, node, "invalid component in with scope"); 
+        return -1;
+    }
+
+    if (node->expr) {
+        const ecs_type_info_t *ti = ecs_get_type_info(v->world, node->id.eval);
+        if (!ti) {
+            return 0;
+        }
+
+        const EcsType *type = ecs_get(v->world, ti->component, EcsType);
+        if (type) {
+            bool is_collection = false;
+
+            switch(type->kind) {
+            case EcsPrimitiveType:
+            case EcsBitmaskType:
+            case EcsEnumType:
+            case EcsStructType:
+            case EcsOpaqueType:
+                break;
+            case EcsArrayType:
+            case EcsVectorType:
+                is_collection = true;
+                break;
+            }
+
+            if (node->is_collection != is_collection) {
+                char *id_str = ecs_id_str(v->world, ti->component);
+                if (node->is_collection && !is_collection) {
+                    flecs_script_eval_error(v, node, 
+                        "type %s is not a collection (use '%s: {...}')", 
+                            id_str, id_str);
+                } else {
+                    flecs_script_eval_error(v, node, 
+                        "type %s is a collection (use '%s: [...]')", 
+                            id_str, id_str);
+                }
+                ecs_os_free(id_str);
+                return -1;
+            }
+        }
+
+        ecs_entity_t expr_type = ti->component;
+        if (flecs_script_check_expr(v, &node->expr, &expr_type)) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_var_component(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_var_component_t *node)
+{
+    ecs_script_var_t *var = ecs_script_vars_lookup(v->vars, node->name);
+    if (!var) {
+        flecs_script_eval_error(v, node, 
+            "unresolved variable '%s'", node->name);
+        return -1;
+    }
+
+    node->sp = var->sp;
+
+    return 0;
+}
+
+static
+int flecs_script_check_default_component(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_default_component_t *node)
+{
+    if (!v->entity) {
+        flecs_script_eval_error(v, node, 
+            "missing entity for default component");
+        return -1;
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_with_var(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_var_component_t *node)
+{
+    ecs_script_var_t *var = ecs_script_vars_lookup(v->vars, node->name);
+    if (!var) {
+        flecs_script_eval_error(v, node, 
+            "unresolved variable '%s'", node->name);
+        return -1;
+    }
+
+    node->sp = var->sp;
+
+    return 0;
+}
+
+static
+int flecs_script_check_with_tag(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_tag_t *node)
+{
+    if (flecs_script_eval_id(v, node, &node->id)) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_with_component(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_component_t *node)
+{
+    if (flecs_script_eval_id(v, node, &node->id)) {
+        return -1;
+    }
+
+    if (node->expr) {
+        ecs_entity_t type = node->id.eval;
+
+        if (flecs_script_check_expr(v, &node->expr, &type)) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_with(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_with_t *node)
+{
+    if (ecs_script_visit_scope(v, ((ecs_script_with_t*)node)->expressions)) {
+        return -1;
+    }
+
+    bool old_is_with_scope = v->is_with_scope;
+    v->is_with_scope = true;
+
+    if (ecs_script_visit_scope(v, ((ecs_script_with_t*)node)->scope)) {
+        return -1;
+    }
+
+    v->is_with_scope = old_is_with_scope;
+
+    return 0;
+}
+
+static
+int flecs_script_check_using(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_using_t *node)
+{
+    return flecs_script_eval_using(v, node);
+}
+
+static
+int flecs_script_check_const(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_var_node_t *node)
+{
+    return flecs_script_eval_const(v, node);
+}
+
+static
+int flecs_script_check_pair_scope(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_pair_scope_t *node)
+{
+    ecs_entity_t dummy;
+
+    if (flecs_script_find_entity(
+        v, 0, node->id.first, &node->id.first_sp, &dummy))
+    {
+        return -1;
+    }
+
+    if (flecs_script_find_entity(
+        v, 0, node->id.second, &node->id.second_sp, &dummy))
+    {
+        return -1;
+    }
+
+    if (ecs_script_visit_scope(v, node->scope)) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_if(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_if_t *node)
+{
+    if (flecs_script_check_expr(v, &node->expr, NULL)) {
+        return -1;
+    }
+
+    if (flecs_script_check_scope(v, node->if_true)) {
+        return -1;
+    }
+
+    if (flecs_script_check_scope(v, node->if_false)) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static
+int flecs_script_check_for_range(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_for_range_t *node)
+{
+    ecs_entity_t type = ecs_id(ecs_i32_t);
+    if (flecs_script_check_expr(v, &node->from, &type)) {
+        return -1;
+    }
+
+    type = ecs_id(ecs_i32_t);
+    if (flecs_script_check_expr(v, &node->to, &type)) {
+        return -1;
+    }
+
+    v->vars = flecs_script_vars_push(v->vars, &v->r->stack, &v->r->allocator);
+
+    ecs_script_var_t *var = ecs_script_vars_declare(v->vars, node->loop_var);
+    const ecs_type_info_t *ti = ecs_get_type_info(v->world, ecs_id(ecs_i32_t));
+    int32_t dummy = 0;
+    var->value.ptr = &dummy;
+    var->value.type = ecs_id(ecs_i32_t);
+    var->type_info = ti;
+
+    if (flecs_script_eval_scope(v, node->scope)) {
+        return -1;
+    }
+
+    var->value.ptr = NULL;
+
+    v->vars = ecs_script_vars_pop(v->vars);
+
+    return 0;
+}
+
+static
+int flecs_script_check_annot(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_annot_t *node)
+{
+    if (!v->base.next) {
+        flecs_script_eval_error(v, node,
+            "annotation '%s' is not applied to anything", node->name);
+        return -1;
+    }
+
+    ecs_script_node_kind_t kind = v->base.next->kind;
+    if (kind != EcsAstEntity && kind != EcsAstAnnotation) {
+        flecs_script_eval_error(v, node,
+            "annotation must be applied to an entity");
+        return -1;
+    }
+
+    return 0;
+}
+
+int flecs_script_check_node(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_node_t *node)
+{
+    switch(node->kind) {
+    case EcsAstScope:
+        return flecs_script_check_scope(
+            v, (ecs_script_scope_t*)node);
+    case EcsAstTag:
+        return flecs_script_check_tag(
+            v, (ecs_script_tag_t*)node);
+    case EcsAstComponent:
+        return flecs_script_check_component(
+            v, (ecs_script_component_t*)node);
+    case EcsAstVarComponent:
+        return flecs_script_check_var_component(
+            v, (ecs_script_var_component_t*)node);
+    case EcsAstDefaultComponent:
+        return flecs_script_check_default_component(
+            v, (ecs_script_default_component_t*)node);
+    case EcsAstWithVar:
+        return flecs_script_check_with_var(
+            v, (ecs_script_var_component_t*)node);
+    case EcsAstWithTag:
+        return flecs_script_check_with_tag(
+            v, (ecs_script_tag_t*)node);
+    case EcsAstWithComponent:
+        return flecs_script_check_with_component(
+            v, (ecs_script_component_t*)node);
+    case EcsAstWith:
+        return flecs_script_check_with(
+            v, (ecs_script_with_t*)node);
+    case EcsAstUsing:
+        return flecs_script_check_using(
+            v, (ecs_script_using_t*)node);
+    case EcsAstModule:
+        return 0;
+    case EcsAstAnnotation:
+        return flecs_script_check_annot(
+            v, (ecs_script_annot_t*)node);
+    case EcsAstTemplate:
+        return 0;
+    case EcsAstProp:
+        return 0;
+    case EcsAstConst:
+        return flecs_script_check_const(
+            v, (ecs_script_var_node_t*)node);
+    case EcsAstEntity:
+        return flecs_script_check_entity(
+            v, (ecs_script_entity_t*)node);
+    case EcsAstPairScope:
+        return flecs_script_check_pair_scope(
+            v, (ecs_script_pair_scope_t*)node);
+    case EcsAstIf:
+        return flecs_script_check_if(
+            v, (ecs_script_if_t*)node);
+    case EcsAstFor:
+        return flecs_script_check_for_range(
+            v, (ecs_script_for_range_t*)node);
+    }
+
+    ecs_abort(ECS_INTERNAL_ERROR, "corrupt AST node kind");
+}
+
+int flecs_script_check(
+    const ecs_script_t *script,
+    const ecs_script_eval_desc_t *desc)
+{
+    ecs_script_eval_visitor_t v;
+    ecs_script_impl_t *impl = flecs_script_impl(
+        /* Safe, script will only be used for reading by visitor */
+        ECS_CONST_CAST(ecs_script_t*, script));
+
+    ecs_script_eval_desc_t priv_desc = {0};
+    if (desc) {
+        priv_desc = *desc;
+    }
+
+    if (!priv_desc.runtime) {
+        priv_desc.runtime = flecs_script_runtime_get(script->world);
+    }
+
+    flecs_script_eval_visit_init(impl, &v, &priv_desc);
+    int result = ecs_script_visit(impl, &v, flecs_script_check_node);
+    flecs_script_eval_visit_fini(&v, &priv_desc);
+
+    return result;
+}
+
+#endif
+
+/**
  * @file addons/script/visit_eval.c
  * @brief Script evaluation visitor.
  */
@@ -60304,20 +61463,20 @@ ecs_value_t* flecs_script_with_append(
     ecs_script_eval_visitor_t *v,
     const ecs_type_info_t *ti)
 {
-    if (ecs_vec_count(&v->with)) {
-        ecs_assert(ecs_vec_last_t(&v->with, ecs_value_t)->type == 0, 
+    if (ecs_vec_count(&v->r->with)) {
+        ecs_assert(ecs_vec_last_t(&v->r->with, ecs_value_t)->type == 0, 
             ECS_INTERNAL_ERROR, NULL);
-        ecs_assert(ecs_vec_last_t(&v->with, ecs_value_t)->ptr == NULL, 
+        ecs_assert(ecs_vec_last_t(&v->r->with, ecs_value_t)->ptr == NULL, 
             ECS_INTERNAL_ERROR, NULL);
-        ecs_vec_remove_last(&v->with);
+        ecs_vec_remove_last(&v->r->with);
     }
 
-    ecs_vec_append_t(a, &v->with_type_info, const ecs_type_info_t*)[0] = ti;
+    ecs_vec_append_t(a, &v->r->with_type_info, const ecs_type_info_t*)[0] = ti;
 
-    ecs_vec_append_t(a, &v->with, ecs_value_t);
-    ecs_value_t *last = ecs_vec_append_t(a, &v->with, ecs_value_t);
+    ecs_vec_append_t(a, &v->r->with, ecs_value_t);
+    ecs_value_t *last = ecs_vec_append_t(a, &v->r->with, ecs_value_t);
     ecs_os_memset_t(last, 0, ecs_value_t);
-    return ecs_vec_get_t(&v->with, ecs_value_t, ecs_vec_count(&v->with) - 2);
+    return ecs_vec_get_t(&v->r->with, ecs_value_t, ecs_vec_count(&v->r->with) - 2);
 }
 
 static
@@ -60326,34 +61485,34 @@ void flecs_script_with_set_count(
     ecs_script_eval_visitor_t *v,
     int32_t count)
 {
-    int32_t i = count, until = ecs_vec_count(&v->with) - 1;
+    int32_t i = count, until = ecs_vec_count(&v->r->with) - 1;
     for (; i < until; i ++) {
-        ecs_value_t *val = ecs_vec_get_t(&v->with, ecs_value_t, i);
+        ecs_value_t *val = ecs_vec_get_t(&v->r->with, ecs_value_t, i);
         ecs_type_info_t *ti = ecs_vec_get_t(
-            &v->with_type_info, ecs_type_info_t*, i)[0];
+            &v->r->with_type_info, ecs_type_info_t*, i)[0];
         if (ti && ti->hooks.dtor) {
             ti->hooks.dtor(val->ptr, 1, ti);
         }
     }
 
     if (count) {
-        ecs_value_t *last = ecs_vec_get_t(&v->with, ecs_value_t, count);
+        ecs_value_t *last = ecs_vec_get_t(&v->r->with, ecs_value_t, count);
         ecs_os_memset_t(last, 0, ecs_value_t);
-        ecs_vec_set_count_t(a, &v->with, ecs_value_t, count + 1);
+        ecs_vec_set_count_t(a, &v->r->with, ecs_value_t, count + 1);
     } else {
-        ecs_vec_set_count_t(a, &v->with, ecs_value_t, 0);
+        ecs_vec_set_count_t(a, &v->r->with, ecs_value_t, 0);
     }
 
-    ecs_vec_set_count_t(a, &v->with_type_info, ecs_type_info_t*, count);
+    ecs_vec_set_count_t(a, &v->r->with_type_info, ecs_type_info_t*, count);
 }
 
 static
 ecs_value_t* flecs_script_with_last(
     ecs_script_eval_visitor_t *v)
 {
-    int32_t count = ecs_vec_count(&v->with);
+    int32_t count = ecs_vec_count(&v->r->with);
     if (count) {
-        return ecs_vec_get_t(&v->with, ecs_value_t, count - 2);
+        return ecs_vec_get_t(&v->r->with, ecs_value_t, count - 2);
     }
     return NULL;
 }
@@ -60362,12 +61521,12 @@ static
 int32_t flecs_script_with_count(
     ecs_script_eval_visitor_t *v)
 {
-    if (ecs_vec_count(&v->with)) {
-        ecs_assert(ecs_vec_last_t(&v->with, ecs_value_t)->type == 0, 
+    if (ecs_vec_count(&v->r->with)) {
+        ecs_assert(ecs_vec_last_t(&v->r->with, ecs_value_t)->type == 0, 
             ECS_INTERNAL_ERROR, NULL);
-        ecs_assert(ecs_vec_last_t(&v->with, ecs_value_t)->ptr == NULL, 
+        ecs_assert(ecs_vec_last_t(&v->r->with, ecs_value_t)->ptr == NULL, 
             ECS_INTERNAL_ERROR, NULL);
-        return ecs_vec_count(&v->with) - 1;
+        return ecs_vec_count(&v->r->with) - 1;
     }
     return 0;
 }
@@ -60392,24 +61551,50 @@ error:
         char *idstr = ecs_id_str(v->world, id);
         flecs_script_eval_error(v, node, 
             "cannot set value of '%s': not a component", idstr);
+        flecs_dump_backtrace(stdout);
         ecs_os_free(idstr);
     }
     return NULL;
 }
 
-ecs_entity_t flecs_script_find_entity(
+ecs_script_var_t* flecs_script_find_var(
+    const ecs_script_vars_t *vars,
+    const char *name,
+    int32_t *sp)
+{
+    if (sp && sp[0] != -1) {
+        return ecs_script_vars_from_sp(vars, sp[0]);
+    } else {
+        ecs_script_var_t *var = ecs_script_vars_lookup(vars, name);
+        if (var && sp) {
+            sp[0] = var->sp;
+        }
+        return var;
+    }
+}
+
+int flecs_script_find_entity(
     ecs_script_eval_visitor_t *v,
     ecs_entity_t from,
-    const char *path)
+    const char *path,
+    int32_t *sp,
+    ecs_entity_t *out)
 {
     if (!path) {
-        return 0;
+        goto error;
     }
 
     if (path[0] == '$') {
-        const ecs_script_var_t *var = ecs_script_vars_lookup(v->vars, &path[1]);
+        if (!sp) {
+            flecs_script_eval_error(v, NULL, 
+                "variable identifier '%s' not allowed here", path);
+            goto error;
+        }
+
+        const ecs_script_var_t *var = flecs_script_find_var(
+            v->vars, &path[1], v->dynamic_variable_binding ? NULL : sp);
         if (!var) {
-            return 0;
+            goto error;
         }
 
         if (var->value.type != ecs_id(ecs_entity_t)) {
@@ -60418,43 +61603,54 @@ ecs_entity_t flecs_script_find_entity(
                 "variable '%s' must be of type entity, got '%s'", 
                     path, type_str);
             ecs_os_free(type_str);
+            goto error;
+        }
+
+        if (v->template) {
             return 0;
         }
 
-        if (var->value.ptr == NULL) {
+        if (var->value.ptr == NULL) {            
             flecs_script_eval_error(v, NULL, 
                 "variable '%s' is not initialized", path);
-            return 0;
+            goto error;
         }
 
         ecs_entity_t result = *(ecs_entity_t*)var->value.ptr;
         if (!result) {
             flecs_script_eval_error(v, NULL, 
                 "variable '%s' contains invalid entity id (0)", path);
-            return 0;
+            goto error;
         }
 
-        return result;
+        *out = result;
+
+        return 0;
     }
 
     if (from) {
-        return ecs_lookup_path_w_sep(v->world, from, path, NULL, NULL, false);
+        *out = ecs_lookup_path_w_sep(v->world, from, path, NULL, NULL, false);
     } else {
-        int32_t i, using_count = ecs_vec_count(&v->using);
+        int32_t i, using_count = ecs_vec_count(&v->r->using);
         if (using_count) {
-            ecs_entity_t *using = ecs_vec_first(&v->using);
+            ecs_entity_t *using = ecs_vec_first(&v->r->using);
             for (i = using_count - 1; i >= 0; i --) {
                 ecs_entity_t e = ecs_lookup_path_w_sep(
                     v->world, using[i], path, NULL, NULL, false);
                 if (e) {
-                    return e;
+                    *out = e;
+                    return 0;
                 }
             }
         }
 
-        return ecs_lookup_path_w_sep(
+        *out = ecs_lookup_path_w_sep(
             v->world, v->parent, path, NULL, NULL, true);
     }
+
+    return 0;
+error:
+    return -1;
 }
 
 ecs_entity_t flecs_script_create_entity(
@@ -60463,7 +61659,7 @@ ecs_entity_t flecs_script_create_entity(
 {
     ecs_value_t *with = NULL;
     if (flecs_script_with_count(v)) {
-        with = ecs_vec_first_t(&v->with, ecs_value_t);
+        with = ecs_vec_first_t(&v->r->with, ecs_value_t);
     }
 
     ecs_entity_desc_t desc = {0};
@@ -60473,7 +61669,6 @@ ecs_entity_t flecs_script_create_entity(
     return ecs_entity_init(v->world, &desc);
 }
 
-static
 ecs_entity_t flecs_script_find_entity_action(
     const ecs_world_t *world,
     const char *path,
@@ -60481,41 +61676,61 @@ ecs_entity_t flecs_script_find_entity_action(
 {
     (void)world;
     ecs_script_eval_visitor_t *v = ctx;
-    return flecs_script_find_entity(v, 0, path);
+    ecs_entity_t result;
+    if (!flecs_script_find_entity(v, 0, path, NULL, &result)) {
+        return result;
+    }
+    return 0;
 }
 
 static
 int flecs_script_find_template_entity(
     ecs_script_eval_visitor_t *v,
+    void *node,
     const char *name)
 {
+    ecs_assert(name != NULL, ECS_INTERNAL_ERROR, NULL);
+
     /* Loop template scope to see if it declares an entity with requested name */
     ecs_script_template_t *t = v->template;
+    ecs_assert(t != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(t->node != NULL, ECS_INTERNAL_ERROR, NULL);
+
     ecs_script_scope_t *scope = t->node->scope;
     ecs_script_node_t **nodes = ecs_vec_first_t(
         &scope->stmts, ecs_script_node_t*);
 
     int32_t i, count = ecs_vec_count(&scope->stmts);
     for (i = 0; i < count; i ++) {
-        ecs_script_node_t *node = nodes[i];
-        if (node->kind == EcsAstEntity) {
-            ecs_script_entity_t *entity_node = (ecs_script_entity_t*)node;
+        ecs_script_node_t *elem = nodes[i];
+        if (elem->kind == EcsAstEntity) {
+            ecs_script_entity_t *entity_node = (ecs_script_entity_t*)elem;
+            if (!entity_node->name) {
+                continue;
+            }
+
             if (!ecs_os_strcmp(entity_node->name, name)) {
                 return 0;
             }
         }
     }
 
+    flecs_script_eval_error(v, node, "unresolved reference to '%s'", name);
+
     return -1;
 }
 
-static
 int flecs_script_eval_id(
     ecs_script_eval_visitor_t *v,
     void *node,
     ecs_script_id_t *id)
 {
     ecs_entity_t second_from = 0;
+
+    if (id->eval && !id->dynamic) {
+        /* Already resolved */
+        return 0;
+    }
 
     if (!id->first) {
         flecs_script_eval_error(v, node, 
@@ -60526,15 +61741,33 @@ int flecs_script_eval_id(
     if (v->template) {
         /* Can't resolve variables while preprocessing template scope */
         if (id->first[0] == '$') {
-            return 0;
+            if (flecs_script_find_var(v->vars, &id->first[1], 
+                v->dynamic_variable_binding ? NULL : &id->first_sp)) 
+            {
+                return 0;
+            } else {
+                flecs_script_eval_error(v, node, 
+                    "unresolved variable '%s'", &id->first[1]);
+                return -1;
+            }
         }
         if (id->second && id->second[0] == '$') {
-            return 0;
+            if (flecs_script_find_var(v->vars, &id->second[1], 
+                v->dynamic_variable_binding ? NULL : &id->second_sp))
+            {
+                return 0;
+            } else {
+                flecs_script_eval_error(v, node, 
+                    "unresolved variable '%s'", &id->second[1]);
+                return -1;
+            }
         }
     }
 
-    ecs_entity_t first = flecs_script_find_entity(v, 0, id->first);
-    if (!first) {
+    ecs_entity_t first = 0;
+    if (flecs_script_find_entity(
+        v, 0, id->first, &id->first_sp, &first) || !first)
+    {
         if (id->first[0] == '$') {
             flecs_script_eval_error(v, node, 
                 "unresolved variable '%s'", id->first);
@@ -60543,15 +61776,18 @@ int flecs_script_eval_id(
 
         flecs_script_eval_error(v, node,
             "unresolved identifier '%s'", id->first);
+
         return -1;
     } else if (id->second) {
         second_from = flecs_get_oneof(v->world, first);
     }
 
     if (id->second) {
-        ecs_entity_t second = flecs_script_find_entity(
-            v, second_from, id->second);
-        if (!second) {
+        ecs_entity_t second = 0;
+        if (flecs_script_find_entity(
+            v, second_from, id->second, &id->second_sp, &second) || 
+            !second) 
+        {
             if (id->second[0] == '$') {
                 flecs_script_eval_error(v, node, 
                     "unresolved variable '%s'", id->second);
@@ -60560,7 +61796,8 @@ int flecs_script_eval_id(
 
             /* Targets may be defined by the template */
             if (v->template) {
-                if (!flecs_script_find_template_entity(v, id->second)) {
+                if (!flecs_script_find_template_entity(v, node, id->second)) {
+                    id->dynamic = true;
                     return 0;
                 } else {
                     return -1;
@@ -60577,6 +61814,7 @@ int flecs_script_eval_id(
 
             flecs_script_eval_error(v, node,
                 "unresolved identifier '%s'", id->second);
+
             return -1;
         }
 
@@ -60602,36 +61840,49 @@ int flecs_script_eval_id(
 
 int flecs_script_eval_expr(
     ecs_script_eval_visitor_t *v,
-    const char *expr,
+    ecs_expr_node_t **expr_ptr,
     ecs_value_t *value)
 {
-    if (!value->type && expr[0] == '{') {
-        expr ++;
-    }
+    ecs_expr_node_t *expr = *expr_ptr;
+    ecs_assert(expr != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_script_impl_t *impl = v->base.script;
+    ecs_script_t *script = &impl->pub;
 
-    ecs_script_expr_run_desc_t desc = {
-        .name = v->base.script->pub.name,
-        .expr = expr,
+    ecs_expr_eval_desc_t desc = {
+        .name = script->name,
         .lookup_action = flecs_script_find_entity_action,
         .lookup_ctx = v,
-        .vars = v->vars
+        .vars = v->vars,
+        .type = value->type,
+        .runtime = v->r,
+        .disable_dynamic_variable_binding = !v->dynamic_variable_binding
     };
 
-    if (!ecs_script_expr_run(v->world, expr, value, &desc)) {
-        return -1;
+    if (expr->type_info == NULL) {
+        if (flecs_expr_visit_type(script, expr, &desc)) {
+            goto error;
+        }
+        if (flecs_expr_visit_fold(script, expr_ptr, &desc)) {
+            goto error;
+        }
+    }
+
+    if (flecs_expr_visit_eval(script, *expr_ptr, &desc, value)) {
+        goto error;
     }
 
     return 0;
+error:
+    return -1;
 }
 
-static
 int flecs_script_eval_scope(
     ecs_script_eval_visitor_t *v,
     ecs_script_scope_t *node)
 {
     ecs_script_node_t *scope_parent = ecs_script_parent_node(v);
     ecs_entity_t prev_eval_parent = v->parent;
-    int32_t prev_using_count = ecs_vec_count(&v->using);
+    int32_t prev_using_count = ecs_vec_count(&v->r->using);
 
     for (int i = v->base.depth - 2; i >= 0; i --) {
         if (v->base.nodes[i]->kind == EcsAstScope) {
@@ -60640,8 +61891,8 @@ int flecs_script_eval_scope(
         }
     }
 
-    ecs_allocator_t *a = v->allocator;
-    v->vars = flecs_script_vars_push(v->vars, &v->stack, a);
+    ecs_allocator_t *a = &v->r->allocator;
+    v->vars = flecs_script_vars_push(v->vars, &v->r->stack, a);
 
     if (scope_parent && (scope_parent->kind == EcsAstEntity)) {
         if (!v->template) {
@@ -60649,9 +61900,18 @@ int flecs_script_eval_scope(
         }
     }
 
+    if (v->entity) {
+        ecs_entity_t src = v->entity->eval;
+        int32_t count = ecs_vec_count(&node->components);
+        if (src != EcsSingleton && count) {
+            flecs_add_ids(
+                v->world, src, ecs_vec_first(&node->components), count);
+        }
+    }
+
     int result = ecs_script_visit_scope(v, node);
 
-    ecs_vec_set_count_t(a, &v->using, ecs_entity_t, prev_using_count);
+    ecs_vec_set_count_t(a, &v->r->using, ecs_entity_t, prev_using_count);
     v->vars = ecs_script_vars_pop(v->vars);
     v->parent = prev_eval_parent;
 
@@ -60715,15 +61975,54 @@ int flecs_script_eval_entity(
         }
     }
 
-    if (v->template) {
-        if (ecs_script_visit_node(v, node->scope)) {
+    ecs_expr_node_t *name_expr = node->name_expr;
+    if (name_expr) {
+        ecs_script_t *script = &v->base.script->pub;
+        ecs_expr_eval_desc_t desc = {
+            .name = script->name,
+            .lookup_action = flecs_script_find_entity_action,
+            .lookup_ctx = v,
+            .vars = v->vars,
+            .type = ecs_id(ecs_string_t),
+            .runtime = v->r
+        };
+
+        if (!name_expr->type_info) {
+            if (flecs_expr_visit_type(script, name_expr, &desc)) {
+                return -1;
+            }
+
+            if (flecs_expr_visit_fold(script, &node->name_expr, &desc)) {
+                return -1;
+            }
+
+            name_expr = node->name_expr;
+        }
+
+        ecs_value_t value = { .type = ecs_id(ecs_string_t) };
+        if (flecs_expr_visit_eval(script, name_expr, &desc, &value)) {
             return -1;
         }
-        return 0;
+
+        char *name = *(char**)value.ptr;
+        if (!name) {
+            flecs_script_eval_error(v, node, "failed to evaluate entity name");
+            return -1;
+        }
+
+        node->eval = flecs_script_create_entity(v, name);
+
+        ecs_value_free(script->world, value.type, value.ptr);
+    } else {
+        node->eval = flecs_script_create_entity(v, node->name);
     }
 
-    node->eval = flecs_script_create_entity(v, node->name);
     node->parent = v->entity;
+
+    if (v->template_entity) {
+        ecs_add_pair(
+            v->world, node->eval, EcsScriptTemplate, v->template_entity);
+    }
 
     if (is_slot) {
         ecs_entity_t parent = ecs_get_target(
@@ -60758,18 +62057,25 @@ int flecs_script_eval_entity(
         }
     }
 
-    int32_t i, count = ecs_vec_count(&v->annot);
+    int32_t i, count = ecs_vec_count(&v->r->annot);
     if (count) {
-        ecs_script_annot_t **annots = ecs_vec_first(&v->annot);
+        ecs_script_annot_t **annots = ecs_vec_first(&v->r->annot);
         for (i = 0; i < count ; i ++) {
             flecs_script_apply_annot(v, node->eval, annots[i]);
         }
-        ecs_vec_clear(&v->annot);
+        ecs_vec_clear(&v->r->annot);
     }
 
+
+    bool old_is_with_scope = v->is_with_scope;
+    ecs_entity_t old_template_entity = v->template_entity;
+    v->is_with_scope = false;
+    v->template_entity = 0;
     if (ecs_script_visit_node(v, node->scope)) {
         return -1;
     }
+    v->template_entity = old_template_entity;
+    v->is_with_scope = old_is_with_scope;
 
     if (node->eval_kind) {
         if (!node->kind_w_expr) {
@@ -60809,8 +62115,9 @@ int flecs_script_eval_tag(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
+    if (v->is_with_scope) {
+        flecs_script_eval_error(v, node, "invalid component in with scope"); 
+        return -1;
     }
 
     if (!v->entity) {
@@ -60823,10 +62130,6 @@ int flecs_script_eval_tag(
                 node->id.first);
         }
         return -1;
-    }
-
-    if (v->template) {
-        return 0;
     }
 
     ecs_entity_t src = flecs_script_get_src(
@@ -60845,10 +62148,6 @@ int flecs_script_eval_component(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
-    }
-
     if (!v->entity) {
         if (node->id.second) {
             flecs_script_eval_error(v, node, "missing entity for pair (%s, %s)",
@@ -60860,13 +62159,14 @@ int flecs_script_eval_component(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
+    if (v->is_with_scope) {
+        flecs_script_eval_error(v, node, "invalid component in with scope"); 
+        return -1;
     }
 
     ecs_entity_t src = flecs_script_get_src(v, v->entity->eval, node->id.eval);
 
-    if (node->expr && node->expr[0]) {
+    if (node->expr) {
         const ecs_type_info_t *ti = flecs_script_get_type_info(
             v, node, node->id.eval);
         if (!ti) {
@@ -60905,6 +62205,10 @@ int flecs_script_eval_component(
                 return -1;
             }
         }
+
+        ecs_record_t *r = flecs_entities_get(v->world, src);
+        ecs_assert(r != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_table_t *table = r->table;
  
         ecs_value_t value = {
             .ptr = ecs_ensure_id(v->world, src, node->id.eval),
@@ -60913,19 +62217,19 @@ int flecs_script_eval_component(
 
         /* Assign entire value, including members not set by expression. This 
          * prevents uninitialized or unexpected values. */
-        if (!ti->hooks.ctor) {
-            ecs_os_memset(value.ptr, 0, ti->size);
-        } else if (ti->hooks.ctor) {
-            if (ti->hooks.dtor) {
-                ti->hooks.dtor(value.ptr, 1, ti);
+        if (r->table != table) {
+            if (!ti->hooks.ctor) {
+                ecs_os_memset(value.ptr, 0, ti->size);
+            } else if (ti->hooks.ctor) {
+                if (ti->hooks.dtor) {
+                    ti->hooks.dtor(value.ptr, 1, ti);
+                }
+                ti->hooks.ctor(value.ptr, 1, ti);
             }
-            ti->hooks.ctor(value.ptr, 1, ti);
         }
 
-        if (ecs_os_strcmp(node->expr, "{}")) {
-            if (flecs_script_eval_expr(v, node->expr, &value)) {
-                return -1;
-            }
+        if (flecs_script_eval_expr(v, &node->expr, &value)) {
+            return -1;
         }
 
         ecs_modified_id(v->world, src, node->id.eval);
@@ -60941,15 +62245,18 @@ int flecs_script_eval_var_component(
     ecs_script_eval_visitor_t *v,
     ecs_script_var_component_t *node)
 {
-    ecs_script_var_t *var = ecs_script_vars_lookup(v->vars, node->name);
+    
+    ecs_script_var_t *var = flecs_script_find_var(
+        v->vars, node->name, v->dynamic_variable_binding ? NULL : &node->sp);
     if (!var) {
         flecs_script_eval_error(v, node, 
             "unresolved variable '%s'", node->name);
         return -1;
     }
 
-    if (v->template) {
-        return 0;
+    if (v->is_with_scope) {
+        flecs_script_eval_error(v, node, "invalid component in with scope"); 
+        return -1;
     }
 
     ecs_id_t var_id = var->value.type;
@@ -60987,10 +62294,6 @@ int flecs_script_eval_default_component(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
-    }
-
     ecs_script_scope_t *scope = ecs_script_current_scope(v);
     ecs_assert(scope != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(scope->node.kind == EcsAstScope, ECS_INTERNAL_ERROR, NULL);
@@ -61025,7 +62328,7 @@ int flecs_script_eval_default_component(
         .type = default_type
     };
 
-    if (flecs_script_eval_expr(v, node->expr, &value)) {
+    if (flecs_script_eval_expr(v, &node->expr, &value)) {
         return -1;
     }
 
@@ -61037,20 +62340,17 @@ int flecs_script_eval_default_component(
 static
 int flecs_script_eval_with_var(
     ecs_script_eval_visitor_t *v,
-    ecs_script_var_node_t *node)
+    ecs_script_var_component_t *node)
 {
-    ecs_script_var_t *var = ecs_script_vars_lookup(v->vars, node->name);
+    ecs_script_var_t *var = flecs_script_find_var(
+        v->vars, node->name, v->dynamic_variable_binding ? NULL : &node->sp);
     if (!var) {
         flecs_script_eval_error(v, node, 
             "unresolved variable '%s'", node->name);
         return -1;
     }
 
-    if (v->template) {
-        return 0;
-    }
-
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     ecs_value_t *value = flecs_script_with_append(a, v, NULL); // TODO: vars of non trivial types
     *value = var->value;
 
@@ -61066,11 +62366,7 @@ int flecs_script_eval_with_tag(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
-    }
-
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     ecs_value_t *value = flecs_script_with_append(a, v, NULL);
     value->type = node->id.eval;
     value->ptr = NULL;
@@ -61087,11 +62383,7 @@ int flecs_script_eval_with_component(
         return -1;
     }
 
-    if (v->template) {
-        return 0;
-    }
-
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     const ecs_type_info_t *ti = flecs_script_get_type_info(
         v, node, node->id.eval);
 
@@ -61099,19 +62391,19 @@ int flecs_script_eval_with_component(
     value->type = node->id.eval;
     value->ptr = NULL;
 
-    if (node->expr && node->expr[0]) {
+    if (node->expr) {
         if (!ti) {
             return -1;
         }
 
-        value->ptr = flecs_stack_alloc(&v->stack, ti->size, ti->alignment);
+        value->ptr = flecs_stack_alloc(&v->r->stack, ti->size, ti->alignment);
         value->type = ti->component; // Expression parser needs actual type
 
         if (ti->hooks.ctor) {
             ti->hooks.ctor(value->ptr, 1, ti);
         }
 
-        if (flecs_script_eval_expr(v, node->expr, value)) {
+        if (flecs_script_eval_expr(v, &node->expr, value)) {
             return -1;
         }
 
@@ -61126,9 +62418,9 @@ int flecs_script_eval_with(
     ecs_script_eval_visitor_t *v,
     ecs_script_with_t *node)
 {
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     int32_t prev_with_count = flecs_script_with_count(v);
-    ecs_stack_cursor_t *prev_stack_cursor = flecs_stack_get_cursor(&v->stack);
+    ecs_stack_cursor_t *prev_stack_cursor = flecs_stack_get_cursor(&v->r->stack);
     int result = 0;
 
     if (ecs_script_visit_scope(v, node->expressions)) {
@@ -61143,23 +62435,27 @@ int flecs_script_eval_with(
         }
     }
 
+    bool old_is_with_scope = v->is_with_scope;
+    v->is_with_scope = true;
+
     if (ecs_script_visit_scope(v, node->scope)) {
         result = -1;
         goto error;
     }
 
+    v->is_with_scope = old_is_with_scope;
+
 error:
     flecs_script_with_set_count(a, v, prev_with_count);
-    flecs_stack_restore_cursor(&v->stack, prev_stack_cursor);
+    flecs_stack_restore_cursor(&v->r->stack, prev_stack_cursor);
     return result;
 }
 
-static
 int flecs_script_eval_using(
     ecs_script_eval_visitor_t *v,
     ecs_script_using_t *node)
 {
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     int32_t len = ecs_os_strlen(node->name);
 
     if (len > 2 && !ecs_os_strcmp(&node->name[len - 2], ".*")) {
@@ -61180,7 +62476,7 @@ int flecs_script_eval_using(
             int32_t i, count = it.count;
             for (i = 0; i < count; i ++) {
                 ecs_vec_append_t(
-                    a, &v->using, ecs_entity_t)[0] = it.entities[i];
+                    a, &v->r->using, ecs_entity_t)[0] = it.entities[i];
             }
         }
 
@@ -61199,7 +62495,7 @@ int flecs_script_eval_using(
             }
         }
 
-        ecs_vec_append_t(a, &v->using, ecs_entity_t)[0] = from;
+        ecs_vec_append_t(a, &v->r->using, ecs_entity_t)[0] = from;
     }
 
     return 0;
@@ -61223,36 +62519,51 @@ int flecs_script_eval_module(
     return 0;
 }
 
-static
 int flecs_script_eval_const(
     ecs_script_eval_visitor_t *v,
     ecs_script_var_node_t *node)
 {
-    ecs_script_var_t *var = ecs_script_vars_declare(v->vars, node->name);
+    /* Declare variable. If this variable is declared while instantiating a
+     * template, the variable sp has already been resolved in all expressions
+     * that used it, so we don't need to create the variable with a name. */
+    ecs_script_var_t *var = ecs_script_vars_declare(v->vars, 
+        v->template_entity ? NULL : node->name);
     if (!var) {
         flecs_script_eval_error(v, node, 
             "variable '%s' redeclared", node->name);
         return -1;
     }
 
-    if (node->type) {
-        ecs_entity_t type = flecs_script_find_entity(v, 0, node->type);
-        if (!type) {
+    ecs_entity_t type = 0;
+    const ecs_type_info_t *ti = NULL;
+    if (node->expr) {
+        type = node->expr->type;
+        ti = node->expr->type_info;
+    }
+
+    if (!type && node->type) {
+        if (flecs_script_find_entity(v, 0, node->type, NULL, &type) || !type) {
             flecs_script_eval_error(v, node,
                 "unresolved type '%s' for const variable '%s'", 
                     node->type, node->name);
             return -1;
         }
 
-        const ecs_type_info_t *ti = flecs_script_get_type_info(v, node, type);
+        ti = flecs_script_get_type_info(v, node, type);
         if (!ti) {
             flecs_script_eval_error(v, node,
                 "failed to retrieve type info for '%s' for const variable '%s'", 
                     node->type, node->name);
             return -1;
         }
+    }
 
-        var->value.ptr = flecs_stack_calloc(&v->stack, ti->size, ti->alignment);
+    if (type && ti) {
+        ecs_assert(type != 0, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
+
+        var->value.ptr = flecs_stack_calloc(
+            &v->r->stack, ti->size, ti->alignment);
         var->value.type = type;
         var->type_info = ti;
 
@@ -61260,7 +62571,7 @@ int flecs_script_eval_const(
             ti->hooks.ctor(var->value.ptr, 1, ti);
         }
 
-        if (flecs_script_eval_expr(v, node->expr, &var->value)) {
+        if (flecs_script_eval_expr(v, &node->expr, &var->value)) {
             flecs_script_eval_error(v, node,
                 "failed to evaluate expression for const variable '%s'", 
                     node->name);
@@ -61270,7 +62581,7 @@ int flecs_script_eval_const(
         /* We don't know the type yet, so we can't create a storage for it yet.
          * Run the expression first to deduce the type. */
         ecs_value_t value = {0};
-        if (flecs_script_eval_expr(v, node->expr, &value)) {
+        if (flecs_script_eval_expr(v, &node->expr, &value)) {
             flecs_script_eval_error(v, node,
                 "failed to evaluate expression for const variable '%s'", 
                     node->name);
@@ -61278,10 +62589,11 @@ int flecs_script_eval_const(
         }
 
         ecs_assert(value.type != 0, ECS_INTERNAL_ERROR, NULL);
-        const ecs_type_info_t *ti = ecs_get_type_info(v->world, value.type);
+        ti = ecs_get_type_info(v->world, value.type);
         ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
 
-        var->value.ptr = flecs_stack_calloc(&v->stack, ti->size, ti->alignment);
+        var->value.ptr = flecs_stack_calloc(
+            &v->r->stack, ti->size, ti->alignment);
         var->value.type = value.type;
         var->type_info = ti;
 
@@ -61294,6 +62606,12 @@ int flecs_script_eval_const(
         flecs_free(&v->world->allocator, ti->size, value.ptr);
     }
 
+    /* If variable resolves to a constant expression, mark it as const so that
+     * its value can be folded. */
+    if (node->expr->kind == EcsExprValue) {
+        var->is_const = true;
+    }
+
     return 0;
 }
 
@@ -61302,20 +62620,35 @@ int flecs_script_eval_pair_scope(
     ecs_script_eval_visitor_t *v,
     ecs_script_pair_scope_t *node)
 {
-    ecs_entity_t first = flecs_script_find_entity(v, 0, node->id.first);
-    if (!first) {
+    ecs_entity_t first;
+    if (flecs_script_find_entity(
+        v, 0, node->id.first, &node->id.first_sp, &first) || !first)
+    {
         first = flecs_script_create_entity(v, node->id.first);
         if (!first) {
             return -1;
         }
     }
 
-    ecs_entity_t second = flecs_script_create_entity(v, node->id.second);
+    ecs_entity_t second = 0;
+    if (node->id.second) {
+        if (node->id.second[0] == '$') {
+            if (flecs_script_find_entity(
+                v, 0, node->id.second, &node->id.second_sp, &second)) 
+            {
+                return -1;
+            }
+        } else {
+            second = flecs_script_create_entity(v, node->id.second);
+        }
+        
+    }
+     
     if (!second) {
         return -1;
     }
 
-    ecs_allocator_t *a = v->allocator;
+    ecs_allocator_t *a = &v->r->allocator;
     ecs_entity_t prev_first = v->with_relationship;
     ecs_entity_t prev_second = 0;
     int32_t prev_with_relationship_sp = v->with_relationship_sp;
@@ -61331,7 +62664,7 @@ int flecs_script_eval_pair_scope(
     } else {
         /* Get existing with element for current relationhip stack */
         ecs_value_t *value = ecs_vec_get_t(
-            &v->with, ecs_value_t, v->with_relationship_sp);
+            &v->r->with, ecs_value_t, v->with_relationship_sp);
         ecs_assert(ECS_PAIR_FIRST(value->type) == (uint32_t)first, 
             ECS_INTERNAL_ERROR, NULL);
         prev_second = ECS_PAIR_SECOND(value->type);
@@ -61345,7 +62678,7 @@ int flecs_script_eval_pair_scope(
 
     if (prev_second) {
         ecs_value_t *value = ecs_vec_get_t(
-            &v->with, ecs_value_t, v->with_relationship_sp);
+            &v->r->with, ecs_value_t, v->with_relationship_sp);
         value->type = ecs_pair(first, prev_second);
     } else {
         flecs_script_with_set_count(a, v, v->with_relationship_sp);
@@ -61363,7 +62696,7 @@ int flecs_script_eval_if(
     ecs_script_if_t *node)
 {
     ecs_value_t condval = { .type = 0, .ptr = NULL };
-    if (flecs_script_eval_expr(v, node->expr, &condval)) {
+    if (flecs_script_eval_expr(v, &node->expr, &condval)) {
         return -1;
     }
 
@@ -61386,25 +62719,52 @@ int flecs_script_eval_if(
 }
 
 static
+int flecs_script_eval_for_range(
+    ecs_script_eval_visitor_t *v,
+    ecs_script_for_range_t *node)
+{
+    int32_t from;
+    int32_t to;
+    ecs_value_t from_val = { .type = ecs_id(ecs_i32_t), .ptr = &from };
+    ecs_value_t to_val = { .type = ecs_id(ecs_i32_t), .ptr = &to };
+
+    if (flecs_script_eval_expr(v, &node->from, &from_val)) {
+        return -1;
+    }
+
+    if (flecs_script_eval_expr(v, &node->to, &to_val)) {
+        return -1;
+    }
+
+    v->vars = flecs_script_vars_push(v->vars, &v->r->stack, &v->r->allocator);
+
+    ecs_script_var_t *var = ecs_script_vars_declare(v->vars, node->loop_var);
+    var->value.ptr = flecs_stack_calloc(&v->r->stack, 4, 4);
+    var->value.type = ecs_id(ecs_i32_t);
+    var->type_info = ecs_get_type_info(v->world, ecs_id(ecs_i32_t));
+    
+    int32_t i;
+    for (i = from; i < to; i ++) {
+        *(int32_t*)var->value.ptr = i;
+        if (flecs_script_eval_scope(v, node->scope)) {
+            return -1;
+        }
+    }
+
+    v->vars = ecs_script_vars_pop(v->vars);
+
+    return 0;
+}
+
+static
 int flecs_script_eval_annot(
     ecs_script_eval_visitor_t *v,
     ecs_script_annot_t *node)
 {
-    if (!v->base.next) {
-        flecs_script_eval_error(v, node,
-            "annotation '%s' is not applied to anything", node->name);
-        return -1;
-    }
+    ecs_assert(v->base.next != NULL, ECS_INTERNAL_ERROR, NULL);
 
-    ecs_script_node_kind_t kind = v->base.next->kind;
-    if (kind != EcsAstEntity && kind != EcsAstAnnotation) {
-        flecs_script_eval_error(v, node,
-            "annotation must be applied to an entity");
-        return -1;
-    }
-
-    ecs_allocator_t *a = v->allocator;
-    ecs_vec_append_t(a, &v->annot, ecs_script_annot_t*)[0] = node;
+    ecs_allocator_t *a = &v->r->allocator;
+    ecs_vec_append_t(a, &v->r->annot, ecs_script_annot_t*)[0] = node;
 
     return 0;
 }
@@ -61413,6 +62773,8 @@ int flecs_script_eval_node(
     ecs_script_eval_visitor_t *v,
     ecs_script_node_t *node)
 {
+    ecs_assert(v->template == NULL, ECS_INTERNAL_ERROR, NULL);
+
     switch(node->kind) {
     case EcsAstScope:
         return flecs_script_eval_scope(
@@ -61431,7 +62793,7 @@ int flecs_script_eval_node(
             v, (ecs_script_default_component_t*)node);
     case EcsAstWithVar:
         return flecs_script_eval_with_var(
-            v, (ecs_script_var_node_t*)node);
+            v, (ecs_script_var_component_t*)node);
     case EcsAstWithTag:
         return flecs_script_eval_with_tag(
             v, (ecs_script_tag_t*)node);
@@ -61467,53 +62829,84 @@ int flecs_script_eval_node(
     case EcsAstIf:
         return flecs_script_eval_if(
             v, (ecs_script_if_t*)node);
+    case EcsAstFor:
+        return flecs_script_eval_for_range(
+            v, (ecs_script_for_range_t*)node);
     }
 
     ecs_abort(ECS_INTERNAL_ERROR, "corrupt AST node kind");
 }
 
 void flecs_script_eval_visit_init(
-    ecs_script_impl_t *script,
-    ecs_script_eval_visitor_t *v)
+    const ecs_script_impl_t *script,
+    ecs_script_eval_visitor_t *v,
+    const ecs_script_eval_desc_t *desc)
 {
     *v = (ecs_script_eval_visitor_t){
         .base = {
-            .script = script,
-            .visit = (ecs_visit_action_t)flecs_script_eval_node
-        },  
+            .visit = (ecs_visit_action_t)flecs_script_eval_node,
+            .script = ECS_CONST_CAST(ecs_script_impl_t*, script)
+        },
         .world = script->pub.world,
-        .allocator = &script->allocator
+        .r = desc ? desc->runtime : NULL
     };
 
-    flecs_stack_init(&v->stack);
-    ecs_vec_init_t(v->allocator, &v->using, ecs_entity_t, 0);
-    ecs_vec_init_t(v->allocator, &v->with, ecs_value_t, 0);
-    ecs_vec_init_t(v->allocator, &v->with_type_info, ecs_type_info_t*, 0);
-    ecs_vec_init_t(v->allocator, &v->annot, ecs_script_annot_t*, 0);
+    if (!v->r) {
+        v->r = ecs_script_runtime_new();
+    }
+
+    if (desc && desc->vars) {
+        ecs_allocator_t *a = &v->r->allocator;
+        v->vars = flecs_script_vars_push(v->vars, &v->r->stack, a);
+        v->vars->parent = desc->vars;
+        v->vars->sp = ecs_vec_count(&desc->vars->vars);
+
+        /* When variables are provided to script, don't use cached variable
+         * stack pointers, as the order in which the application provides 
+         * variables may not be the same across evaluations. */
+        v->dynamic_variable_binding = true;
+    }
 
     /* Always include flecs.meta */
-    ecs_vec_append_t(v->allocator, &v->using, ecs_entity_t)[0] = 
+    ecs_vec_append_t(&v->r->allocator, &v->r->using, ecs_entity_t)[0] = 
         ecs_lookup(v->world, "flecs.meta");
 }
 
 void flecs_script_eval_visit_fini(
-    ecs_script_eval_visitor_t *v)
+    ecs_script_eval_visitor_t *v,
+    const ecs_script_eval_desc_t *desc)
 {
-    ecs_vec_fini_t(v->allocator, &v->annot, ecs_script_annot_t*);
-    ecs_vec_fini_t(v->allocator, &v->with, ecs_value_t);
-    ecs_vec_fini_t(v->allocator, &v->with_type_info, ecs_type_info_t*);
-    ecs_vec_fini_t(v->allocator, &v->using, ecs_entity_t);
-    flecs_stack_fini(&v->stack);
+    if (desc && desc->vars) {
+        v->vars = ecs_script_vars_pop(v->vars);
+    }
+
+    if (!desc || (v->r != desc->runtime)) {
+        ecs_script_runtime_free(v->r);
+    }
 }
 
 int ecs_script_eval(
-    ecs_script_t *script)
+    const ecs_script_t *script,
+    const ecs_script_eval_desc_t *desc)
 {
     ecs_script_eval_visitor_t v;
-    ecs_script_impl_t *impl = flecs_script_impl(script);
-    flecs_script_eval_visit_init(impl, &v);
+    ecs_script_impl_t *impl = flecs_script_impl(
+        /* Safe, script will only be used for reading by visitor */
+        ECS_CONST_CAST(ecs_script_t*, script));
+
+    ecs_script_eval_desc_t priv_desc = {0};
+    if (desc) {
+        priv_desc = *desc;
+    }
+
+    if (!priv_desc.runtime) {
+        priv_desc.runtime = flecs_script_runtime_get(script->world);
+    }
+
+    flecs_script_eval_visit_init(impl, &v, &priv_desc);
     int result = ecs_script_visit(impl, &v, flecs_script_eval_node);
-    flecs_script_eval_visit_fini(&v);
+    flecs_script_eval_visit_fini(&v, &priv_desc);
+
     return result;
 }
 
@@ -61534,6 +62927,7 @@ void flecs_script_scope_free(
 {
     ecs_script_visit_scope(v, node);
     ecs_vec_fini_t(&v->script->allocator, &node->stmts, ecs_script_node_t*);
+    ecs_vec_fini_t(&v->script->allocator, &node->components, ecs_id_t);
     flecs_free_t(&v->script->allocator, ecs_script_scope_t, node);
 }
 
@@ -61560,6 +62954,9 @@ void flecs_script_entity_free(
     ecs_script_entity_t *node)
 {
     flecs_script_scope_free(v, node->scope);
+    if (node->name_expr) {
+        flecs_expr_visit_free(&v->script->pub, node->name_expr);
+    }
 }
 
 static
@@ -61577,6 +62974,41 @@ void flecs_script_if_free(
 {
     flecs_script_scope_free(v, node->if_true);
     flecs_script_scope_free(v, node->if_false);
+    flecs_expr_visit_free(&v->script->pub, node->expr);
+}
+
+static
+void flecs_script_for_range_free(
+    ecs_script_visit_t *v,
+    ecs_script_for_range_t *node)
+{
+    flecs_expr_visit_free(&v->script->pub, node->from);
+    flecs_expr_visit_free(&v->script->pub, node->to);
+    flecs_script_scope_free(v, node->scope);
+}
+
+static
+void flecs_script_component_free(
+    ecs_script_visit_t *v,
+    ecs_script_component_t *node)
+{
+    flecs_expr_visit_free(&v->script->pub, node->expr);
+}
+
+static
+void flecs_script_default_component_free(
+    ecs_script_visit_t *v,
+    ecs_script_default_component_t *node)
+{
+    flecs_expr_visit_free(&v->script->pub, node->expr);
+}
+
+static
+void flecs_script_var_node_free(
+    ecs_script_visit_t *v,
+    ecs_script_var_node_t *node)
+{
+    flecs_expr_visit_free(&v->script->pub, node->expr);
 }
 
 static
@@ -61609,13 +63041,21 @@ int flecs_script_stmt_free(
         flecs_script_if_free(v, (ecs_script_if_t*)node);
         flecs_free_t(a, ecs_script_if_t, node);
         break;
+    case EcsAstFor:
+        flecs_script_for_range_free(v, (ecs_script_for_range_t*)node);
+        flecs_free_t(a, ecs_script_for_range_t, node);
+        break;
     case EcsAstTag:
         flecs_free_t(a, ecs_script_tag_t, node);
         break;
     case EcsAstComponent:
+    case EcsAstWithComponent:
+        flecs_script_component_free(v, (ecs_script_component_t*)node);
         flecs_free_t(a, ecs_script_component_t, node);
         break;
     case EcsAstDefaultComponent:
+        flecs_script_default_component_free(v, 
+            (ecs_script_default_component_t*)node);
         flecs_free_t(a, ecs_script_default_component_t, node);
         break;
     case EcsAstVarComponent:
@@ -61626,9 +63066,6 @@ int flecs_script_stmt_free(
         break;
     case EcsAstWithTag:
         flecs_free_t(a, ecs_script_tag_t, node);
-        break;
-    case EcsAstWithComponent:
-        flecs_free_t(a, ecs_script_component_t, node);
         break;
     case EcsAstUsing:
         flecs_free_t(a, ecs_script_using_t, node);
@@ -61641,6 +63078,7 @@ int flecs_script_stmt_free(
         break;
     case EcsAstProp:
     case EcsAstConst:
+        flecs_script_var_node_free(v, (ecs_script_var_node_t*)node);
         flecs_free_t(a, ecs_script_var_node_t, node);
         break;
     }
@@ -61682,12 +63120,21 @@ typedef struct ecs_script_str_visitor_t {
     ecs_strbuf_t *buf;
     int32_t depth;
     bool newline;
+    bool colors;
 } ecs_script_str_visitor_t;
 
 static
 int flecs_script_scope_to_str(
     ecs_script_str_visitor_t *v,
     ecs_script_scope_t *scope);
+
+static
+void flecs_script_color_to_str(
+    ecs_script_str_visitor_t *v,
+    const char *color)
+{
+    if (v->colors) ecs_strbuf_appendstr(v->buf, color);
+}
 
 static
 void flecs_scriptbuf_append(
@@ -61749,12 +63196,13 @@ void flecs_script_id_to_str(
 }
 
 static
-void flecs_script_expr_to_str(
+void flecs_expr_to_str(
     ecs_script_str_visitor_t *v,
-    const char *expr)
+    const ecs_expr_node_t *expr)
 {
     if (expr) {
-        flecs_scriptbuf_append(v, "%s%s%s", ECS_GREEN, expr, ECS_NORMAL);
+        flecs_expr_to_str_buf(
+            v->base.script->pub.world, expr, v->buf, v->colors);
     } else {
         flecs_scriptbuf_appendstr(v, "{}");
     }
@@ -61783,6 +63231,7 @@ const char* flecs_script_node_to_str(
     case EcsAstEntity:             return "entity";
     case EcsAstPairScope:          return "pair_scope";
     case EcsAstIf:                 return "if";
+    case EcsAstFor:                return "for";
     }
     return "???";
 }
@@ -61792,8 +63241,9 @@ void flecs_scriptbuf_node(
     ecs_script_str_visitor_t *v,
     ecs_script_node_t *node)
 {
-    flecs_scriptbuf_append(v, "%s%s%s: ", 
-        ECS_BLUE, flecs_script_node_to_str(node), ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_BLUE);
+    flecs_scriptbuf_append(v, "%s: ", flecs_script_node_to_str(node));
+    flecs_script_color_to_str(v, ECS_NORMAL);
 }
 
 static
@@ -61815,7 +63265,7 @@ void flecs_script_component_to_str(
     flecs_script_id_to_str(v, &node->id);
     if (node->expr) {
         flecs_scriptbuf_appendstr(v, ": ");
-        flecs_script_expr_to_str(v, node->expr);
+        flecs_expr_to_str(v, node->expr);
     }
     flecs_scriptbuf_appendstr(v, "\n");
 }
@@ -61827,7 +63277,7 @@ void flecs_script_default_component_to_str(
 {
     flecs_scriptbuf_node(v, &node->node);
     if (node->expr) {
-        flecs_script_expr_to_str(v, node->expr);
+        flecs_expr_to_str(v, node->expr);
     }
     flecs_scriptbuf_appendstr(v, "\n");
 }
@@ -61851,9 +63301,13 @@ void flecs_script_with_to_str(
     
     flecs_scriptbuf_appendstr(v, "{\n");
     v->depth ++;
-    flecs_scriptbuf_append(v, "%sexpressions%s: ", ECS_CYAN, ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_CYAN);
+    flecs_scriptbuf_appendstr(v, "expressions: ");
+    flecs_script_color_to_str(v, ECS_NORMAL);
     flecs_script_scope_to_str(v, node->expressions);
-    flecs_scriptbuf_append(v, "%sscope%s: ", ECS_CYAN, ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_CYAN);
+    flecs_scriptbuf_append(v, "scope: ");
+    flecs_script_color_to_str(v, ECS_NORMAL);
     flecs_script_scope_to_str(v, node->scope);
     v->depth --;
     flecs_scriptbuf_appendstr(v, "}\n");
@@ -61883,8 +63337,9 @@ void flecs_script_annot_to_str(
     ecs_script_annot_t *node)
 {
     flecs_scriptbuf_node(v, &node->node);
-    flecs_scriptbuf_append(v, "%s = %s\"%s\"%s", node->name, 
-        ECS_GREEN, node->expr, ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_GREEN);
+    flecs_scriptbuf_append(v, "%s = \"%s\"", node->name, node->expr);
+    flecs_script_color_to_str(v, ECS_NORMAL);
     flecs_scriptbuf_appendstr(v, "\n");
 }
 
@@ -61912,7 +63367,7 @@ void flecs_script_var_node_to_str(
         flecs_scriptbuf_append(v, "%s = ", 
             node->name);
     }
-    flecs_script_expr_to_str(v, node->expr);
+    flecs_expr_to_str(v, node->expr);
     flecs_scriptbuf_appendstr(v, "\n");
 }
 
@@ -61955,14 +63410,37 @@ void flecs_script_if_to_str(
     ecs_script_if_t *node)
 {
     flecs_scriptbuf_node(v, &node->node);
-    flecs_script_expr_to_str(v, node->expr);
+    flecs_expr_to_str(v, node->expr);
 
     flecs_scriptbuf_appendstr(v, " {\n");
     v->depth ++;
-    flecs_scriptbuf_append(v, "%strue%s: ", ECS_CYAN, ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_CYAN);
+    flecs_scriptbuf_appendstr(v, "true: ");
+    flecs_script_color_to_str(v, ECS_NORMAL);
     flecs_script_scope_to_str(v, node->if_true);
-    flecs_scriptbuf_append(v, "%sfalse%s: ", ECS_CYAN, ECS_NORMAL);
+    flecs_script_color_to_str(v, ECS_CYAN);
+    flecs_scriptbuf_appendstr(v, "false: ");
+    flecs_script_color_to_str(v, ECS_NORMAL);
     flecs_script_scope_to_str(v, node->if_false);
+    v->depth --;
+    flecs_scriptbuf_appendstr(v, "}\n");
+}
+
+static
+void flecs_script_for_range_to_str(
+    ecs_script_str_visitor_t *v,
+    ecs_script_for_range_t *node)
+{
+    flecs_scriptbuf_node(v, &node->node);
+    flecs_scriptbuf_appendstr(v, node->loop_var);
+    flecs_scriptbuf_appendstr(v, " ");
+    flecs_expr_to_str(v, node->from);
+    flecs_scriptbuf_appendstr(v, " .. ");
+    flecs_expr_to_str(v, node->to);
+
+    flecs_scriptbuf_appendstr(v, " {\n");
+    v->depth ++;
+    flecs_script_scope_to_str(v, node->scope);
     v->depth --;
     flecs_scriptbuf_appendstr(v, "}\n");
 }
@@ -62048,6 +63526,9 @@ int flecs_script_stmt_to_str(
     case EcsAstIf:
         flecs_script_if_to_str(v, (ecs_script_if_t*)node);
         break;
+    case EcsAstFor:
+        flecs_script_for_range_to_str(v, (ecs_script_for_range_t*)node);
+        break;
     }
 
     return 0;
@@ -62055,11 +63536,12 @@ int flecs_script_stmt_to_str(
 
 int ecs_script_ast_to_buf(
     ecs_script_t *script,
-    ecs_strbuf_t *buf)
+    ecs_strbuf_t *buf,
+    bool colors)
 {
     ecs_check(script != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(buf != NULL, ECS_INVALID_PARAMETER, NULL);
-    ecs_script_str_visitor_t v = { .buf = buf };
+    ecs_script_str_visitor_t v = { .buf = buf, .colors = colors };
     if (ecs_script_visit(flecs_script_impl(script), &v, flecs_script_stmt_to_str)) {
         goto error;
     }
@@ -62071,12 +63553,19 @@ error:
 }
 
 char* ecs_script_ast_to_str(
-    ecs_script_t *script)
+    ecs_script_t *script,
+    bool colors)
 {
     ecs_check(script != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_strbuf_t buf = ECS_STRBUF_INIT;
-    if (ecs_script_ast_to_buf(script, &buf)) {
-        goto error;
+
+    if (flecs_script_impl(script)->expr) {
+        flecs_expr_to_str_buf(
+            script->world, flecs_script_impl(script)->expr, &buf, colors);
+    } else {
+        if (ecs_script_ast_to_buf(script, &buf, colors)) {
+            goto error;
+        }
     }
 
     return ecs_strbuf_get(&buf);
@@ -62952,7 +64441,7 @@ void ecs_world_stats_get(
     ECS_GAUGE_RECORD(&s->components.tag_count, t, world->info.tag_id_count);
     ECS_GAUGE_RECORD(&s->components.component_count, t, world->info.component_id_count);
     ECS_GAUGE_RECORD(&s->components.pair_count, t, world->info.pair_id_count);
-    ECS_GAUGE_RECORD(&s->components.type_count, t, ecs_sparse_count(&world->type_info));
+    ECS_GAUGE_RECORD(&s->components.type_count, t, ecs_map_count(&world->type_info));
     ECS_COUNTER_RECORD(&s->components.create_count, t, world->info.id_create_total);
     ECS_COUNTER_RECORD(&s->components.delete_count, t, world->info.id_delete_total);
 
@@ -62964,7 +64453,6 @@ void ecs_world_stats_get(
     ECS_COUNTER_RECORD(&s->tables.create_count, t, world->info.table_create_total);
     ECS_COUNTER_RECORD(&s->tables.delete_count, t, world->info.table_delete_total);
     ECS_GAUGE_RECORD(&s->tables.count, t, world->info.table_count);
-    ECS_GAUGE_RECORD(&s->tables.empty_count, t, world->info.empty_table_count);
 
     ECS_COUNTER_RECORD(&s->commands.add_count, t, world->info.cmd.add_count);
     ECS_COUNTER_RECORD(&s->commands.remove_count, t, world->info.cmd.remove_count);
@@ -63789,6 +65277,7 @@ ecs_entity_t flecs_run_intern(
     ecs_ftime_t delta_time,
     void *param) 
 {
+    flecs_poly_assert(world, ecs_world_t);
     ecs_ftime_t time_elapsed = delta_time;
     ecs_entity_t tick_source = system_data->tick_source;
 
@@ -63837,6 +65326,8 @@ ecs_entity_t flecs_run_intern(
     } else {
         stage = world->stages[0];
     }
+
+    flecs_poly_assert(stage, ecs_stage_t);
 
     /* Prepare the query iterator */
     ecs_iter_t wit, qit = ecs_query_iter(thread_ctx, system_data->query);
@@ -64454,7 +65945,12 @@ int flecs_query_discover_vars(
             table_this = true;
         }
 
-        if (ECS_TERM_REF_ID(first) == EcsThis || ECS_TERM_REF_ID(second) == EcsThis) {
+        bool first_is_this = 
+            (ECS_TERM_REF_ID(first) == EcsThis) && (first->id & EcsIsVariable);
+        bool second_is_this = 
+            (ECS_TERM_REF_ID(first) == EcsThis) && (first->id & EcsIsVariable);
+
+        if (first_is_this || second_is_this) {
             if (!table_this) {
                 entity_before_table_this = true;
             }
@@ -64656,6 +66152,7 @@ bool flecs_query_term_is_unknown(
     ecs_query_compile_ctx_t *ctx) 
 {
     ecs_query_op_t dummy = {0};
+
     flecs_query_compile_term_ref(NULL, query, &dummy, &term->first, 
         &dummy.first, EcsQueryFirst, EcsVarEntity, ctx, false);
     flecs_query_compile_term_ref(NULL, query, &dummy, &term->second, 
@@ -65072,6 +66569,7 @@ int flecs_query_compile(
     int32_t i, term_count = q->term_count;
     for (i = 0; i < term_count; i ++) {
         ecs_term_t *term = &terms[i];
+
         if (term->src.id & EcsIsEntity) {
             ecs_query_op_t set_fixed = {0};
             set_fixed.kind = EcsQuerySetFixed;
@@ -65316,6 +66814,8 @@ ecs_var_id_t flecs_query_find_var_id(
             if (query->pub.flags & EcsQueryHasTableThisVar) {
                 return 0;
             } else {
+                printf("VARNONE\n");
+                flecs_dump_backtrace(stdout);
                 return EcsVarNone;
             }
         }
@@ -66059,6 +67559,8 @@ static
 void flecs_query_compile_pop(
     ecs_query_compile_ctx_t *ctx)
 {
+    /* Should've been caught by query validator */
+    ecs_assert(ctx->scope > 0, ECS_INTERNAL_ERROR, NULL);
     ctx->cur = &ctx->ctrlflow[-- ctx->scope];
 }
 
@@ -66793,22 +68295,12 @@ error:
 int32_t flecs_query_cache_table_count(
     ecs_query_cache_t *cache)
 {
-    ecs_run_aperiodic(cache->query->world, EcsAperiodicEmptyTables);
     return cache->cache.tables.count;
-}
-
-int32_t flecs_query_cache_empty_table_count(
-    ecs_query_cache_t *cache)
-{
-    ecs_run_aperiodic(cache->query->world, EcsAperiodicEmptyTables);
-    return cache->cache.empty_tables.count;
 }
 
 int32_t flecs_query_cache_entity_count(
     const ecs_query_cache_t *cache)
-{
-    ecs_run_aperiodic(cache->query->world, EcsAperiodicEmptyTables);
-    
+{    
     int32_t result = 0;
     ecs_table_cache_hdr_t *cur, *last = cache->cache.tables.last;
     if (!last) {
@@ -67008,7 +68500,9 @@ void flecs_query_cache_create_group(
 
         /* This group should appear after another group */
         ecs_query_cache_table_match_t *insert_before = insert_after->next;
-        match->prev = insert_after;
+        if (match != insert_after) {
+            match->prev = insert_after;
+        }
         insert_after->next = match;
         match->next = insert_before;
         if (insert_before) {
@@ -67159,6 +68653,7 @@ void flecs_query_cache_insert_table_node(
 
     ecs_query_cache_table_list_t *list = 
         flecs_query_cache_ensure_node_list(cache, match);
+
     if (list->last) {
         ecs_assert(cache->list.first != NULL, ECS_INTERNAL_ERROR, NULL);
         ecs_assert(cache->list.last != NULL, ECS_INTERNAL_ERROR, NULL);
@@ -67267,11 +68762,7 @@ ecs_query_cache_table_match_t* flecs_query_cache_add_table_match(
     qm->trs = flecs_balloc(&cache->allocators.trs);
 
     /* Insert match to iteration list if table is not empty */
-    if (!table || ecs_table_count(table) != 0 || 
-        (cache->query->flags & EcsQueryCacheYieldEmptyTables))
-    {
-        flecs_query_cache_insert_table_node(cache, qm);
-    }
+    flecs_query_cache_insert_table_node(cache, qm);
 
     return qm;
 }
@@ -67347,11 +68838,7 @@ ecs_query_cache_table_t* flecs_query_cache_table_insert(
         qt->table_id = 0;
     }
 
-    if (cache->query->flags & EcsQueryCacheYieldEmptyTables) {
-        ecs_table_cache_insert_w_empty(&cache->cache, table, &qt->hdr, false);
-    } else {
-        ecs_table_cache_insert(&cache->cache, table, &qt->hdr);
-    }
+    ecs_table_cache_insert(&cache->cache, table, &qt->hdr);
 
     return qt;
 }
@@ -67374,6 +68861,7 @@ void flecs_query_cache_match_tables(
             /* New table matched, add record to cache */
             table = it.table;
             qt = flecs_query_cache_table_insert(world, cache, table);
+            ecs_dbg_3("query cache matched existing table [%s]", NULL);
         }
 
         ecs_query_cache_table_match_t *qm = 
@@ -67527,48 +69015,10 @@ error:
     return -1;
 }
 
-/** When a table becomes empty remove it from the query list, or vice versa. */
-static
-void flecs_query_cache_update_table(
-    ecs_query_cache_t *cache,
-    ecs_table_t *table,
-    bool empty)
-{
-    int32_t prev_count = flecs_query_cache_table_count(cache);
-    ecs_table_cache_set_empty(&cache->cache, table, empty);
-    int32_t cur_count = flecs_query_cache_table_count(cache);
-
-    if (prev_count != cur_count) {
-        ecs_query_cache_table_t *qt = ecs_table_cache_get(&cache->cache, table);
-        ecs_assert(qt != NULL, ECS_INTERNAL_ERROR, NULL);
-        ecs_query_cache_table_match_t *cur, *next;
-
-        for (cur = qt->first; cur != NULL; cur = next) {
-            next = cur->next_match;
-
-            if (empty) {
-                ecs_assert(ecs_table_count(table) == 0, 
-                    ECS_INTERNAL_ERROR, NULL);
-
-                flecs_query_cache_remove_table_node(cache, cur);
-            } else {
-                ecs_assert(ecs_table_count(table) != 0, 
-                    ECS_INTERNAL_ERROR, NULL);
-
-                flecs_query_cache_insert_table_node(cache, cur);
-            }
-        }
-    }
-
-    ecs_assert(cur_count || cache->list.first == NULL, 
-        ECS_INTERNAL_ERROR, NULL);
-}
-
 /* Remove table */
 static
 void flecs_query_cache_table_match_free(
     ecs_query_cache_t *cache,
-    ecs_query_cache_table_t *elem,
     ecs_query_cache_table_match_t *first)
 {
     ecs_query_cache_table_match_t *cur, *next;
@@ -67589,9 +69039,7 @@ void flecs_query_cache_table_match_free(
             flecs_bfree(&cache->allocators.monitors, cur->monitor);
         }
 
-        if (!elem->hdr.empty) {
-            flecs_query_cache_remove_table_node(cache, cur);
-        }
+        flecs_query_cache_remove_table_node(cache, cur);
 
         next = cur->next_match;
 
@@ -67604,7 +69052,7 @@ void flecs_query_cache_table_free(
     ecs_query_cache_t *cache,
     ecs_query_cache_table_t *elem)
 {
-    flecs_query_cache_table_match_free(cache, elem, elem->first);
+    flecs_query_cache_table_match_free(cache, elem->first);
     flecs_bfree(&cache->query->world->allocators.query_table, elem);
 }
 
@@ -67629,6 +69077,8 @@ void flecs_query_cache_rematch_tables(
     ecs_world_t *world,
     ecs_query_impl_t *impl)
 {
+    flecs_poly_assert(world, ecs_world_t);
+
     ecs_iter_t it;
     ecs_table_t *table = NULL;
     ecs_query_cache_table_t *qt = NULL;
@@ -67657,7 +69107,7 @@ void flecs_query_cache_rematch_tables(
     while (ecs_query_next(&it)) {
         if ((table != it.table) || (!it.table && !qt)) {
             if (qm && qm->next_match) {
-                flecs_query_cache_table_match_free(cache, qt, qm->next_match);
+                flecs_query_cache_table_match_free(cache, qm->next_match);
                 qm->next_match = NULL;
             }
 
@@ -67683,7 +69133,7 @@ void flecs_query_cache_rematch_tables(
 
         flecs_query_cache_set_table_match(cache, qm, &it);
 
-        if (table && ecs_table_count(table) && cache->group_by_callback) {
+        if (table && cache->group_by_callback) {
             if (flecs_query_cache_get_group_id(cache, table) != qm->group_id) {
                 /* Update table group */
                 flecs_query_cache_remove_table_node(cache, qm);
@@ -67693,7 +69143,7 @@ void flecs_query_cache_rematch_tables(
     }
 
     if (qm && qm->next_match) {
-        flecs_query_cache_table_match_free(cache, qt, qm->next_match);
+        flecs_query_cache_table_match_free(cache, qm->next_match);
         qm->next_match = NULL;
     }
 
@@ -67874,12 +69324,7 @@ void flecs_query_cache_on_event(
         ecs_os_free(table_str);
     }
 
-    if (event == EcsOnTableEmpty) {
-        flecs_query_cache_update_table(cache, table, true);
-    } else
-    if (event == EcsOnTableFill) {
-        flecs_query_cache_update_table(cache, table, false);
-    } else if (event == EcsOnTableDelete) {
+    if (event == EcsOnTableDelete) {
         /* Deletion of table */
         flecs_query_cache_unmatch_table(cache, table, NULL);
         return;
@@ -67988,7 +69433,11 @@ ecs_query_cache_t* flecs_query_cache_init(
     const ecs_query_desc_t *const_desc)
 {
     ecs_world_t *world = impl->pub.real_world;
+    flecs_poly_assert(world, ecs_world_t);
+
     ecs_stage_t *stage = impl->stage;
+    flecs_poly_assert(stage, ecs_stage_t);
+
     ecs_check(world != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_check(const_desc != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_check(const_desc->_canary == 0, ECS_INVALID_PARAMETER,
@@ -68023,6 +69472,12 @@ ecs_query_cache_t* flecs_query_cache_init(
     ecs_flags32_t query_flags = const_desc->flags | world->default_query_flags;
     desc.flags |= EcsQueryMatchEmptyTables | EcsQueryTableOnly | EcsQueryNested;
 
+    /* order_by is not compatible with matching empty tables, as it causes
+     * a query to return table slices, not entire tables. */
+    if (const_desc->order_by_callback) {
+        query_flags &= ~EcsQueryMatchEmptyTables;
+    }
+
     ecs_query_t *q = result->query = ecs_query_init(world, &desc);
     if (!q) {
         goto error;
@@ -68049,11 +69504,6 @@ ecs_query_cache_t* flecs_query_cache_init(
         observer_desc.ctx = impl;
 
         int32_t event_index = 0;
-        if (!(q->flags & EcsQueryCacheYieldEmptyTables)) {
-            observer_desc.events[event_index ++] = EcsOnTableEmpty;
-            observer_desc.events[event_index ++] = EcsOnTableFill;
-        }
-
         observer_desc.events[event_index ++] = EcsOnTableCreate;
         observer_desc.events[event_index ++] = EcsOnTableDelete;
         observer_desc.flags_ = EcsObserverBypassQuery;
@@ -68104,11 +69554,6 @@ ecs_query_cache_t* flecs_query_cache_init(
         result->group_by_ctx_free = const_desc->group_by_ctx_free;
     }
 
-    /* Ensure that while initially populating the query with tables, they are
-     * in the right empty/non-empty list. This ensures the query won't miss
-     * empty/non-empty events for tables that are currently out of sync, but
-     * change back to being in sync before processing pending events. */
-    ecs_run_aperiodic(world, EcsAperiodicEmptyTables);
     ecs_table_cache_init(world, &result->cache);
     flecs_query_cache_match_tables(world, result);
 
@@ -68222,6 +69667,7 @@ void flecs_query_update_node_up_trs(
         const ecs_query_impl_t *impl = ctx->query;
         const ecs_query_t *q = &impl->pub;
         ecs_query_cache_t *cache = impl->cache;
+        int8_t *field_map = cache->field_map;
         int32_t i, field_count = q->field_count;
         for (i = 0; i < field_count; i ++) {
             if (!(fields & (1llu << i))) {
@@ -68236,10 +69682,11 @@ void flecs_query_update_node_up_trs(
                 ecs_assert(r->table != NULL, ECS_INTERNAL_ERROR, NULL);
                 if (r->table != tr->hdr.table) {
                     ecs_id_record_t *idr = (ecs_id_record_t*)tr->hdr.cache;
-                    ecs_assert(idr->id == q->ids[i], ECS_INTERNAL_ERROR, NULL);
+                    ecs_assert(idr->id == q->ids[field_map ? field_map[i] : i], 
+                        ECS_INTERNAL_ERROR, NULL);
                     tr = node->trs[i] = flecs_id_record_get_table(idr, r->table);
-                    if (cache->field_map) {
-                        ctx->it->trs[cache->field_map[i]] = tr;
+                    if (field_map) {
+                        ctx->it->trs[field_map[i]] = tr;
                     }
                 }
             }
@@ -68249,20 +69696,35 @@ void flecs_query_update_node_up_trs(
 
 static
 ecs_query_cache_table_match_t* flecs_query_cache_next(
-    const ecs_query_run_ctx_t *ctx)
+    const ecs_query_run_ctx_t *ctx,
+    bool match_empty)
 {
     ecs_iter_t *it = ctx->it;
     ecs_query_iter_t *qit = &it->priv_.iter.query;
-    ecs_query_cache_table_match_t *node = qit->node;
-    ecs_query_cache_table_match_t *prev = qit->prev;
 
-    if (prev != qit->last) {
-        ecs_assert(node != NULL, ECS_INTERNAL_ERROR, NULL);
-        ctx->vars[0].range.table = node->table;
-        it->group_id = node->group_id;
-        qit->node = node->next;
-        qit->prev = node;
-        return node;
+    repeat: {
+        ecs_query_cache_table_match_t *node = qit->node;
+        ecs_query_cache_table_match_t *prev = qit->prev;
+
+        if (prev != qit->last) {
+            ecs_assert(node != NULL, ECS_INTERNAL_ERROR, NULL);
+            ctx->vars[0].range.table = node->table;
+            it->group_id = node->group_id;
+            qit->node = node->next;
+            qit->prev = node;
+            if (node) {
+                if (!ecs_table_count(node->table)) {
+                    if (!match_empty) {
+                        if (ctx->query->pub.flags & EcsQueryHasMonitor) {
+                            flecs_query_sync_match_monitor(
+                                flecs_query_impl(qit->query), node);
+                        }
+                        goto repeat;
+                    }
+                }
+            }
+            return node;
+        }
     }
 
     return NULL;
@@ -68292,7 +69754,7 @@ ecs_query_cache_table_match_t* flecs_query_test(
         qit->last = qt->last;
     }
 
-    return flecs_query_cache_next(ctx);
+    return flecs_query_cache_next(ctx, true);
 }
 
 static
@@ -68325,7 +69787,8 @@ void flecs_query_cache_init_mapped_fields(
 bool flecs_query_cache_search(
     const ecs_query_run_ctx_t *ctx)
 {
-    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx);
+    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx,
+        ctx->query->pub.flags & EcsQueryMatchEmptyTables);
     if (!node) {
         return false;
     }
@@ -68343,7 +69806,8 @@ bool flecs_query_cache_search(
 bool flecs_query_is_cache_search(
     const ecs_query_run_ctx_t *ctx)
 {
-    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx);
+    ecs_query_cache_table_match_t *node = flecs_query_cache_next(ctx,
+        ctx->query->pub.flags & EcsQueryMatchEmptyTables);
     if (!node) {
         return false;
     }
@@ -68482,6 +69946,7 @@ void flecs_query_cache_build_sorted_table_range(
     ecs_query_cache_table_list_t *list)
 {
     ecs_world_t *world = cache->query->world;
+    flecs_poly_assert(world, ecs_world_t);
     ecs_assert(!(world->flags & EcsWorldMultiThreaded), ECS_UNSUPPORTED,
         "cannot sort query in multithreaded mode");
 
@@ -68551,7 +70016,9 @@ void flecs_query_cache_build_sorted_table_range(
         to_sort ++;      
     }
 
-    ecs_assert(to_sort != 0, ECS_INTERNAL_ERROR, NULL);
+    if (!to_sort) {
+        goto done;
+    }
 
     bool proceed;
     do {
@@ -68609,9 +70076,12 @@ void flecs_query_cache_build_sorted_table_range(
         nodes[i].next = &nodes[i + 1];
     }
 
-    nodes[0].prev = NULL;
-    nodes[i - 1].next = NULL;
+    if (nodes) {
+        nodes[0].prev = NULL;
+        nodes[i - 1].next = NULL;
+    }
 
+done:
     flecs_free_n(&world->allocator, sort_helper_t, table_count, helper);
 }
 
@@ -68666,7 +70136,7 @@ void flecs_query_cache_sort_tables(
     ecs_id_record_t *idr = flecs_id_record_get(world, order_by);
     ecs_table_cache_iter_t it;
     ecs_query_cache_table_t *qt;
-    flecs_table_cache_iter(&cache->cache, &it);
+    flecs_table_cache_all_iter(&cache->cache, &it);
 
     while ((qt = flecs_table_cache_next(&it, ecs_query_cache_table_t))) {
         ecs_table_t *table = qt->hdr.table;
@@ -68675,6 +70145,16 @@ void flecs_query_cache_sort_tables(
         if (flecs_query_check_table_monitor(impl, qt, 0)) {
             tables_sorted = true;
             dirty = true;
+
+            if (!ecs_table_count(table)) {
+                /* If table is empty, there's a chance the query won't iterate it
+                * so update the match monitor here. */
+                ecs_query_cache_table_match_t *cur, *next;
+                for (cur = qt->first; cur != NULL; cur = next) {
+                    flecs_query_sync_match_monitor(impl, cur);
+                    next = cur->next_match;
+                }
+            }
         }
 
         int32_t column = -1;
@@ -68813,7 +70293,7 @@ bool flecs_query_get_fixed_monitor(
     bool check)
 {
     ecs_query_t *q = &impl->pub;
-    ecs_world_t *world = q->world;
+    ecs_world_t *world = q->real_world;
     ecs_term_t *terms = q->terms;
     int32_t i, term_count = q->term_count;
 
@@ -68938,7 +70418,7 @@ bool flecs_query_check_cache_monitor(
     }
 
     ecs_table_cache_iter_t it;
-    if (flecs_table_cache_iter(&cache->cache, &it)) {
+    if (flecs_table_cache_all_iter(&cache->cache, &it)) {
         ecs_query_cache_table_t *qt;
         while ((qt = flecs_table_cache_next(&it, ecs_query_cache_table_t))) {
             if (flecs_query_check_table_monitor(impl, qt, -1)) {
@@ -69080,7 +70560,7 @@ void flecs_query_mark_fields_dirty(
         return;
     }
 
-    ecs_world_t *world = q->world;
+    ecs_world_t *world = q->real_world;
     int16_t i, field_count = q->field_count;
     for (i = 0; i < field_count; i ++) {
         ecs_termset_t field_bit = (ecs_termset_t)(1u << i);
@@ -69131,7 +70611,7 @@ void flecs_query_mark_fixed_fields_dirty(
         return;
     }
 
-    ecs_world_t *world = q->world;
+    ecs_world_t *world = q->real_world;
     int32_t i, field_count = q->field_count;
     for (i = 0; i < field_count; i ++) {
         if (!(fixed_write_fields & flecs_ito(uint32_t, 1 << i))) {
@@ -69196,6 +70676,9 @@ void flecs_query_sync_match_monitor(
 
             flecs_query_get_column_for_field(q, match, field, &tc);
 
+            /* Query for cache should never point to stage */
+            ecs_assert(q->world == q->real_world, ECS_INTERNAL_ERROR, NULL);
+
             monitor[field + 1] = flecs_table_get_dirty_state(
                 q->world, tc.table)[tc.column + 1];
         }
@@ -69225,10 +70708,6 @@ bool ecs_query_changed(
      * cached/cacheable and don't have a fixed source, since that requires 
      * storing state per result, which doesn't happen for uncached queries. */
     if (impl->cache) {
-        /* If we're checking the cache, make sure that tables are in the correct
-         * empty/non-empty lists. */
-        flecs_process_pending_tables(q->world);
-
         if (!(impl->pub.flags & EcsQueryHasMonitor)) {
             flecs_query_init_query_monitors(impl);
         }
@@ -69687,13 +71166,15 @@ bool flecs_query_x_from(
     ecs_query_xfrom_ctx_t *op_ctx = flecs_op_ctx(ctx, xfrom);
     ecs_world_t *world = ctx->world;
     ecs_type_t *type;
+    ecs_entity_t type_id;
     int32_t i;
 
     if (!redo) {
         /* Find entity that acts as the template from which we match the ids */
-        ecs_id_t id = flecs_query_op_get_id(op, ctx);
-        ecs_assert(ecs_is_alive(world, id), ECS_INTERNAL_ERROR, NULL);
-        ecs_record_t *r = flecs_entities_get(world, id);
+        type_id = flecs_query_op_get_id(op, ctx);
+        op_ctx->type_id = type_id;
+        ecs_assert(ecs_is_alive(world, type_id), ECS_INTERNAL_ERROR, NULL);
+        ecs_record_t *r = flecs_entities_get(world, type_id);
         ecs_table_t *table;
         if (!r || !(table = r->table)) {
             /* Nothing to match */
@@ -69710,6 +71191,7 @@ bool flecs_query_x_from(
             return false; /* No ids to filter on */
         }
     } else {
+        type_id = op_ctx->type_id;
         type = op_ctx->type;
     }
 
@@ -69755,7 +71237,7 @@ bool flecs_query_x_from(
         if (!src_table) {
             continue;
         }
-        
+
         redo = true;
 
         if (!src_written && oper == EcsOrFrom) {
@@ -69781,7 +71263,7 @@ bool flecs_query_x_from(
                     continue;
                 }
             }
-            return true;
+            goto match;
         }
 
         if (oper == EcsAndFrom || oper == EcsNotFrom || src_written) {
@@ -69807,7 +71289,7 @@ bool flecs_query_x_from(
                     if (oper == EcsNotFrom) {
                         break; /* Must have none of the ids */
                     } else if (oper == EcsOrFrom) {
-                        return true; /* Single match is enough */
+                        goto match; /* Single match is enough */
                     }
                 }
             }
@@ -69820,6 +71302,8 @@ bool flecs_query_x_from(
         }
     } while (true);
 
+match:
+    ctx->it->ids[op->field_index] = type_id;
     return true;
 }
 
@@ -71063,9 +72547,11 @@ ecs_iter_t flecs_query_iter(
 
         if (cache->order_by_callback && cache->list.info.table_count) {
             flecs_query_cache_sort_tables(it.real_world, impl);
-            qit->node = ecs_vec_first(&cache->table_slices);
-            qit->last = ecs_vec_last_t(
-                &cache->table_slices, ecs_query_cache_table_match_t);
+            if (ecs_vec_count(&cache->table_slices)) {
+                qit->node = ecs_vec_first(&cache->table_slices);
+                qit->last = ecs_vec_last_t(
+                    &cache->table_slices, ecs_query_cache_table_match_t);
+            }
         }
 
         cache->prev_match_count = cache->match_count;
@@ -71105,10 +72591,6 @@ ecs_iter_t ecs_query_iter(
 {
     ecs_assert(world != NULL, ECS_INVALID_PARAMETER, NULL);
     ecs_assert(q != NULL, ECS_INVALID_PARAMETER, NULL);
-    
-    if (!(q->flags & EcsQueryCacheYieldEmptyTables)) {
-        ecs_run_aperiodic(q->real_world, EcsAperiodicEmptyTables);
-    }
 
     /* Ok, only for stats */
     ecs_os_linc(&ECS_CONST_CAST(ecs_query_t*, q)->eval_count);
@@ -71118,7 +72600,9 @@ ecs_iter_t ecs_query_iter(
     if (cache) {
         /* If monitors changed, do query rematching */
         ecs_flags32_t flags = q->flags;
-        if (!(world->flags & EcsWorldReadonly) && flags & EcsQueryHasRefs) {
+        if (!(ecs_world_get_flags(world) & EcsWorldReadonly) && 
+             (flags & EcsQueryHasRefs)) 
+        {
             flecs_eval_component_monitors(q->world);
         }
     }
@@ -72712,7 +74196,7 @@ bool flecs_query_up_select(
     /* If id record is not found, or if it doesn't have any tables, revert to
      * iterating owned components (no traversal) */
     if (!op_ctx->idr_trav || 
-        !flecs_table_cache_all_count(&op_ctx->idr_trav->cache))
+        !flecs_table_cache_count(&op_ctx->idr_trav->cache))
     {
         if (!self) {
             /* If operation does not match owned components, return false */
@@ -72843,7 +74327,7 @@ bool flecs_query_up_with(
     }
 
     if (!op_ctx->idr_trav || 
-        !flecs_table_cache_all_count(&op_ctx->idr_trav->cache))
+        !flecs_table_cache_count(&op_ctx->idr_trav->cache))
     {
         /* If there are no tables with traversable relationship, there are no
          * matches. */
@@ -73526,7 +75010,6 @@ ecs_trav_down_t* flecs_trav_entity_down(
     ecs_trav_up_cache_t *cache,
     ecs_trav_down_t *dst,
     ecs_entity_t trav,
-    ecs_entity_t entity,
     ecs_id_record_t *idr_trav,
     ecs_id_record_t *idr_with,
     bool self,
@@ -73586,7 +75069,7 @@ ecs_trav_down_t* flecs_trav_table_down(
             }
 
             flecs_trav_entity_down(world, a, cache, dst, 
-                trav, entity, idr_trav, idr_with, self, empty);
+                trav, idr_trav, idr_with, self, empty);
         }
     }
 
@@ -73643,7 +75126,7 @@ void flecs_trav_entity_down_isa(
                     ecs_id_record_t *idr_trav = flecs_id_record_get(world, 
                         ecs_pair(trav, e));
                     if (idr_trav) {
-                        flecs_trav_entity_down(world, a, cache, dst, trav, e,
+                        flecs_trav_entity_down(world, a, cache, dst, trav,
                             idr_trav, idr_with, self, empty);
                     }
 
@@ -73662,7 +75145,6 @@ ecs_trav_down_t* flecs_trav_entity_down(
     ecs_trav_up_cache_t *cache,
     ecs_trav_down_t *dst,
     ecs_entity_t trav,
-    ecs_entity_t e,
     ecs_id_record_t *idr_trav,
     ecs_id_record_t *idr_with,
     bool self,
@@ -73671,9 +75153,6 @@ ecs_trav_down_t* flecs_trav_entity_down(
     ecs_assert(dst != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(idr_with != NULL, ECS_INTERNAL_ERROR, NULL);
     ecs_assert(idr_trav != NULL, ECS_INTERNAL_ERROR, NULL);
-
-    flecs_trav_entity_down_isa(
-        world, a, cache, dst, trav, e, idr_with, self, empty);
 
     int32_t first = ecs_vec_count(&dst->elems);
 
@@ -73770,8 +75249,16 @@ ecs_trav_down_t* flecs_query_get_down_cache(
     }
 
     ecs_vec_init_t(a, &result->elems, ecs_trav_down_elem_t, 0);
+
+    /* Cover IsA -> trav paths. If a parent inherits a component, then children
+     * of that parent should find the component through up traversal. */
+    if (idr_with->flags & EcsIdOnInstantiateInherit) {
+        flecs_trav_entity_down_isa(
+            world, a, cache, result, trav, e, idr_with, self, empty);
+    }
+
     flecs_trav_entity_down(
-        world, a, cache, result, trav, e, idr_trav, idr_with, self, empty);
+        world, a, cache, result, trav, idr_trav, idr_with, self, empty);
     result->ready = true;
 
     return result;
@@ -73913,7 +75400,7 @@ ecs_trav_up_t* flecs_trav_table_up(
                 &up_pair, table, r_column + 1, rel, &type);
         }
 
-        if (!is_a) {
+        if (!is_a && (idr_with->flags & EcsIdOnInstantiateInherit)) {
             idr_trav = world->idr_isa_wildcard;
             r_column = flecs_trav_type_search(
                     &up_pair, table, idr_trav, &type);
@@ -74207,4 +75694,5814 @@ bool flecs_query_trivial_test(
         return true;
     }
 }
+
+/**
+ * @file addons/script/expr_ast.c
+ * @brief Script expression AST implementation.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+#define flecs_expr_ast_new(parser, T, kind)\
+    (T*)flecs_expr_ast_new_(parser, ECS_SIZEOF(T), kind)
+
+static
+void* flecs_expr_ast_new_(
+    ecs_script_parser_t *parser,
+    ecs_size_t size, 
+    ecs_expr_node_kind_t kind)
+{
+    ecs_assert(parser->script != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_allocator_t *a = &parser->script->allocator;
+    ecs_expr_node_t *result = flecs_calloc_w_dbg_info(a, size,
+        "ecs_expr_node_t");
+    result->kind = kind;
+    result->pos = parser->pos;
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_value_from(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    ecs_entity_t type)
+{
+    ecs_expr_value_node_t *result = flecs_calloc_t(
+        &((ecs_script_impl_t*)script)->allocator, ecs_expr_value_node_t);
+    result->ptr = &result->storage.u64;
+    result->node.kind = EcsExprValue;
+    result->node.pos = node ? node->pos : NULL;
+    result->node.type = type;
+    result->node.type_info = ecs_get_type_info(script->world, type);
+    return result;
+}
+
+ecs_expr_variable_t* flecs_expr_variable_from(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const char *name)
+{
+    ecs_expr_variable_t *result = flecs_calloc_t(
+        &((ecs_script_impl_t*)script)->allocator, ecs_expr_variable_t);
+    result->name = name;
+    result->sp = -1;
+    result->node.kind = EcsExprVariable;
+    result->node.pos = node ? node->pos : NULL;
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_bool(
+    ecs_script_parser_t *parser,
+    bool value)
+{
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.bool_ = value;
+    result->ptr = &result->storage.bool_;
+    result->node.type = ecs_id(ecs_bool_t);
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_int(
+    ecs_script_parser_t *parser,
+    int64_t value)
+{
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.i64 = value;
+    result->ptr = &result->storage.i64;
+    result->node.type = ecs_id(ecs_i64_t);
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_uint(
+    ecs_script_parser_t *parser,
+    uint64_t value)
+{
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.u64 = value;
+    result->ptr = &result->storage.u64;
+    result->node.type = ecs_id(ecs_i64_t);
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_float(
+    ecs_script_parser_t *parser,
+    double value)
+{
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.f64 = value;
+    result->ptr = &result->storage.f64;
+    result->node.type = ecs_id(ecs_f64_t);
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_string(
+    ecs_script_parser_t *parser,
+    const char *value)
+{
+    char *str = ECS_CONST_CAST(char*, value);
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.string = str;
+    result->ptr = &result->storage.string;
+    result->node.type = ecs_id(ecs_string_t);
+
+    if (!flecs_string_escape(str)) {
+        return NULL;
+    }
+
+    return result;
+}
+
+ecs_expr_interpolated_string_t* flecs_expr_interpolated_string(
+    ecs_script_parser_t *parser,
+    const char *value)
+{
+    ecs_expr_interpolated_string_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_interpolated_string_t, EcsExprInterpolatedString);
+    result->value = ECS_CONST_CAST(char*, value);
+    result->buffer = flecs_strdup(&parser->script->allocator, value);
+    result->buffer_size = ecs_os_strlen(result->buffer) + 1;
+    result->node.type = ecs_id(ecs_string_t);
+    ecs_vec_init_t(&parser->script->allocator, &result->fragments, char*, 0);
+    ecs_vec_init_t(&parser->script->allocator, &result->expressions, 
+        ecs_expr_node_t*, 0);
+
+    return result;
+}
+
+ecs_expr_value_node_t* flecs_expr_entity(
+    ecs_script_parser_t *parser,
+    ecs_entity_t value)
+{
+    ecs_expr_value_node_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_value_node_t, EcsExprValue);
+    result->storage.entity = value;
+    result->ptr = &result->storage.entity;
+    result->node.type = ecs_id(ecs_entity_t);
+    return result;
+}
+
+ecs_expr_initializer_t* flecs_expr_initializer(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_initializer_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_initializer_t, EcsExprInitializer);
+    ecs_vec_init_t(&parser->script->allocator, &result->elements, 
+        ecs_expr_initializer_element_t, 0);
+    return result;
+}
+
+ecs_expr_identifier_t* flecs_expr_identifier(
+    ecs_script_parser_t *parser,
+    const char *value)
+{
+    ecs_expr_identifier_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_identifier_t, EcsExprIdentifier);
+    result->value = value;
+    return result;
+}
+
+ecs_expr_variable_t* flecs_expr_variable(
+    ecs_script_parser_t *parser,
+    const char *value)
+{
+    ecs_expr_variable_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_variable_t, EcsExprVariable);
+    result->name = value;
+    result->sp = -1;
+    return result;
+}
+
+ecs_expr_unary_t* flecs_expr_unary(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_unary_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_unary_t, EcsExprUnary);
+    return result;
+}
+
+ecs_expr_binary_t* flecs_expr_binary(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_binary_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_binary_t, EcsExprBinary);
+    return result;
+}
+
+ecs_expr_member_t* flecs_expr_member(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_member_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_member_t, EcsExprMember);
+    return result;
+}
+
+ecs_expr_function_t* flecs_expr_function(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_function_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_function_t, EcsExprFunction);
+    return result;
+}
+
+ecs_expr_element_t* flecs_expr_element(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_element_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_element_t, EcsExprElement);
+    return result;
+}
+
+ecs_expr_match_t* flecs_expr_match(
+    ecs_script_parser_t *parser)
+{
+    ecs_expr_match_t *result = flecs_expr_ast_new(
+        parser, ecs_expr_match_t, EcsExprMatch);
+    return result;
+}
+
+static
+bool flecs_expr_explicit_cast_allowed(
+    ecs_world_t *world,
+    ecs_entity_t from,
+    ecs_entity_t to)
+{
+    if (from == to) {
+        return true;
+    }
+
+    const EcsType *from_type = ecs_get(world, from, EcsType);
+    const EcsType *to_type = ecs_get(world, to, EcsType);
+    ecs_assert(from_type != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(to_type != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    /* Treat opaque types asthe types that they're pretending to be*/
+    if (from_type->kind == EcsOpaqueType) {
+        const EcsOpaque *o = ecs_get(world, from, EcsOpaque);
+        ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
+        from_type = ecs_get(world, o->as_type, EcsType);
+        ecs_assert(from_type != NULL, ECS_INTERNAL_ERROR, NULL);
+    }
+    if (to_type->kind == EcsOpaqueType) {
+        const EcsOpaque *o = ecs_get(world, to, EcsOpaque);
+        ecs_assert(o != NULL, ECS_INTERNAL_ERROR, NULL);
+        to_type = ecs_get(world, o->as_type, EcsType);
+        ecs_assert(to_type != NULL, ECS_INTERNAL_ERROR, NULL);
+    }
+
+    if (from_type->kind != EcsPrimitiveType || 
+        to_type->kind != EcsPrimitiveType) 
+    {
+        if (from_type->kind == EcsEnumType || 
+            from_type->kind == EcsBitmaskType)
+        {
+            if (flecs_expr_is_type_integer(to)) {
+                /* Can cast enums/bitmasks to integers */
+                return true;
+            }
+        }
+
+        if (flecs_expr_is_type_integer(from)) {
+            if (to_type->kind == EcsEnumType || 
+                to_type->kind == EcsBitmaskType)
+            {
+                /* Can cast integers to enums/bitmasks */
+                return true;
+            }
+        }
+
+        /* Cannot cast complex types that are not the same */
+        return false;
+    }
+
+    /* Anything can be casted to a number */
+    if (flecs_expr_is_type_number(to)) {
+        return true;
+    }
+
+    /* Anything can be casted to a number */
+    if (to == ecs_id(ecs_string_t)) {
+        return true;
+    }
+
+    return true;
+}
+
+ecs_expr_cast_t* flecs_expr_cast(
+    ecs_script_t *script,
+    ecs_expr_node_t *expr,
+    ecs_entity_t type)
+{
+    if (!flecs_expr_explicit_cast_allowed(script->world, expr->type, type)) {
+        char *from = ecs_id_str(script->world, expr->type);
+        char *to = ecs_id_str(script->world, type);
+        flecs_expr_visit_error(script, expr, "invalid cast from %s to %s", 
+            from, to);
+        ecs_os_free(from);
+        ecs_os_free(to);
+        return NULL;
+    }
+
+    ecs_allocator_t *a = &((ecs_script_impl_t*)script)->allocator;
+    ecs_expr_cast_t *result = flecs_calloc_t(a, ecs_expr_cast_t);
+    result->node.kind = EcsExprCast;
+    if (flecs_expr_is_type_number(expr->type) && 
+        flecs_expr_is_type_number(type)) 
+    {
+        result->node.kind = EcsExprCastNumber;
+    }
+
+    result->node.pos = expr->pos;
+    result->node.type = type;
+    result->node.type_info = ecs_get_type_info(script->world, type);
+    ecs_assert(result->node.type_info != NULL, ECS_INTERNAL_ERROR, NULL);
+    result->expr = expr;
+    return result;
+}
+
+#endif
+
+/**
+ * @file addons/script/expr/parser.c
+ * @brief Script expression parser.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+/* From https://en.cppreference.com/w/c/language/operator_precedence */
+
+static int flecs_expr_precedence[] = {
+    [EcsTokParenOpen] = 1,
+    [EcsTokMember] = 1,
+    [EcsTokBracketOpen] = 1,
+    [EcsTokNot] = 2,
+    [EcsTokMul] = 3,
+    [EcsTokDiv] = 3,
+    [EcsTokMod] = 3,
+    [EcsTokAdd] = 4,
+    [EcsTokSub] = 4,
+    [EcsTokShiftLeft] = 5,
+    [EcsTokShiftRight] = 5,
+    [EcsTokGt] = 6,
+    [EcsTokGtEq] = 6,
+    [EcsTokLt] = 6,
+    [EcsTokLtEq] = 6,
+    [EcsTokEq] = 7,
+    [EcsTokNeq] = 7,
+    [EcsTokBitwiseAnd] = 8,
+    [EcsTokBitwiseOr] = 10,
+    [EcsTokAnd] = 11,
+    [EcsTokOr] = 12,
+};
+
+static
+const char* flecs_script_parse_lhs(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_tokenizer_t *tokenizer,
+    ecs_script_token_kind_t left_oper,
+    ecs_expr_node_t **out);
+
+static
+void flecs_script_parser_expr_free(
+    ecs_script_parser_t *parser,
+    ecs_expr_node_t *node)
+{
+    flecs_expr_visit_free(&parser->script->pub, node);
+}
+
+static
+bool flecs_has_precedence(
+    ecs_script_token_kind_t first,
+    ecs_script_token_kind_t second)
+{
+    if (!flecs_expr_precedence[first]) {
+        return false;
+    }
+    return flecs_expr_precedence[first] <= flecs_expr_precedence[second];
+}
+
+static
+ecs_entity_t flecs_script_default_lookup(
+    const ecs_world_t *world,
+    const char *name,
+    void *ctx)
+{
+    (void)ctx;
+    return ecs_lookup(world, name);
+}
+
+static
+const char* flecs_script_parse_match_elems(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_expr_match_t *node)
+{
+    ecs_allocator_t *a = &parser->script->allocator;
+    bool old_significant_newline = parser->significant_newline;
+    parser->significant_newline = true;
+
+    ecs_vec_init_t(NULL, &node->elements, ecs_expr_match_element_t, 0);
+
+    do {
+        ParserBegin;
+
+        LookAhead(
+            case '\n': {
+                pos = lookahead;
+                continue;
+            }
+
+            case '}': {
+                /* Return last character of initializer */
+                pos = lookahead - 1;
+                parser->significant_newline = old_significant_newline;
+                EndOfRule;
+            }
+        )
+
+        ecs_expr_match_element_t *elem = ecs_vec_append_t(
+            a, &node->elements, ecs_expr_match_element_t);
+        ecs_os_zeromem(elem);
+
+        pos = flecs_script_parse_expr(parser, pos, 0, &elem->compare);
+        if (!pos) {
+            goto error;
+        }
+
+        Parse_1(':', {
+            pos = flecs_script_parse_expr(parser, pos, 0, &elem->expr);
+            if (!pos) {
+                goto error;
+            }
+
+            Parse(
+                case ';':
+                case '\n': {
+                    break;
+                }
+            )
+
+            break;
+        })
+
+    } while (true);
+
+    ParserEnd;
+}
+
+const char* flecs_script_parse_initializer(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    char until,
+    ecs_expr_initializer_t **node_out)
+{
+    bool first = true;
+
+    ecs_expr_initializer_t *node = *node_out = flecs_expr_initializer(parser);
+    ecs_allocator_t *a = &parser->script->allocator;
+
+    do {
+        ParserBegin;
+
+        /* End of initializer */
+        LookAhead(
+            case ')':
+            case '}': {
+                if ((char)lookahead_token.kind != until) {
+                    Error("expected '%c'", until);
+                }
+                if (first) {
+                    node->node.kind = EcsExprEmptyInitializer;
+                }
+                pos = lookahead - 1;
+                EndOfRule;
+            })
+
+        first = false;
+
+        ecs_expr_initializer_element_t *elem = ecs_vec_append_t(
+            a, &node->elements, ecs_expr_initializer_element_t);
+        ecs_os_zeromem(elem);
+
+        /* Parse member name */
+        {
+            LookAhead_2(EcsTokIdentifier, ':', {
+                elem->member = Token(0);
+                LookAhead_Keep();
+                pos = lookahead;
+                break;
+            })
+        }
+        {
+            LookAhead_2(EcsTokIdentifier, EcsTokAddAssign, {
+                elem->member = Token(0);
+                elem->operator = EcsTokAddAssign;
+                LookAhead_Keep();
+                pos = lookahead;
+                break;
+            })
+        }
+        {
+            LookAhead_2(EcsTokIdentifier, EcsTokMulAssign, {
+                elem->member = Token(0);
+                elem->operator = EcsTokMulAssign;
+                LookAhead_Keep();
+                pos = lookahead;
+                break;
+            })
+        }
+
+        pos = flecs_script_parse_expr(parser, pos, 0, &elem->value);
+        if (!pos) {
+            goto error;
+        }
+
+        {
+            /* Parse next element or end of initializer*/
+            LookAhead(
+                case ',': {
+                    pos = lookahead;
+                    break;
+                }
+
+                case ')':
+                case '}': 
+                    /* Return last character of initializer */
+                    pos = lookahead - 1;
+
+                case '\n': {
+                    if ((char)lookahead_token.kind != until) {
+                        Error("expected '%c'", until);
+                    }
+                    EndOfRule;
+                }
+            )
+        }
+    } while (true);
+
+    ParserEnd;
+}
+
+static
+const char* flecs_script_parse_collection_initializer(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_expr_initializer_t **node_out)
+{
+    bool first = true;
+    
+    ecs_expr_initializer_t *node = *node_out = flecs_expr_initializer(parser);
+    ecs_allocator_t *a = &parser->script->allocator;
+
+    do {
+        ParserBegin;
+
+        /* End of initializer */
+        LookAhead_1(']', {
+            if (first) {                
+                node->node.kind = EcsExprEmptyInitializer;
+            }
+            pos = lookahead - 1;
+            EndOfRule;
+        })
+
+        first = false;
+
+        ecs_expr_initializer_element_t *elem = ecs_vec_append_t(
+            a, &node->elements, ecs_expr_initializer_element_t);
+        ecs_os_zeromem(elem);
+
+        pos = flecs_script_parse_expr(parser, pos, 0, &elem->value);
+        if (!pos) {
+            goto error;
+        }
+
+        {
+            /* Parse next element or end of initializer */
+            LookAhead(
+                case ',': {
+                    pos = lookahead;
+                    break;
+                }
+                case ']': {
+                    EndOfRule;
+                }
+            )
+        }
+    } while (true);
+
+    ParserEnd;
+}
+
+static
+const char* flecs_script_parse_rhs(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_tokenizer_t *tokenizer,
+    ecs_script_token_kind_t left_oper,
+    ecs_expr_node_t **out)
+{
+    const char *last_pos = pos;
+
+    do {
+        TokenFramePush();
+
+        last_pos = pos;
+
+        LookAhead(
+            case EcsTokNumber:
+                if (pos[0] == '-') {
+                    lookahead = &pos[1];
+                    lookahead_token.kind = EcsTokSub;
+                } else {
+                    Error("unexpected number");
+                }
+            case EcsTokAdd:
+            case EcsTokSub:
+            case EcsTokMul:
+            case EcsTokDiv:
+            case EcsTokMod:
+            case EcsTokBitwiseOr:
+            case EcsTokBitwiseAnd:
+            case EcsTokEq:
+            case EcsTokNeq:
+            case EcsTokGt:
+            case EcsTokGtEq:
+            case EcsTokLt:
+            case EcsTokLtEq:
+            case EcsTokAnd:
+            case EcsTokOr:
+            case EcsTokShiftLeft:
+            case EcsTokShiftRight: 
+            case EcsTokBracketOpen:
+            case EcsTokMember:
+            case EcsTokParenOpen:
+            {
+                ecs_script_token_kind_t oper = lookahead_token.kind;
+
+                /* Only consume more tokens if operator has precedence */
+                if (flecs_has_precedence(left_oper, oper)) {
+                    break;
+                }
+
+                /* Consume lookahead token */
+                pos = lookahead;
+
+                switch(oper) {
+                case EcsTokBracketOpen: {
+                    ecs_expr_element_t *result = flecs_expr_element(parser);
+                    result->left = *out;
+                    
+                    *out = (ecs_expr_node_t*)result;
+
+                    pos = flecs_script_parse_lhs(
+                        parser, pos, tokenizer, 0, &result->index);
+                    if (!pos) {
+                        goto error;
+                    }
+
+                    Parse_1(']', {
+                        break;
+                    });
+
+                    break;
+                }
+
+                case EcsTokMember: {
+                    Parse_1(EcsTokIdentifier, {
+                        ecs_expr_member_t *result = flecs_expr_member(parser);
+                        result->left = *out;
+                        result->member_name = Token(1);
+                        *out = (ecs_expr_node_t*)result;
+                        break;
+                    });
+
+                    break;
+                }
+
+                case EcsTokParenOpen: {
+                    ecs_expr_function_t *result = flecs_expr_function(parser);
+                    result->left = *out;
+
+                    pos = flecs_script_parse_initializer(
+                        parser, pos, ')', &result->args);
+                    if (!pos) {
+                        goto error;
+                    }
+
+                    *out = (ecs_expr_node_t*)result;
+
+                    if (pos[0] != ')') {
+                        Error("expected end of argument list");
+                    }
+
+                    pos ++;
+                    break;
+                }
+
+                default: {
+                    ecs_expr_binary_t *result = flecs_expr_binary(parser);
+                    result->left = *out;
+                    result->operator = oper;
+
+                    *out = (ecs_expr_node_t*)result;
+
+                    pos = flecs_script_parse_lhs(parser, pos, tokenizer,
+                        result->operator, &result->right);
+                    if (!pos) {
+                        goto error;
+                    }
+
+                    break;
+                }
+                };
+
+                /* Ensures lookahead tokens in token buffer don't get overwritten */
+                parser->token_keep = parser->token_cur;
+                break;
+            }
+        )
+
+        TokenFramePop();
+    } while (pos != last_pos);
+
+    return pos;
+error:
+    return NULL;
+}
+
+static
+const char* flecs_script_parse_lhs(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_tokenizer_t *tokenizer,
+    ecs_script_token_kind_t left_oper,
+    ecs_expr_node_t **out)
+{
+    TokenFramePush();
+
+    bool can_have_rhs = true;
+
+    Parse(
+        case EcsTokNumber: {
+            const char *expr = Token(0);
+            if (strchr(expr, '.') || strchr(expr, 'e')) {
+                *out = (ecs_expr_node_t*)flecs_expr_float(parser, atof(expr));
+            } else if (expr[0] == '-') {
+                char *end;
+                *out = (ecs_expr_node_t*)flecs_expr_int(parser, 
+                    strtoll(expr, &end, 10));
+            } else {
+                char *end;
+                *out = (ecs_expr_node_t*)flecs_expr_uint(parser, 
+                    strtoull(expr, &end, 10));
+            }
+            break;
+        }
+
+        case EcsTokString: {
+            if (flecs_string_is_interpolated(Token(0))) {
+                *out = (ecs_expr_node_t*)flecs_expr_interpolated_string(
+                    parser, Token(0));
+            } else {
+                *out = (ecs_expr_node_t*)flecs_expr_string(parser, Token(0));
+            }
+            break;
+        }
+
+        case EcsTokIdentifier: {
+            const char *expr = Token(0);
+            if (expr[0] == '$') {
+                *out = (ecs_expr_node_t*)flecs_expr_variable(parser, &expr[1]);
+            } else if (!ecs_os_strcmp(expr, "true")) {
+                *out = (ecs_expr_node_t*)flecs_expr_bool(parser, true);
+            } else if (!ecs_os_strcmp(expr, "false")) {
+                *out = (ecs_expr_node_t*)flecs_expr_bool(parser, false);
+            } else {
+                char *last_elem = strrchr(expr, '.');
+                if (last_elem && last_elem[1] == '$') {
+                    /* Scoped global variable */
+                    ecs_expr_variable_t *v = flecs_expr_variable(parser, expr);
+                    ecs_os_memmove(&last_elem[1], &last_elem[2],
+                        ecs_os_strlen(&last_elem[2]) + 1);
+                    v->node.kind = EcsExprGlobalVariable;
+                    *out = (ecs_expr_node_t*)v;
+                } else {
+                    /* Entity identifier */
+                    *out = (ecs_expr_node_t*)flecs_expr_identifier(parser, expr);
+                }
+            }
+            break;
+        }
+
+        case EcsTokNot: {
+            ecs_expr_unary_t *node = flecs_expr_unary(parser);
+            pos = flecs_script_parse_expr(parser, pos, EcsTokNot, &node->expr);
+            if (!pos) {
+                flecs_script_parser_expr_free(parser, (ecs_expr_node_t*)node);
+                goto error;
+            }
+
+            node->operator = EcsTokNot;
+            *out = (ecs_expr_node_t*)node;
+            break;
+        }
+
+        case EcsTokSub: {
+            ecs_expr_binary_t *node = flecs_expr_binary(parser);
+            
+            /* Use EcsTokNot as it has the same precedence as a unary - */
+            pos = flecs_script_parse_expr(parser, pos, EcsTokNot, &node->right);
+            if (!pos) {
+                flecs_script_parser_expr_free(parser, (ecs_expr_node_t*)node);
+                goto error;
+            }
+
+            node->left = (ecs_expr_node_t*)flecs_expr_int(parser, -1);
+            node->operator = EcsTokMul;
+            *out = (ecs_expr_node_t*)node;
+            break;
+        }
+
+        case EcsTokKeywordMatch: {
+            ecs_expr_match_t *node = flecs_expr_match(parser);
+            pos = flecs_script_parse_expr(parser, pos, 0, &node->expr);
+            if (!pos) {
+                flecs_script_parser_expr_free(parser, (ecs_expr_node_t*)node);
+                goto error;
+            }
+
+            Parse_1('{', {
+                pos = flecs_script_parse_match_elems(parser, pos, node);
+                if (!pos) {
+                    flecs_script_parser_expr_free(
+                        parser, (ecs_expr_node_t*)node);
+                    goto error;
+                }
+
+                Parse_1('}', {
+                    *out = (ecs_expr_node_t*)node;
+                    break;
+                })
+
+                break;
+            })
+
+            can_have_rhs = false;
+
+            break;
+        }
+
+        case '(': {
+            pos = flecs_script_parse_expr(parser, pos, 0, out);
+            if (!pos) {
+                goto error;
+            }
+
+            Parse_1(')', {
+                break;
+            })
+
+            break;
+        }
+
+        case '{': {
+            ecs_expr_initializer_t *node = NULL;
+            pos = flecs_script_parse_initializer(parser, pos, '}', &node);
+            if (!pos) {
+                flecs_script_parser_expr_free(parser, (ecs_expr_node_t*)node);
+                goto error;
+            }
+
+            Parse_1('}', {
+                break;
+            })
+
+            can_have_rhs = false;
+
+            *out = (ecs_expr_node_t*)node;
+            break;
+        }
+
+        case '[': {
+            ecs_expr_initializer_t *node = NULL;
+            pos = flecs_script_parse_collection_initializer(parser, pos, &node);
+            if (!pos) {
+                flecs_script_parser_expr_free(parser, (ecs_expr_node_t*)node);
+                goto error;
+            }
+
+            node->is_collection = true;
+
+            Parse_1(']', {
+                break;
+            })
+
+            can_have_rhs = false;
+
+            *out = (ecs_expr_node_t*)node;
+            break;
+        }
+    )
+
+    TokenFramePop();
+
+    /* Return if this was end of expression, or if the parsed expression cannot
+     * have a right hand side. */
+    if (!pos[0] || !can_have_rhs) {
+        return pos;
+    }
+
+    /* Parse right-hand side of expression if there is one */
+    return flecs_script_parse_rhs(parser, pos, tokenizer, left_oper, out);
+error:
+    return NULL;
+}
+
+const char* flecs_script_parse_expr(
+    ecs_script_parser_t *parser,
+    const char *pos,
+    ecs_script_token_kind_t left_oper,
+    ecs_expr_node_t **out)
+{
+    ParserBegin;
+
+    pos = flecs_script_parse_lhs(parser, pos, tokenizer, left_oper, out);
+
+    EndOfRule;
+
+    ParserEnd;
+}
+
+ecs_script_t* ecs_expr_parse(
+    ecs_world_t *world,
+    const char *expr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_eval_desc_t priv_desc = {0};
+    if (desc) {
+        priv_desc = *desc;
+    }
+
+    if (!priv_desc.lookup_action) {
+        priv_desc.lookup_action = flecs_script_default_lookup;
+    }
+
+    ecs_script_t *script = flecs_script_new(world);
+    ecs_script_impl_t *impl = flecs_script_impl(script);
+
+    ecs_script_parser_t parser = {
+        .script = impl,
+        .scope = impl->root,
+        .significant_newline = false
+    };
+
+    impl->token_buffer_size = ecs_os_strlen(expr) * 2 + 1;
+    impl->token_buffer = flecs_alloc_w_dbg_info(
+        &impl->allocator, impl->token_buffer_size, "token buffer");
+    parser.token_cur = impl->token_buffer;
+
+    const char *ptr = flecs_script_parse_expr(&parser, expr, 0, &impl->expr);
+    if (!ptr) {
+        goto error;
+    }
+
+    impl->next_token = ptr;
+    impl->token_remaining = parser.token_cur;
+
+    if (flecs_expr_visit_type(script, impl->expr, &priv_desc)) {
+        goto error;
+    }
+
+    //printf("%s\n", ecs_script_ast_to_str(script, true));
+
+    if (!desc || !desc->disable_folding) {
+        if (flecs_expr_visit_fold(script, &impl->expr, &priv_desc)) {
+            goto error;
+        }
+    }
+
+    //printf("%s\n", ecs_script_ast_to_str(script, true));
+
+    return script;
+error:
+    ecs_script_free(script);
+    return NULL;
+}
+
+int ecs_expr_eval(
+    const ecs_script_t *script,
+    ecs_value_t *value,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_assert(script != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_script_impl_t *impl = flecs_script_impl(
+        /* Safe, won't be writing to script */
+        ECS_CONST_CAST(ecs_script_t*, script));
+    ecs_assert(impl->expr != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_expr_eval_desc_t priv_desc = {0};
+    if (desc) {
+        priv_desc = *desc;
+    }
+
+    if (!priv_desc.lookup_action) {
+        priv_desc.lookup_action = flecs_script_default_lookup;
+    }
+
+    if (flecs_expr_visit_eval(script, impl->expr, &priv_desc, value)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+FLECS_API
+const char* ecs_expr_run(
+    ecs_world_t *world,
+    const char *expr,
+    ecs_value_t *value,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_eval_desc_t priv_desc = {0};
+    if (desc) {
+        priv_desc = *desc;
+    }
+    
+    if (!priv_desc.type) {
+        priv_desc.type = value->type;
+    } else if (desc && (value->type != desc->type)) {
+        ecs_throw(ECS_INVALID_PARAMETER, 
+            "type of value parameter does not match desc->type");
+    }
+
+    ecs_script_t *s = ecs_expr_parse(world, expr, &priv_desc);
+    if (!s) {
+        goto error;
+    }
+
+    if (ecs_expr_eval(s, value, &priv_desc)) {
+        ecs_script_free(s);
+        goto error;
+    }
+
+    const char *result = flecs_script_impl(s)->next_token;
+
+    ecs_script_free(s);
+
+    return result;
+error:
+    return NULL;
+}
+
+FLECS_API
+char* ecs_script_string_interpolate(
+    ecs_world_t *world,
+    const char *str,
+    const ecs_script_vars_t *vars)
+{
+    if (!flecs_string_is_interpolated(str)) {
+        char *result = ecs_os_strdup(str);
+        if (!flecs_string_escape(result)) {
+            ecs_os_free(result);
+            return NULL;
+        }
+        return result;
+    }
+
+    char *expr = flecs_asprintf("\"%s\"", str);
+
+    ecs_expr_eval_desc_t desc = { .vars = vars };
+    char *r = NULL;
+    if (!ecs_expr_run(world, expr, &ecs_value_ptr(ecs_string_t, &r), &desc)) {
+        ecs_os_free(expr);
+        return NULL;
+    }
+
+    ecs_os_free(expr);
+
+    return r;
+}
+
+#endif
+
+/**
+ * @file addons/script/expr/stack.c
+ * @brief Script expression stack implementation.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+void flecs_expr_value_alloc(
+    ecs_expr_stack_t *stack,
+    ecs_expr_value_t *v,
+    const ecs_type_info_t *ti)
+{
+    ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(v->type_info == NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(ti != NULL, ECS_INTERNAL_ERROR, NULL);
+    v->type_info = ti;
+    v->value.type = ti->component;
+    v->value.ptr = flecs_stack_alloc(&stack->stack, ti->size, ti->alignment);
+
+    if (ti->hooks.ctor) {
+        ti->hooks.ctor(v->value.ptr, 1, ti);
+    }
+}
+
+static
+void flecs_expr_value_free(
+    ecs_expr_value_t *v)
+{
+    const ecs_type_info_t *ti = v->type_info;
+    v->type_info = NULL;
+
+    if (!v->owned) {
+        return; /* Runtime doesn't own value, don't destruct */
+    }
+
+    if (ti && ti->hooks.dtor) {
+        ecs_assert(v->value.ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+        ti->hooks.dtor(v->value.ptr, 1, ti);
+        flecs_stack_free(v->value.ptr, ti->size);
+    }
+
+    v->value.ptr = NULL;
+}
+
+void flecs_expr_stack_init(
+    ecs_expr_stack_t *stack)
+{
+    ecs_os_zeromem(stack);
+    flecs_stack_init(&stack->stack);
+}
+
+void flecs_expr_stack_fini(
+    ecs_expr_stack_t *stack)
+{
+    ecs_assert(stack->frame == 0, ECS_INTERNAL_ERROR, NULL);
+    flecs_stack_fini(&stack->stack);
+}
+
+ecs_expr_value_t* flecs_expr_stack_result(
+    ecs_expr_stack_t *stack,
+    ecs_expr_node_t *node)
+{
+    ecs_assert(node != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(node->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
+    return flecs_expr_stack_alloc(stack, node->type_info);
+}
+
+ecs_expr_value_t* flecs_expr_stack_alloc(
+    ecs_expr_stack_t *stack,
+    const ecs_type_info_t *ti)
+{
+    ecs_assert(stack->frame > 0, ECS_INTERNAL_ERROR, NULL);
+
+    int32_t sp = stack->frames[stack->frame - 1].sp ++;
+    ecs_assert(sp < FLECS_EXPR_STACK_MAX, ECS_OUT_OF_RANGE, 
+        "expression nesting is too deep");
+    ecs_expr_value_t *v = &stack->values[sp];
+
+    if (ti) {
+        flecs_expr_value_alloc(stack, v, ti);
+    }
+
+    return v;
+}
+
+void flecs_expr_stack_push(
+    ecs_expr_stack_t *stack)
+{
+    int32_t frame = stack->frame ++;
+    ecs_assert(frame < FLECS_EXPR_STACK_MAX, ECS_OUT_OF_RANGE, 
+        "expression nesting is too deep");
+    stack->frames[frame].cur = flecs_stack_get_cursor(&stack->stack);
+    if (frame) {
+        stack->frames[frame].sp = stack->frames[frame - 1].sp;
+    } else {
+        stack->frames[frame].sp = 0;
+    }
+}
+
+void flecs_expr_stack_pop(
+    ecs_expr_stack_t *stack)
+{
+    int32_t frame = -- stack->frame;
+    ecs_assert(frame >= 0, ECS_INTERNAL_ERROR, NULL);
+    int32_t sp, start = 0, end = stack->frames[frame].sp;
+    if (frame) {
+        start = stack->frames[frame - 1].sp;
+    }
+
+    for (sp = end - 1; sp >= start; sp --) {
+        flecs_expr_value_free(&stack->values[sp]);
+    }
+
+    flecs_stack_restore_cursor(&stack->stack, stack->frames[frame].cur);
+}
+
+#endif
+
+/**
+ * @file addons/script/expr/parser.c * brief Scriptexpoutsion parser.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+int flecs_value_copy_to(
+    ecs_world_t *world,
+    ecs_value_t *dst,
+    const ecs_expr_value_t *src)
+{
+    ecs_assert(dst->type != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(src->value.type != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(src->value.ptr != 0, ECS_INTERNAL_ERROR, NULL);
+
+    if (src->value.type == dst->type) {
+        ecs_assert(src->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_value_copy_w_type_info(
+            world, src->type_info, dst->ptr, src->value.ptr);
+    } else {
+        /* Cast value to desired output type */
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, dst->type, dst->ptr);
+        if (ecs_meta_set_value(&cur, &src->value)) {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+int flecs_value_move_to(
+    ecs_world_t *world,
+    ecs_value_t *dst,
+    ecs_value_t *src)
+{
+    ecs_assert(dst->type != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(src->type != 0, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(src->ptr != 0, ECS_INTERNAL_ERROR, NULL);
+
+    if (src->type == dst->type) {
+        ecs_value_move(world, src->type, dst->ptr, src->ptr);
+    } else {
+        ecs_value_t tmp;
+        tmp.type = src->type;
+        tmp.ptr = ecs_value_new(world, src->type);
+        ecs_value_move(world, src->type, tmp.ptr, src->ptr);
+
+        /* Cast value to desired output type */
+        ecs_meta_cursor_t cur = ecs_meta_cursor(world, dst->type, dst->ptr);
+        if (ecs_meta_set_value(&cur, &tmp)) {
+            goto error;
+        }
+
+        ecs_value_free(world, src->type, tmp.ptr);
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+
+int flecs_value_unary(
+    const ecs_script_t *script,
+    const ecs_value_t *expr,
+    ecs_value_t *out,
+    ecs_script_token_kind_t operator)
+{
+    (void)script;
+    switch(operator) {
+    case EcsTokNot:
+        ecs_assert(expr->type == ecs_id(ecs_bool_t), ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(out->type == ecs_id(ecs_bool_t), ECS_INTERNAL_ERROR, NULL);
+        *(bool*)out->ptr = !*(bool*)expr->ptr;
+        break;
+    case EcsTokEnd:
+    case EcsTokUnknown:
+    case EcsTokScopeOpen:
+    case EcsTokScopeClose:
+    case EcsTokParenOpen:
+    case EcsTokParenClose:
+    case EcsTokBracketOpen:
+    case EcsTokBracketClose:
+    case EcsTokMember:
+    case EcsTokComma:
+    case EcsTokSemiColon:
+    case EcsTokColon:
+    case EcsTokAssign:
+    case EcsTokAdd:
+    case EcsTokSub:
+    case EcsTokMul:
+    case EcsTokDiv:
+    case EcsTokMod:
+    case EcsTokBitwiseOr:
+    case EcsTokBitwiseAnd:
+    case EcsTokOptional:
+    case EcsTokAnnotation:
+    case EcsTokNewline:
+    case EcsTokEq:
+    case EcsTokNeq:
+    case EcsTokGt:
+    case EcsTokGtEq:
+    case EcsTokLt:
+    case EcsTokLtEq:
+    case EcsTokAnd:
+    case EcsTokOr:
+    case EcsTokMatch:
+    case EcsTokRange:
+    case EcsTokShiftLeft:
+    case EcsTokShiftRight:
+    case EcsTokAddAssign:
+    case EcsTokMulAssign:
+    case EcsTokIdentifier:
+    case EcsTokString:
+    case EcsTokNumber:
+    case EcsTokKeywordModule:
+    case EcsTokKeywordUsing:
+    case EcsTokKeywordWith:
+    case EcsTokKeywordIf:
+    case EcsTokKeywordElse:
+    case EcsTokKeywordFor:
+    case EcsTokKeywordIn:
+    case EcsTokKeywordMatch:
+    case EcsTokKeywordTemplate:
+    case EcsTokKeywordProp:
+    case EcsTokKeywordConst:
+    default:
+        ecs_abort(ECS_INTERNAL_ERROR, "invalid operator for binary expression");
+    }
+
+    return 0;
+}
+
+#define ECS_VALUE_GET(value, T) (*(T*)(value)->ptr)
+
+#define ECS_BOP(left, right, result, op, R, T)\
+    ECS_VALUE_GET(result, R) = (R)(ECS_VALUE_GET(left, T) op ECS_VALUE_GET(right, T))
+
+#define ECS_BOP_COND(left, right, result, op, R, T)\
+    ECS_VALUE_GET(result, ecs_bool_t) = ECS_VALUE_GET(left, T) op ECS_VALUE_GET(right, T)
+
+#define ECS_BOP_ASSIGN(left, right, result, op, R, T)\
+    ECS_VALUE_GET(result, R) op (R)(ECS_VALUE_GET(right, T))
+
+/* Unsigned operations */
+#define ECS_BINARY_UINT_OPS(left, right, result, op, OP)\
+    if ((right)->type == ecs_id(ecs_u64_t)) { \
+        OP(left, right, result, op, ecs_u64_t, ecs_u64_t);\
+    } else if ((right)->type == ecs_id(ecs_u32_t)) { \
+        OP(left, right, result, op, ecs_u32_t, ecs_u32_t);\
+    } else if ((right)->type == ecs_id(ecs_u16_t)) { \
+        OP(left, right, result, op, ecs_u16_t, ecs_u16_t);\
+    } else if ((right)->type == ecs_id(ecs_u8_t)) { \
+        OP(left, right, result, op, ecs_u8_t, ecs_u8_t);\
+    }
+
+/* Unsigned + signed operations */
+#define ECS_BINARY_INT_OPS(left, right, result, op, OP)\
+    ECS_BINARY_UINT_OPS(left, right, result, op, OP)\
+     else if ((right)->type == ecs_id(ecs_i64_t)) { \
+        OP(left, right, result, op, ecs_i64_t, ecs_i64_t);\
+    } else if ((right)->type == ecs_id(ecs_i32_t)) { \
+        OP(left, right, result, op, ecs_i32_t, ecs_i32_t);\
+    } else if ((right)->type == ecs_id(ecs_i16_t)) { \
+        OP(left, right, result, op, ecs_i16_t, ecs_i16_t);\
+    } else if ((right)->type == ecs_id(ecs_i8_t)) { \
+        OP(left, right, result, op, ecs_i8_t, ecs_i8_t);\
+    }
+
+/* Unsigned + signed + floating point operations */
+#define ECS_BINARY_NUMBER_OPS(left, right, result, op, OP)\
+    ECS_BINARY_INT_OPS(left, right, result, op, OP)\
+      else if ((right)->type == ecs_id(ecs_f64_t)) { \
+        OP(left, right, result, op, ecs_f64_t, ecs_f64_t);\
+    } else if ((right)->type == ecs_id(ecs_f32_t)) { \
+        OP(left, right, result, op, ecs_f32_t, ecs_f32_t);\
+    }
+
+
+/* Combinations + error checking */
+
+#define ECS_BINARY_INT_OP(left, right, result, op)\
+    ECS_BINARY_INT_OPS(left, right, result, op, ECS_BOP) else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_UINT_OP(left, right, result, op)\
+    ECS_BINARY_UINT_OPS(left, right, result, op, ECS_BOP) else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_OP(left, right, result, op)\
+    ECS_BINARY_NUMBER_OPS(left, right, result, op, ECS_BOP) else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_COND_EQ_OP(left, right, result, op)\
+    ECS_BINARY_INT_OPS(left, right, result, op, ECS_BOP_COND)\
+      else if ((right)->type == ecs_id(ecs_char_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_char_t);\
+    } else if ((right)->type == ecs_id(ecs_u8_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_u8_t);\
+    } else if ((right)->type == ecs_id(ecs_bool_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_bool_t);\
+    } else if ((right)->type == ecs_id(ecs_entity_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_entity_t, ecs_entity_t);\
+    } else if ((right)->type == ecs_id(ecs_string_t)) { \
+        char *lstr = *(char**)(left)->ptr;\
+        char *rstr = *(char**)(right)->ptr;\
+        if (lstr && rstr) {\
+            *(bool*)(result)->ptr = ecs_os_strcmp(lstr, rstr) op 0;\
+        } else {\
+            *(bool*)(result)->ptr = lstr == rstr;\
+        }\
+    } else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_COND_OP(left, right, result, op)\
+    ECS_BINARY_NUMBER_OPS(left, right, result, op, ECS_BOP_COND)\
+      else if ((right)->type == ecs_id(ecs_char_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_char_t);\
+    } else if ((right)->type == ecs_id(ecs_u8_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_u8_t);\
+    } else if ((right)->type == ecs_id(ecs_bool_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_bool_t);\
+    } else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+#define ECS_BINARY_ASSIGN_OP(left, right, result, op)\
+    ECS_BINARY_NUMBER_OPS(left, right, result, op, ECS_BOP_ASSIGN)\
+
+#define ECS_BINARY_BOOL_OP(left, right, result, op)\
+    if ((right)->type == ecs_id(ecs_bool_t)) { \
+        ECS_BOP_COND(left, right, result, op, ecs_bool_t, ecs_bool_t);\
+    } else {\
+        ecs_abort(ECS_INTERNAL_ERROR, "unexpected type in binary expression");\
+    }
+
+int flecs_value_binary(
+    const ecs_script_t *script,
+    const ecs_value_t *left,
+    const ecs_value_t *right,
+    ecs_value_t *out,
+    ecs_script_token_kind_t operator)
+{
+    (void)script;
+
+    if (operator == EcsTokDiv || operator == EcsTokMod) {
+        if (flecs_value_is_0(right)) {
+            ecs_err("%s: division by zero", 
+                script->name ? script->name : "anonymous script");
+            return -1;
+        }
+    }
+
+    switch(operator) {
+    case EcsTokAdd:
+        ECS_BINARY_OP(left, right, out, +);
+        break;
+    case EcsTokSub:
+        ECS_BINARY_OP(left, right, out, -);
+        break;
+    case EcsTokMul:
+        ECS_BINARY_OP(left, right, out, *);
+        break;
+    case EcsTokDiv:
+        ECS_BINARY_OP(left, right, out, /);
+        break;
+    case EcsTokMod:
+        ECS_BINARY_INT_OP(left, right, out, %);
+        break;
+    case EcsTokEq:
+        ECS_BINARY_COND_EQ_OP(left, right, out, ==);
+        break;
+    case EcsTokNeq:
+        ECS_BINARY_COND_EQ_OP(left, right, out, !=);
+        break;
+    case EcsTokGt:
+        ECS_BINARY_COND_OP(left, right, out, >);
+        break;
+    case EcsTokGtEq:
+        ECS_BINARY_COND_OP(left, right, out, >=);
+        break;
+    case EcsTokLt:
+        ECS_BINARY_COND_OP(left, right, out, <);
+        break;
+    case EcsTokLtEq:
+        ECS_BINARY_COND_OP(left, right, out, <=);
+        break;
+    case EcsTokAnd:
+        ECS_BINARY_BOOL_OP(left, right, out, &&);
+        break;
+    case EcsTokOr:
+        ECS_BINARY_BOOL_OP(left, right, out, ||);
+        break;
+    case EcsTokBitwiseAnd:
+        ECS_BINARY_INT_OP(left, right, out, &);
+        break;
+    case EcsTokBitwiseOr:
+        ECS_BINARY_INT_OP(left, right, out, |);
+        break;
+    case EcsTokShiftLeft:
+        ECS_BINARY_INT_OP(left, right, out, <<);
+        break;
+    case EcsTokShiftRight:
+        ECS_BINARY_INT_OP(left, right, out, >>);
+        break;
+    case EcsTokAddAssign:
+        ECS_BINARY_ASSIGN_OP(left, right, out, +=);
+        break;
+    case EcsTokMulAssign:
+        ECS_BINARY_ASSIGN_OP(left, right, out, *=);
+        break;
+    case EcsTokEnd:
+    case EcsTokUnknown:
+    case EcsTokScopeOpen:
+    case EcsTokScopeClose:
+    case EcsTokParenOpen:
+    case EcsTokParenClose:
+    case EcsTokBracketOpen:
+    case EcsTokBracketClose:
+    case EcsTokMember:
+    case EcsTokComma:
+    case EcsTokSemiColon:
+    case EcsTokColon:
+    case EcsTokAssign:
+    case EcsTokNot:
+    case EcsTokOptional:
+    case EcsTokAnnotation:
+    case EcsTokNewline:
+    case EcsTokMatch:
+    case EcsTokRange:
+    case EcsTokIdentifier:
+    case EcsTokString:
+    case EcsTokNumber:
+    case EcsTokKeywordModule:
+    case EcsTokKeywordUsing:
+    case EcsTokKeywordWith:
+    case EcsTokKeywordIf:
+    case EcsTokKeywordElse:
+    case EcsTokKeywordFor:
+    case EcsTokKeywordIn:
+    case EcsTokKeywordTemplate:
+    case EcsTokKeywordMatch:
+    case EcsTokKeywordProp:
+    case EcsTokKeywordConst:
+    default:
+        ecs_abort(ECS_INTERNAL_ERROR, "invalid operator for binary expression");
+    }
+
+    return 0;
+}
+
+bool flecs_string_is_interpolated(
+    const char *value)
+{
+    const char *ptr = value;
+
+    for (ptr = strchr(ptr, '$'); ptr; ptr = strchr(ptr + 1, '$')) {
+        if (ptr != value) {
+            if (ptr[-1] == '\\') {
+                continue; /* Escaped */
+            }
+        }
+
+        if (isspace(ptr[1]) || !ptr[1]) {
+            continue; /* $ by itself */
+        }
+
+        return true;
+    }
+
+    ptr = value;
+
+    for (ptr = strchr(ptr, '{'); ptr; ptr = strchr(ptr + 1, '{')) {
+        if (ptr != value) {
+            if (ptr[-1] == '\\') {
+                continue; /* Escaped */
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+char* flecs_string_escape(
+    char *str)
+{
+    const char *ptr;
+    char *out = str, ch;
+
+    for (ptr = str; ptr[0]; ) {
+        if (ptr[0] == '\\') {
+            if (ptr[1] == '{') { /* Escape string interpolation delimiter */
+                ch = '{';
+                ptr += 2;
+            } else if (ptr[1] == '$') { /* Escape string interpolation var */
+                ch = '$';
+                ptr += 2;
+            } else {
+                ptr = flecs_chrparse(ptr, &ch);
+                if (!ptr) {
+                    ecs_err("invalid escape sequence in string '%s'", str);
+                    return NULL;
+                }
+            }
+        } else {
+            ch = ptr[0];
+            ptr ++;
+        }
+
+        out[0] = ch;
+        out ++;
+    }
+
+    out[0] = '\0';
+
+    return out + 1;
+}
+
+bool flecs_value_is_0(
+    const ecs_value_t *value)
+{
+    ecs_entity_t type = value->type;
+    void *ptr = value->ptr;
+           if (type == ecs_id(ecs_i8_t)) {
+        return *(ecs_i8_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_i16_t)) {
+        return *(ecs_i16_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_i32_t)) {
+        return *(ecs_i32_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_i64_t)) {
+        return *(ecs_i64_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_iptr_t)) {
+        return *(ecs_iptr_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_u8_t)) {
+        return *(ecs_u8_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_u16_t)) {
+        return *(ecs_u16_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_u32_t)) {
+        return *(ecs_u32_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_u64_t)) {
+        return *(ecs_u64_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_uptr_t)) {
+        return *(ecs_uptr_t*)ptr == 0;
+    } else if (type == ecs_id(ecs_f32_t)) {
+        return ECS_EQZERO(*(ecs_f32_t*)ptr);
+    } else if (type == ecs_id(ecs_f64_t)) {
+        return ECS_EQZERO(*(ecs_f64_t*)ptr);
+    } else {
+        return true;
+    }
+}
+
+#endif
+
+/**
+ * @file addons/script/expr_ast.c
+ * @brief Script expression AST implementation.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+typedef struct ecs_script_eval_ctx_t {
+    const ecs_script_t *script;
+    ecs_world_t *world;
+    const ecs_expr_eval_desc_t *desc;
+    ecs_expr_stack_t *stack;
+} ecs_script_eval_ctx_t;
+
+static
+int flecs_expr_visit_eval_priv(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_node_t *node,
+    ecs_expr_value_t *out);
+
+static
+int flecs_expr_value_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_value_node_t *node,
+    ecs_expr_value_t *out)
+{
+    (void)ctx;
+    out->value.type = node->node.type;
+    out->value.ptr = node->ptr;
+    out->owned = false;
+    return 0;
+}
+
+static
+int flecs_expr_interpolated_string_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_interpolated_string_t *node,
+    ecs_expr_value_t *out)
+{
+    ecs_assert(node->node.type == ecs_id(ecs_string_t), 
+        ECS_INTERNAL_ERROR, NULL);
+
+    ecs_strbuf_t buf = ECS_STRBUF_INIT;
+
+    flecs_expr_stack_push(ctx->stack);
+
+    int32_t i, e = 0, count = ecs_vec_count(&node->fragments);
+    char **fragments = ecs_vec_first(&node->fragments);
+    for (i = 0; i < count; i ++) {
+        char *fragment = fragments[i];
+        if (fragment) {
+            ecs_strbuf_appendstr(&buf, fragment);
+        } else {
+            ecs_expr_node_t *expr = ecs_vec_get_t(
+                &node->expressions, ecs_expr_node_t*, e ++)[0];
+            
+            ecs_expr_value_t *val = flecs_expr_stack_result(ctx->stack, 
+                (ecs_expr_node_t*)node);
+            val->owned = true;
+            if (flecs_expr_visit_eval_priv(ctx, expr, val)) {
+                goto error;
+            }
+
+            ecs_assert(val->value.type == ecs_id(ecs_string_t), 
+                ECS_INTERNAL_ERROR, NULL);
+
+            ecs_strbuf_appendstr(&buf, *(char**)val->value.ptr);
+        }
+    }
+
+    *(char**)out->value.ptr = ecs_strbuf_get(&buf);
+    out->owned = true;
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_initializer_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    void *value);
+
+static
+int flecs_expr_initializer_eval_static(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    void *value)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        if (elem->value->kind == EcsExprInitializer) {
+            if (flecs_expr_initializer_eval(ctx, 
+                (ecs_expr_initializer_t*)elem->value, value)) 
+            {
+                goto error;
+            }
+            continue;
+        }
+
+        ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, elem->value);
+        if (flecs_expr_visit_eval_priv(ctx, elem->value, expr)) {
+            goto error;
+        }
+
+        /* Type is guaranteed to be correct, since type visitor will insert
+         * a cast to the type of the initializer element. */
+        ecs_entity_t type = elem->value->type;
+
+        if (!elem->operator) {
+            if (expr->owned) {
+                if (ecs_value_move(ctx->world, type, 
+                    ECS_OFFSET(value, elem->offset), expr->value.ptr))
+                {
+                    goto error;
+                }
+            } else {
+                if (ecs_value_copy(ctx->world, type, 
+                    ECS_OFFSET(value, elem->offset), expr->value.ptr))
+                {
+                    goto error;
+                }
+            }
+        } else {
+            ecs_value_t dst = { 
+                .type = type, 
+                .ptr = ECS_OFFSET(value, elem->offset) 
+            };
+
+            if (flecs_value_binary(
+                ctx->script, NULL, &expr->value, &dst, elem->operator))
+            {
+                goto error;
+            }
+        }
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_initializer_eval_dynamic(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    void *value)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_meta_cursor_t cur = ecs_meta_cursor(
+        ctx->world, node->node.type, value);
+    
+    if (ecs_meta_push(&cur)) {
+        goto error;
+    }
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        if (i) {
+            ecs_meta_next(&cur);
+        }
+
+        if (elem->value->kind == EcsExprInitializer) {
+            if (flecs_expr_initializer_eval(ctx, 
+                (ecs_expr_initializer_t*)elem->value, value)) 
+            {
+                goto error;
+            }
+            continue;
+        }
+
+        ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, elem->value);
+        if (flecs_expr_visit_eval_priv(ctx, elem->value, expr)) {
+            goto error;
+        }
+
+        if (elem->member) {
+            ecs_meta_member(&cur, elem->member);
+        }
+
+        ecs_value_t v_elem_value = {
+            .ptr = expr->value.ptr,
+            .type = expr->value.type
+        };
+
+        if (ecs_meta_set_value(&cur, &v_elem_value)) {
+            goto error;
+        }
+    }
+
+    if (ecs_meta_pop(&cur)) {
+        goto error;
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_initializer_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    void *value)
+{
+    if (node->is_dynamic) {
+        return flecs_expr_initializer_eval_dynamic(ctx, node, value);
+    } else {
+        return flecs_expr_initializer_eval_static(ctx, node, value);
+    }
+}
+
+static
+int flecs_expr_initializer_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    ecs_expr_value_t *out)
+{
+    out->owned = true;
+    return flecs_expr_initializer_eval(ctx, node, out->value.ptr);
+}
+
+static
+int flecs_expr_unary_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_unary_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->expr);
+    if (flecs_expr_visit_eval_priv(ctx, node->expr, expr)) {
+        goto error;
+    }
+
+    if (flecs_value_unary(
+        ctx->script, &expr->value, &out->value, node->operator)) 
+    {
+        goto error;
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_binary_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_binary_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    /* Evaluate left & right expressions */
+    ecs_expr_value_t *left = flecs_expr_stack_result(ctx->stack, node->left);
+    if (flecs_expr_visit_eval_priv(ctx, node->left, left)) {
+        goto error;
+    }
+
+    ecs_expr_value_t *right = flecs_expr_stack_result(ctx->stack, node->right);
+    if (flecs_expr_visit_eval_priv(ctx, node->right, right)) {
+        goto error;
+    }
+
+    if (flecs_value_binary(
+        ctx->script, &left->value, &right->value, &out->value, node->operator)) 
+    {
+        goto error;
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_identifier_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_identifier_t *node,
+    ecs_expr_value_t *out)
+{
+    if (node->expr) {
+        return flecs_expr_visit_eval_priv(ctx, node->expr, out);
+    } else {
+        ecs_assert(ctx->desc != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(ctx->desc->lookup_action != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_entity_t e = ctx->desc->lookup_action(
+            ctx->world, node->value, ctx->desc->lookup_ctx);
+        if (!e) {
+            flecs_expr_visit_error(ctx->script, node, 
+                "unresolved identifier '%s'", node->value);
+            goto error;
+        }
+
+        ecs_assert(out->value.type == ecs_id(ecs_entity_t), 
+            ECS_INTERNAL_ERROR, NULL);
+        *(ecs_entity_t*)out->value.ptr = e;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_variable_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_variable_t *node,
+    ecs_expr_value_t *out)
+{
+    ecs_assert(ctx->desc != NULL, ECS_INVALID_OPERATION,
+        "variables available at parse time are not provided");
+    ecs_assert(ctx->desc->vars != NULL, ECS_INVALID_OPERATION,
+        "variables available at parse time are not provided");
+
+    const ecs_script_var_t *var = flecs_script_find_var(
+        ctx->desc->vars, node->name, 
+            ctx->desc->disable_dynamic_variable_binding ? &node->sp : NULL);
+    if (!var) {
+        flecs_expr_visit_error(ctx->script, node, "unresolved variable '%s'",
+            node->name);
+        goto error;
+    }
+
+    /* Should've been populated by type visitor */
+    ecs_assert(var != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(var->value.type == node->node.type, ECS_INTERNAL_ERROR, NULL);
+    out->value = var->value;
+    out->owned = false;
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_global_variable_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_variable_t *node,
+    ecs_expr_value_t *out)
+{
+    (void)ctx;
+
+    ecs_assert(ctx->desc != NULL, ECS_INVALID_OPERATION,
+        "variables available at parse time are not provided");
+
+    ecs_assert(node->global_value.type == node->node.type, 
+        ECS_INTERNAL_ERROR, NULL);
+    out->value = node->global_value;
+    out->owned = false;
+
+    return 0;
+}
+
+static
+int flecs_expr_cast_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_cast_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    /* Evaluate expression to cast */
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->expr);
+    if (flecs_expr_visit_eval_priv(ctx, node->expr, expr)) {
+        goto error;
+    }
+
+    /* Copy expression result to storage of casted-to type */
+    if (flecs_value_copy_to(ctx->world, &out->value, expr)) {
+        flecs_expr_visit_error(ctx->script, node, "failed to cast value");
+        goto error;
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+bool flecs_expr_get_signed(
+    const ecs_value_t *value,
+    int64_t *out)
+{
+    ecs_entity_t type = value->type;
+    void *ptr = value->ptr;
+
+    if (type == ecs_id(ecs_i8_t)) {
+        *out = *(int8_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_i16_t)) {
+        *out = *(int16_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_i32_t)) {
+        *out = *(int32_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_i64_t)) {
+        *out = *(int64_t*)ptr;
+        return true;
+    }
+
+    return false;
+}
+
+static
+bool flecs_expr_get_unsigned(
+    const ecs_value_t *value,
+    uint64_t *out)
+{
+    ecs_entity_t type = value->type;
+    void *ptr = value->ptr;
+
+    if (type == ecs_id(ecs_u8_t)) {
+        *out = *(uint8_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_u16_t)) {
+        *out = *(uint16_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_u32_t)) {
+        *out = *(uint32_t*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_u64_t)) {
+        *out = *(uint64_t*)ptr;
+        return true;
+    }
+
+    return false;
+}
+
+static
+bool flecs_expr_get_float(
+    const ecs_value_t *value,
+    double *out)
+{
+    ecs_entity_t type = value->type;
+    void *ptr = value->ptr;
+
+    if (type == ecs_id(ecs_f32_t)) {
+        *out = (double)*(float*)ptr;
+        return true;
+    } else if (type == ecs_id(ecs_f64_t)) {
+        *out = *(double*)ptr;
+        return true;
+    }
+
+    return false;
+}
+
+#define FLECS_EXPR_NUMBER_CAST\
+         if (type == ecs_id(ecs_i8_t))   *(ecs_i8_t*)ptr =   (ecs_i8_t)value;\
+    else if (type == ecs_id(ecs_i16_t))  *(ecs_i16_t*)ptr =  (ecs_i16_t)value;\
+    else if (type == ecs_id(ecs_i32_t))  *(ecs_i32_t*)ptr =  (ecs_i32_t)value;\
+    else if (type == ecs_id(ecs_i64_t))  *(ecs_i64_t*)ptr =  (ecs_i64_t)value;\
+    else if (type == ecs_id(ecs_iptr_t)) *(ecs_iptr_t*)ptr = (ecs_iptr_t)value;\
+    else if (type == ecs_id(ecs_u8_t))   *(ecs_u8_t*)ptr =   (ecs_u8_t)value;\
+    else if (type == ecs_id(ecs_u16_t))  *(ecs_u16_t*)ptr =  (ecs_u16_t)value;\
+    else if (type == ecs_id(ecs_u32_t))  *(ecs_u32_t*)ptr =  (ecs_u32_t)value;\
+    else if (type == ecs_id(ecs_u64_t))  *(ecs_u64_t*)ptr =  (ecs_u64_t)value;\
+    else if (type == ecs_id(ecs_uptr_t)) *(ecs_uptr_t*)ptr = (ecs_uptr_t)value;\
+    else if (type == ecs_id(ecs_f32_t))  *(ecs_f32_t*)ptr =  (ecs_f32_t)value;\
+    else if (type == ecs_id(ecs_f64_t))  *(ecs_f64_t*)ptr =  (ecs_f64_t)value;\
+
+static
+void flecs_expr_set_signed(
+    const ecs_value_t *out,
+    int64_t value)
+{
+    ecs_entity_t type = out->type;
+    void *ptr = out->ptr;
+    FLECS_EXPR_NUMBER_CAST
+}
+
+static
+void flecs_expr_set_unsigned(
+    const ecs_value_t *out,
+    uint64_t value)
+{
+    ecs_entity_t type = out->type;
+    void *ptr = out->ptr;
+    FLECS_EXPR_NUMBER_CAST
+}
+
+static
+void flecs_expr_set_float(
+    const ecs_value_t *out,
+    double value)
+{
+    ecs_entity_t type = out->type;
+    void *ptr = out->ptr;
+    FLECS_EXPR_NUMBER_CAST
+}
+
+static
+int flecs_expr_cast_number_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_cast_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    /* Evaluate expression to cast */
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->expr);
+    if (flecs_expr_visit_eval_priv(ctx, node->expr, expr)) {
+        goto error;
+    }
+
+    int64_t signed_;
+    uint64_t unsigned_;
+    double float_;
+    if (flecs_expr_get_signed(&expr->value, &signed_)) {
+        flecs_expr_set_signed(&out->value, signed_);
+    } else if (flecs_expr_get_unsigned(&expr->value, &unsigned_)) {
+        flecs_expr_set_unsigned(&out->value, unsigned_);
+    } else if (flecs_expr_get_float(&expr->value, &float_)) {
+        flecs_expr_set_float(&out->value, float_);
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_function_args_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_initializer_t *node,
+    ecs_value_t *args)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+        ecs_expr_value_t *expr = flecs_expr_stack_result(
+            ctx->stack, elem->value);
+
+        if (flecs_expr_visit_eval_priv(ctx, elem->value, expr)) {
+            goto error;
+        }
+
+        args[i] = expr->value;
+    }
+
+    return 0;
+error:  
+    return -1;
+}
+
+static
+int flecs_expr_function_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_function_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_function_ctx_t call_ctx = {
+        .world = ctx->world,
+        .function = node->calldata.function,
+        .ctx = node->calldata.ctx
+    };
+
+    ecs_assert(out->value.ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_value_t *argv = NULL;
+    int32_t argc = ecs_vec_count(&node->args->elements);
+    if (argc) {
+        argv = ecs_os_alloca_n(ecs_value_t, argc);
+        if (flecs_expr_function_args_visit_eval(ctx, node->args, argv)) {
+            goto error;
+        }
+    }
+
+    node->calldata.callback(&call_ctx, argc, argv, &out->value);
+    out->owned = true;
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_method_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_function_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    if (node->left) {
+        ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->left);
+        if (flecs_expr_visit_eval_priv(ctx, node->left, expr)) {
+            goto error;
+        }
+
+        ecs_function_ctx_t call_ctx = {
+            .world = ctx->world,
+            .function = node->calldata.function,
+            .ctx = node->calldata.ctx
+        };
+
+        ecs_assert(expr->value.ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(out->value.ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+
+        int32_t argc = ecs_vec_count(&node->args->elements);
+        ecs_value_t *argv = ecs_os_alloca_n(ecs_value_t, argc + 1);
+        argv[0] = expr->value;
+
+        if (argc) {
+            if (flecs_expr_function_args_visit_eval(
+                ctx, node->args, &argv[1])) 
+            {
+                goto error;
+            }
+        }
+
+        node->calldata.callback(&call_ctx, argc, argv, &out->value);
+        out->owned = true;
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_member_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_member_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->left);
+    if (flecs_expr_visit_eval_priv(ctx, node->left, expr)) {
+        goto error;
+    }
+
+    out->value.ptr = ECS_OFFSET(expr->value.ptr, node->offset);
+    out->value.type = node->node.type;
+    out->owned = false;
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_element_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_element_t *node,
+    ecs_expr_value_t *out)
+{
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->left);
+    if (flecs_expr_visit_eval_priv(ctx, node->left, expr)) {
+        goto error;
+    }
+
+    ecs_expr_value_t *index = flecs_expr_stack_result(ctx->stack, node->index);
+    if (flecs_expr_visit_eval_priv(ctx, node->index, index)) {
+        goto error;
+    }
+
+    int64_t index_value = *(int64_t*)index->value.ptr;
+
+    out->value.ptr = ECS_OFFSET(expr->value.ptr, node->elem_size * index_value);
+    out->value.type = node->node.type;
+    out->owned = false;
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_match_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_match_t *node,
+    ecs_expr_value_t *out)
+{
+    flecs_expr_stack_push(ctx->stack);
+
+    ecs_expr_value_t *expr = flecs_expr_stack_result(ctx->stack, node->expr);
+    if (flecs_expr_visit_eval_priv(ctx, node->expr, expr)) {
+        goto error;
+    }
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_match_element_t *elems = ecs_vec_first(&node->elements);
+
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+
+        flecs_expr_stack_push(ctx->stack);
+        ecs_expr_value_t *compare = flecs_expr_stack_result(
+            ctx->stack, node->expr);
+        if (flecs_expr_visit_eval_priv(ctx, elem->compare, compare)) {
+            goto error;
+        }
+
+        bool value = false;
+        ecs_value_t result = { .type = ecs_id(ecs_bool_t), .ptr = &value };
+
+        if (flecs_value_binary(
+            ctx->script, &expr->value, &compare->value, &result, EcsTokEq))
+        {
+            goto error;
+        }
+
+        flecs_expr_stack_pop(ctx->stack);
+
+        if (value) {
+            if (flecs_expr_visit_eval_priv(ctx, elem->expr, out)) {
+                goto error;
+            }
+            break;
+        }
+    }
+
+    if (i == count) {
+        if (node->any.expr) {
+            if (flecs_expr_visit_eval_priv(ctx, node->any.expr, out)) {
+                goto error;
+            }
+        } else {
+            char *str = ecs_ptr_to_str(
+                ctx->world, expr->value.type, expr->value.ptr);
+            flecs_expr_visit_error(ctx->script, node, 
+                "match value '%s' not handled by case", str);
+            ecs_os_free(str);
+            goto error;
+        }
+    }
+
+    flecs_expr_stack_pop(ctx->stack);
+    return 0;
+error:
+    flecs_expr_stack_pop(ctx->stack);
+    return -1;
+}
+
+static
+int flecs_expr_component_visit_eval(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_element_t *node,
+    ecs_expr_value_t *out)
+{
+    ecs_expr_value_t *left = flecs_expr_stack_result(ctx->stack, node->left);
+    if (flecs_expr_visit_eval_priv(ctx, node->left, left)) {
+        goto error;
+    }
+
+    /* Left side of expression must be of entity type */
+    ecs_assert(left->value.type == ecs_id(ecs_entity_t), 
+        ECS_INTERNAL_ERROR, NULL);
+
+    /* Component must be resolvable at parse time */
+    ecs_expr_node_t *index = node->index;
+    if (index->kind == EcsExprIdentifier) {
+        index = ((ecs_expr_identifier_t*)index)->expr;
+    }
+
+    ecs_assert(index->kind == EcsExprValue, ECS_INTERNAL_ERROR, NULL);
+
+    ecs_entity_t entity = *(ecs_entity_t*)left->value.ptr;
+    ecs_entity_t component = ((ecs_expr_value_node_t*)index)->storage.entity;
+
+    ecs_assert(out->value.type == node->node.type, ECS_INTERNAL_ERROR, NULL);
+    out->value.ptr = ECS_CONST_CAST(void*, 
+        ecs_get_id(ctx->world, entity, component));
+    out->owned = false;
+
+    if (!out->value.ptr) {
+        char *estr = ecs_get_path(ctx->world, entity);
+        char *cstr = ecs_get_path(ctx->world, component);
+        flecs_expr_visit_error(ctx->script, node, 
+            "entity '%s' does not have component '%s'", estr, cstr);
+        ecs_os_free(estr);
+        ecs_os_free(cstr);
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_visit_eval_priv(
+    ecs_script_eval_ctx_t *ctx,
+    ecs_expr_node_t *node,
+    ecs_expr_value_t *out)
+{
+    ecs_assert(node != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    switch(node->kind) {
+    case EcsExprValue:
+        if (flecs_expr_value_visit_eval(
+            ctx, (ecs_expr_value_node_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprInterpolatedString: 
+        if (flecs_expr_interpolated_string_visit_eval(
+            ctx, (ecs_expr_interpolated_string_t*)node, out))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprEmptyInitializer:
+        break;
+    case EcsExprInitializer:
+        if (flecs_expr_initializer_visit_eval(
+            ctx, (ecs_expr_initializer_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprUnary:
+        if (flecs_expr_unary_visit_eval(
+            ctx, (ecs_expr_unary_t*)node, out))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprBinary:
+        if (flecs_expr_binary_visit_eval(
+            ctx, (ecs_expr_binary_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprIdentifier:
+        if (flecs_expr_identifier_visit_eval(
+            ctx, (ecs_expr_identifier_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprVariable:
+        if (flecs_expr_variable_visit_eval(
+            ctx, (ecs_expr_variable_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprGlobalVariable:
+        if (flecs_expr_global_variable_visit_eval(
+            ctx, (ecs_expr_variable_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprFunction:
+        if (flecs_expr_function_visit_eval(
+            ctx, (ecs_expr_function_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMethod:
+        if (flecs_expr_method_visit_eval(
+            ctx, (ecs_expr_function_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMember:
+        if (flecs_expr_member_visit_eval(
+            ctx, (ecs_expr_member_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprElement:
+        if (flecs_expr_element_visit_eval(
+            ctx, (ecs_expr_element_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMatch:
+        if (flecs_expr_match_visit_eval(
+            ctx, (ecs_expr_match_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprComponent:
+        if (flecs_expr_component_visit_eval(
+            ctx, (ecs_expr_element_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprCast:
+        if (flecs_expr_cast_visit_eval(
+            ctx, (ecs_expr_cast_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprCastNumber:
+        if (flecs_expr_cast_number_visit_eval(
+            ctx, (ecs_expr_cast_t*)node, out)) 
+        {
+            goto error;
+        }
+        break;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+int flecs_expr_visit_eval(
+    const ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const ecs_expr_eval_desc_t *desc,
+    ecs_value_t *out)
+{
+    ecs_expr_stack_t *stack = NULL, stack_local;
+    if (desc && desc->runtime) {
+        stack = &desc->runtime->expr_stack;
+        ecs_assert(stack->frame == 0, ECS_INTERNAL_ERROR, NULL);
+    }
+    if (!stack) {
+        stack = &stack_local;
+        flecs_expr_stack_init(stack);
+    }
+
+    flecs_expr_stack_push(stack);
+
+    ecs_expr_value_t val_tmp;
+    ecs_expr_value_t *val;
+    if (out->type && (out->type == node->type) && out->ptr) {
+        val_tmp = (ecs_expr_value_t){
+            .value = *out,
+            .owned = false,
+            .type_info = ecs_get_type_info(script->world, out->type)
+        };
+        val = &val_tmp;
+    } else {
+        val = flecs_expr_stack_result(stack, node);
+    }
+
+    ecs_script_eval_ctx_t ctx = {
+        .script = script,
+        .world = script->world,
+        .stack = stack,
+        .desc = desc
+    };
+
+    if (flecs_expr_visit_eval_priv(&ctx, node, val)) {
+        goto error;
+    }
+
+    if (desc && !out->type) {
+        out->type = desc->type;
+    }
+
+    if (!out->type) {
+        out->type = node->type;
+    }
+
+    if (out->type && !out->ptr) {
+        out->ptr = ecs_value_new(ctx.world, out->type);
+    }
+
+    if (val != &val_tmp || out->ptr != val->value.ptr) {
+        if (val->owned) {
+            /* Values owned by the runtime can be moved to output */
+            if (flecs_value_move_to(ctx.world, out, &val->value)) {
+                flecs_expr_visit_error(script, node, "failed to write to output");
+                goto error;
+            }
+        } else {
+            /* Values not owned by runtime should be copied */
+            if (flecs_value_copy_to(ctx.world, out, val)) {
+                flecs_expr_visit_error(script, node, "failed to write to output");
+                goto error;
+            }
+        }
+    }
+
+    flecs_expr_stack_pop(stack);
+    if (stack == &stack_local) {
+        flecs_expr_stack_fini(stack);
+    }
+    return 0;
+error:
+    flecs_expr_stack_pop(stack);
+    if (stack == &stack_local) {
+        flecs_expr_stack_fini(stack);
+    }
+    return -1;
+}
+
+#endif
+
+/**
+ * @file addons/script/expr_fold.c
+ * @brief Script expression constant folding.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+void flecs_visit_fold_replace(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    ecs_expr_node_t *with)
+{
+    ecs_assert(*node_ptr != with, ECS_INTERNAL_ERROR, NULL);
+    flecs_expr_visit_free(script, *node_ptr);
+    *node_ptr = with;
+}
+
+static
+int flecs_expr_unary_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_unary_t *node = (ecs_expr_unary_t*)*node_ptr;
+
+    if (node->operator != EcsTokNot) {
+        flecs_expr_visit_error(script, node, 
+            "operator invalid for unary expression");
+        goto error;
+    }
+
+    if (flecs_expr_visit_fold(script, &node->expr, desc)) {
+        goto error;
+    }
+
+    if (node->expr->kind != EcsExprValue) {
+        /* Only folding literals */
+        return 0;
+    }
+
+    if (node->expr->type != ecs_id(ecs_bool_t)) {
+        char *type_str = ecs_get_path(script->world, node->node.type);
+        flecs_expr_visit_error(script, node, 
+            "! operator cannot be applied to value of type '%s' (must be bool)");
+        ecs_os_free(type_str);
+        goto error;
+    }
+
+    ecs_expr_value_node_t *result = flecs_expr_value_from(
+        script, (ecs_expr_node_t*)node, ecs_id(ecs_bool_t));
+    result->ptr = &result->storage.bool_;
+
+    ecs_value_t dst = { .ptr = result->ptr, .type = ecs_id(ecs_bool_t) };
+    ecs_value_t src = { 
+        .ptr = ((ecs_expr_value_node_t*)node->expr)->ptr, .type = ecs_id(ecs_bool_t) };
+    if (flecs_value_unary(script, &src, &dst, node->operator)) {
+        goto error;
+    }
+
+    flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_binary_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_binary_t *node = (ecs_expr_binary_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->left, desc)) {
+        goto error;
+    }
+
+    if (flecs_expr_visit_fold(script, &node->right, desc)) {
+        goto error;
+    }
+
+    if (node->left->kind != EcsExprValue || node->right->kind != EcsExprValue) {
+        /* Only folding literals */
+        return 0;
+    }
+
+    ecs_expr_value_node_t *left = (ecs_expr_value_node_t*)node->left;
+    ecs_expr_value_node_t *right = (ecs_expr_value_node_t*)node->right;
+
+    ecs_value_t lop = { .type = left->node.type, .ptr = left->ptr };
+    ecs_value_t rop = { .type = right->node.type, .ptr = right->ptr };
+
+    /* flecs_value_binary will detect division by 0, but we have more 
+     * information about where it happens here. */
+    if (node->operator == EcsTokDiv || node->operator == EcsTokMod) {
+        if (flecs_value_is_0(&rop)) {
+            flecs_expr_visit_error(script, node, 
+                "invalid division by zero");
+            goto error;
+        }
+    }
+
+    ecs_expr_value_node_t *result = flecs_expr_value_from(
+        script, (ecs_expr_node_t*)node, node->node.type);
+    ecs_value_t res = { .type = result->node.type, .ptr = result->ptr };
+
+    if (flecs_value_binary(script, &lop, &rop, &res, node->operator)) {
+        goto error;
+    }
+
+    flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+    return 0;
+error:  
+    return -1;
+}
+
+static
+int flecs_expr_cast_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_cast_t *node = (ecs_expr_cast_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->expr, desc)) {
+        goto error;
+    }
+
+    if (node->expr->kind != EcsExprValue) {
+        /* Only folding literals for now */
+        return 0;
+    }
+
+    ecs_expr_value_node_t *expr = (ecs_expr_value_node_t*)node->expr;
+    ecs_entity_t dst_type = node->node.type;
+    ecs_entity_t src_type = expr->node.type;
+
+    if (dst_type == src_type) {
+        /* No cast necessary if types are equal */
+        return 0;
+    }
+
+    void *dst_ptr = ecs_value_new(script->world, dst_type);
+
+    ecs_meta_cursor_t cur = ecs_meta_cursor(script->world, dst_type, dst_ptr);
+    ecs_value_t value = {
+        .type = src_type,
+        .ptr = expr->ptr
+    };
+
+    if (ecs_meta_set_value(&cur, &value)) {
+        flecs_expr_visit_error(script, node, "failed to assign value");
+        ecs_value_free(script->world, dst_type, dst_ptr);
+        goto error;
+    }
+
+    if (expr->ptr != &expr->storage) {
+        ecs_value_free(script->world, expr->node.type, expr->ptr);
+    }
+
+    expr->node.type = dst_type;
+    expr->ptr = dst_ptr;
+
+    node->expr = NULL; /* Prevent cleanup */
+    flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)expr);
+
+    return 0;
+error:  
+    return -1;  
+}
+
+static
+int flecs_expr_interpolated_string_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_interpolated_string_t *node = 
+        (ecs_expr_interpolated_string_t*)*node_ptr;
+
+    bool can_fold = true;
+    
+    int32_t i, e = 0, count = ecs_vec_count(&node->fragments);
+    char **fragments = ecs_vec_first(&node->fragments);
+    for (i = 0; i < count; i ++) {
+        char *fragment = fragments[i];
+        if (!fragment) {
+            ecs_expr_node_t **expr_ptr = ecs_vec_get_t(
+                &node->expressions, ecs_expr_node_t*, e ++);
+
+            if (flecs_expr_visit_fold(script, expr_ptr, desc)) {
+                goto error;
+            }
+
+            if (expr_ptr[0]->kind != EcsExprValue) {
+                can_fold = false;
+            }
+        }
+    }
+
+    if (can_fold) {
+        ecs_strbuf_t buf = ECS_STRBUF_INIT;
+        e = 0;
+
+        for (i = 0; i < count; i ++) {
+            char *fragment = fragments[i];
+            if (fragment) {
+                ecs_strbuf_appendstr(&buf, fragment);
+            } else {
+                ecs_expr_node_t *expr = ecs_vec_get_t(
+                    &node->expressions, ecs_expr_node_t*, e ++)[0];
+                ecs_assert(expr->kind == EcsExprValue, 
+                    ECS_INTERNAL_ERROR, NULL);
+                ecs_assert(expr->type == ecs_id(ecs_string_t),
+                    ECS_INTERNAL_ERROR, NULL);
+                ecs_expr_value_node_t *val = (ecs_expr_value_node_t*)expr;
+                ecs_strbuf_appendstr(&buf, *(char**)val->ptr);
+            }
+        }
+
+        char **value = ecs_value_new(script->world, ecs_id(ecs_string_t));
+        *value = ecs_strbuf_get(&buf);
+
+        ecs_expr_value_node_t *result = flecs_expr_value_from(
+            script, (ecs_expr_node_t*)node, ecs_id(ecs_string_t));
+        result->ptr = value;
+
+        flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_pre_fold(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    const ecs_expr_eval_desc_t *desc,
+    bool *can_fold)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        /* If this is a nested initializer, don't fold it but instead fold its
+         * values. Because nested initializers are flattened, this ensures that
+         * we'll be using the correct member offsets later. */
+        if (elem->value->kind == EcsExprInitializer) {
+            if (flecs_expr_initializer_pre_fold(
+                script, (ecs_expr_initializer_t*)elem->value, desc, can_fold)) 
+            {
+                goto error;
+            }
+            continue;
+        }
+
+        if (flecs_expr_visit_fold(script, &elem->value, desc)) {
+            goto error;
+        }
+
+        if (elem->value->kind != EcsExprValue) {
+            *can_fold = false;
+        }
+
+        if (elem->operator) {
+            *can_fold = false;
+        }
+    }
+
+    if (node->is_dynamic) {
+        *can_fold = false;
+        return 0;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_post_fold(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    void *value)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        if (elem->value->kind == EcsExprInitializer) {
+            if (flecs_expr_initializer_post_fold(
+                script, (ecs_expr_initializer_t*)elem->value, value)) 
+            {
+                goto error;
+            }
+            continue;
+        }
+
+        ecs_expr_value_node_t *elem_value = (ecs_expr_value_node_t*)elem->value;
+
+        /* Type is guaranteed to be correct, since type visitor will insert
+         * a cast to the type of the initializer element. */
+        ecs_entity_t type = elem_value->node.type;
+
+        if (ecs_value_copy(script->world, type, 
+            ECS_OFFSET(value, elem->offset), elem_value->ptr)) 
+        {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    bool can_fold = true;
+
+    ecs_expr_initializer_t *node = (ecs_expr_initializer_t*)*node_ptr;
+
+    if (flecs_expr_initializer_pre_fold(script, node, desc, &can_fold)) {
+        goto error;
+    }
+
+    /* If all elements of initializer fold to literals, initializer itself can
+     * be folded into a literal. */
+    if (can_fold) {
+        void *value = ecs_value_new(script->world, node->node.type);
+
+        if (flecs_expr_initializer_post_fold(script, node, value)) {
+            goto error;
+        }
+
+        ecs_expr_value_node_t *result = flecs_expr_value_from(
+            script, (ecs_expr_node_t*)node, node->node.type);
+        result->ptr = value;
+
+        flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_identifier_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)desc;
+
+    ecs_expr_identifier_t *node = (ecs_expr_identifier_t*)*node_ptr;
+
+    ecs_expr_node_t *expr = node->expr;
+    if (expr) {
+        node->expr = NULL;
+        flecs_visit_fold_replace(script, node_ptr, expr);
+    }
+
+    return 0;
+}
+
+static
+int flecs_expr_variable_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)desc;
+
+    ecs_expr_variable_t *node = (ecs_expr_variable_t*)*node_ptr;
+
+    ecs_script_var_t *var = flecs_script_find_var(
+        desc->vars, node->name, &node->sp);
+    /* Should've been caught by type visitor */
+    ecs_assert(var != NULL, ECS_INTERNAL_ERROR, NULL);
+    ecs_assert(var->value.type == node->node.type, ECS_INTERNAL_ERROR, NULL);
+    ecs_entity_t type = node->node.type;
+
+    if (var->is_const) {
+        ecs_expr_value_node_t *result = flecs_expr_value_from(
+            script, (ecs_expr_node_t*)node, type);
+        void *value = ecs_value_new(script->world, type);
+        ecs_value_copy(script->world, type, value, var->value.ptr);
+        result->ptr = value;
+        flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+    }
+
+    return 0;
+}
+
+static
+int flecs_expr_global_variable_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)desc;
+
+    ecs_expr_variable_t *node = (ecs_expr_variable_t*)*node_ptr;
+    ecs_entity_t type = node->node.type;
+
+    /* Global const variables are always const, so we can always fold */
+
+    ecs_expr_value_node_t *result = flecs_expr_value_from(
+        script, (ecs_expr_node_t*)node, type);
+    void *value = ecs_value_new(script->world, type);
+    ecs_value_copy(script->world, type, value, node->global_value.ptr);
+    result->ptr = value;
+    flecs_visit_fold_replace(script, node_ptr, (ecs_expr_node_t*)result);
+
+    return 0;
+}
+
+static
+int flecs_expr_arguments_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        if (flecs_expr_visit_fold(script, &elem->value, desc)) {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_function_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_function_t *node = (ecs_expr_function_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->left, desc)) {
+        goto error;
+    }
+
+    if (node->args) {
+        if (flecs_expr_arguments_visit_fold(script, node->args, desc)) {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_member_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_member_t *node = (ecs_expr_member_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->left, desc)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_element_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_element_t *node = (ecs_expr_element_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->left, desc)) {
+        goto error;
+    }
+
+    if (flecs_expr_visit_fold(script, &node->index, desc)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_match_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_expr_match_t *node = (ecs_expr_match_t*)*node_ptr;
+
+    if (flecs_expr_visit_fold(script, &node->expr, desc)) {
+        goto error;
+    }
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_match_element_t *elems = ecs_vec_first(&node->elements);
+
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+        if (flecs_expr_visit_fold(script, &elem->compare, desc)) {
+            goto error;
+        }
+
+        if (flecs_expr_visit_fold(script, &elem->expr, desc)) {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+int flecs_expr_visit_fold(
+    ecs_script_t *script,
+    ecs_expr_node_t **node_ptr,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_assert(node_ptr != NULL, ECS_INVALID_PARAMETER, NULL);
+    ecs_expr_node_t *node = *node_ptr;
+
+    switch(node->kind) {
+    case EcsExprValue:
+        break;
+    case EcsExprInterpolatedString:
+        if (flecs_expr_interpolated_string_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprInitializer:
+    case EcsExprEmptyInitializer:
+        if (flecs_expr_initializer_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprUnary:
+        if (flecs_expr_unary_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprBinary:
+        if (flecs_expr_binary_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprIdentifier:
+        if (flecs_expr_identifier_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprVariable:
+        if (flecs_expr_variable_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprGlobalVariable:
+        if (flecs_expr_global_variable_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprFunction:
+    case EcsExprMethod:
+        if (flecs_expr_function_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprMember:
+        if (flecs_expr_member_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprElement:
+    case EcsExprComponent:
+        if (flecs_expr_element_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprMatch:
+        if (flecs_expr_match_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    case EcsExprCast:
+    case EcsExprCastNumber:
+        if (flecs_expr_cast_visit_fold(script, node_ptr, desc)) {
+            goto error;
+        }
+        break;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+#endif
+
+/**
+ * @file addons/script/expr/visit_free.c
+ * @brief Visitor to free expression AST.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+void flecs_expr_value_visit_free(
+    ecs_script_t *script,
+    ecs_expr_value_node_t *node)
+{
+    if (node->ptr != &node->storage) {
+        ecs_value_free(script->world, node->node.type, node->ptr);
+    }
+}
+
+static
+void flecs_expr_interpolated_string_visit_free(
+    ecs_script_t *script,
+    ecs_expr_interpolated_string_t *node)
+{
+    int32_t i, count = ecs_vec_count(&node->expressions);
+    ecs_expr_node_t **expressions = ecs_vec_first(&node->expressions);
+    for (i = 0; i < count; i ++) {
+        flecs_expr_visit_free(script, expressions[i]);
+    }
+
+    ecs_vec_fini_t(&flecs_script_impl(script)->allocator, 
+        &node->fragments, char*);
+    ecs_vec_fini_t(&flecs_script_impl(script)->allocator, 
+        &node->expressions, ecs_expr_node_t*);
+    flecs_free_n(&flecs_script_impl(script)->allocator,
+        char, node->buffer_size, node->buffer);
+}
+
+static
+void flecs_expr_initializer_visit_free(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+        flecs_expr_visit_free(script, elem->value);
+    }
+
+    ecs_allocator_t *a = &flecs_script_impl(script)->allocator;
+    ecs_vec_fini_t(a, &node->elements, ecs_expr_initializer_element_t);
+}
+
+static
+void flecs_expr_unary_visit_free(
+    ecs_script_t *script,
+    ecs_expr_unary_t *node)
+{
+    flecs_expr_visit_free(script, node->expr);
+}
+
+static
+void flecs_expr_binary_visit_free(
+    ecs_script_t *script,
+    ecs_expr_binary_t *node)
+{
+    flecs_expr_visit_free(script, node->left);
+    flecs_expr_visit_free(script, node->right);
+}
+
+static
+void flecs_expr_identifier_visit_free(
+    ecs_script_t *script,
+    ecs_expr_identifier_t *node)
+{
+    flecs_expr_visit_free(script, node->expr);
+}
+
+static
+void flecs_expr_function_visit_free(
+    ecs_script_t *script,
+    ecs_expr_function_t *node)
+{
+    flecs_expr_visit_free(script, node->left);
+    flecs_expr_visit_free(script, (ecs_expr_node_t*)node->args);
+}
+
+static
+void flecs_expr_member_visit_free(
+    ecs_script_t *script,
+    ecs_expr_member_t *node)
+{
+    flecs_expr_visit_free(script, node->left);
+}
+
+static
+void flecs_expr_element_visit_free(
+    ecs_script_t *script,
+    ecs_expr_element_t *node)
+{
+    flecs_expr_visit_free(script, node->left);
+    flecs_expr_visit_free(script, node->index);
+}
+
+static
+void flecs_expr_match_visit_free(
+    ecs_script_t *script,
+    ecs_expr_match_t *node)
+{
+    flecs_expr_visit_free(script, node->expr);
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_match_element_t *elems = ecs_vec_first(&node->elements);
+
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+        flecs_expr_visit_free(script, elem->compare);
+        flecs_expr_visit_free(script, elem->expr);
+    }
+
+    if (node->any.compare) {
+        flecs_expr_visit_free(script, node->any.compare);
+    }
+    if (node->any.expr) {
+        flecs_expr_visit_free(script, node->any.expr);
+    }
+    
+    ecs_vec_fini_t(&flecs_script_impl(script)->allocator, 
+        &node->elements, ecs_expr_match_element_t);
+}
+
+static
+void flecs_expr_cast_visit_free(
+    ecs_script_t *script,
+    ecs_expr_cast_t *node)
+{
+    flecs_expr_visit_free(script, node->expr);
+}
+
+void flecs_expr_visit_free(
+    ecs_script_t *script,
+    ecs_expr_node_t *node)
+{
+    if (!node) {
+        return;
+    }
+
+    ecs_allocator_t *a = &flecs_script_impl(script)->allocator;
+
+    switch(node->kind) {
+    case EcsExprValue:
+        flecs_expr_value_visit_free(
+            script, (ecs_expr_value_node_t*)node);
+        flecs_free_t(a, ecs_expr_value_node_t, node);
+        break;
+    case EcsExprInterpolatedString:
+        flecs_expr_interpolated_string_visit_free(
+            script, (ecs_expr_interpolated_string_t*)node);
+        flecs_free_t(a, ecs_expr_interpolated_string_t, node);
+        break;
+    case EcsExprInitializer:
+    case EcsExprEmptyInitializer:
+        flecs_expr_initializer_visit_free(
+            script, (ecs_expr_initializer_t*)node);
+        flecs_free_t(a, ecs_expr_initializer_t, node);
+        break;
+    case EcsExprUnary:
+        flecs_expr_unary_visit_free(
+            script, (ecs_expr_unary_t*)node);
+        flecs_free_t(a, ecs_expr_unary_t, node);
+        break;
+    case EcsExprBinary:
+        flecs_expr_binary_visit_free(
+            script, (ecs_expr_binary_t*)node);
+        flecs_free_t(a, ecs_expr_binary_t, node);
+        break;
+    case EcsExprIdentifier:
+        flecs_expr_identifier_visit_free(
+            script, (ecs_expr_identifier_t*)node);
+        flecs_free_t(a, ecs_expr_identifier_t, node);
+        break;
+    case EcsExprVariable:
+    case EcsExprGlobalVariable:
+        flecs_free_t(a, ecs_expr_variable_t, node);
+        break;
+    case EcsExprFunction:
+    case EcsExprMethod:
+        flecs_expr_function_visit_free(
+            script, (ecs_expr_function_t*)node);
+        flecs_free_t(a, ecs_expr_function_t, node);
+        break;
+    case EcsExprMember:
+        flecs_expr_member_visit_free(
+            script, (ecs_expr_member_t*)node);
+        flecs_free_t(a, ecs_expr_member_t, node);
+        break;
+    case EcsExprElement:
+    case EcsExprComponent:
+        flecs_expr_element_visit_free(
+            script, (ecs_expr_element_t*)node);
+        flecs_free_t(a, ecs_expr_element_t, node);
+        break;
+    case EcsExprMatch:
+        flecs_expr_match_visit_free(
+            script, (ecs_expr_match_t*)node);
+        flecs_free_t(a, ecs_expr_match_t, node);
+        break;
+    case EcsExprCast:
+    case EcsExprCastNumber:
+        flecs_expr_cast_visit_free(
+            script, (ecs_expr_cast_t*)node);
+        flecs_free_t(a, ecs_expr_cast_t, node);
+        break;
+    }
+}
+
+#endif
+
+/**
+ * @file addons/script/expr_to_str.c
+ * @brief Script expression AST to string visitor.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+typedef struct ecs_expr_str_visitor_t {
+    const ecs_world_t *world;
+    ecs_strbuf_t *buf;
+    int32_t depth;
+    bool newline;
+    bool colors;
+} ecs_expr_str_visitor_t;
+
+static
+int flecs_expr_node_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_node_t *node);
+
+static
+void flecs_expr_color_to_str(
+    ecs_expr_str_visitor_t *v,
+    const char *color)
+{
+    if (v->colors) ecs_strbuf_appendstr(v->buf, color);
+}
+
+static
+int flecs_expr_value_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_value_node_t *node)
+{
+    flecs_expr_color_to_str(v, ECS_YELLOW);
+    int ret = ecs_ptr_to_str_buf(
+        v->world, node->node.type, node->ptr, v->buf);
+    flecs_expr_color_to_str(v, ECS_NORMAL);
+    return ret;
+}
+
+static
+int flecs_expr_interpolated_string_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_interpolated_string_t *node)
+{
+    int32_t i, e = 0, count = ecs_vec_count(&node->fragments);
+    char **fragments = ecs_vec_first(&node->fragments);
+    ecs_expr_node_t **expressions = ecs_vec_first(&node->expressions);
+
+    ecs_strbuf_appendlit(v->buf, "interpolated(");
+
+    for (i = 0; i < count; i ++) {
+        char *fragment = fragments[i];
+
+        if (i) {
+            ecs_strbuf_appendlit(v->buf, ", ");
+        }
+
+        if (fragment) {
+            flecs_expr_color_to_str(v, ECS_YELLOW);
+            ecs_strbuf_appendlit(v->buf, "\"");
+            ecs_strbuf_appendstr(v->buf, fragment);
+            ecs_strbuf_appendlit(v->buf, "\"");
+            flecs_expr_color_to_str(v, ECS_NORMAL);
+        } else {
+            ecs_expr_node_t *expr = expressions[e ++];
+            if (flecs_expr_node_to_str(v, expr)) {
+                return -1;
+            }
+        }
+    }
+
+    ecs_strbuf_appendlit(v->buf, ")");
+    
+    return 0;
+}
+
+static
+int flecs_expr_unary_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_unary_t *node)
+{
+    ecs_strbuf_appendstr(v->buf, flecs_script_token_str(node->operator));
+
+    if (flecs_expr_node_to_str(v, node->expr)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_initializer_t *node)
+{
+    ecs_strbuf_appendlit(v->buf, "{");
+
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        if (i) {
+            ecs_strbuf_appendstr(v->buf, ", ");
+        }
+
+        ecs_expr_initializer_element_t *elem = &elems[i];
+        if (elem->member) {
+            ecs_strbuf_appendstr(v->buf, elem->member);
+            ecs_strbuf_appendlit(v->buf, ":");
+        }
+
+        if (flecs_expr_node_to_str(v, elem->value)) {
+            goto error;
+        }
+    }
+
+    ecs_strbuf_appendlit(v->buf, "}");
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_binary_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_binary_t *node)
+{
+    ecs_strbuf_appendlit(v->buf, "(");
+
+    if (flecs_expr_node_to_str(v, node->left)) {
+        goto error;
+    }
+
+    ecs_strbuf_appendlit(v->buf, " ");
+
+    ecs_strbuf_appendstr(v->buf, flecs_script_token_str(node->operator));
+
+    ecs_strbuf_appendlit(v->buf, " ");
+
+    if (flecs_expr_node_to_str(v, node->right)) {
+        goto error;
+    }
+
+    ecs_strbuf_appendlit(v->buf, ")");
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_identifier_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_identifier_t *node)
+{
+    ecs_strbuf_appendlit(v->buf, "@");
+    ecs_strbuf_appendstr(v->buf, node->value);
+    return 0;
+}
+
+static
+int flecs_expr_variable_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_variable_t *node)
+{
+    flecs_expr_color_to_str(v, ECS_GREEN);
+    ecs_strbuf_appendlit(v->buf, "$");
+    ecs_strbuf_appendstr(v->buf, node->name);
+    flecs_expr_color_to_str(v, ECS_NORMAL);
+    return 0;
+}
+
+static
+int flecs_expr_member_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_member_t *node)
+{
+    if (flecs_expr_node_to_str(v, node->left)) {
+        return -1;
+    }
+
+    ecs_strbuf_appendlit(v->buf, ".");
+    ecs_strbuf_appendstr(v->buf, node->member_name);
+    return 0;
+}
+
+static
+int flecs_expr_function_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_function_t *node)
+{
+    if (node->left) {
+        if (flecs_expr_node_to_str(v, node->left)) {
+            return -1;
+        }
+        ecs_strbuf_appendlit(v->buf, ".");
+    }
+
+    ecs_strbuf_append(v->buf, "%s(", node->function_name);
+
+    if (node->args) {
+        if (flecs_expr_node_to_str(v, (ecs_expr_node_t*)node->args)) {
+            return -1;
+        }
+    }
+
+    ecs_strbuf_append(v->buf, ")");
+    return 0;
+}
+
+static
+int flecs_expr_element_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_element_t *node)
+{
+    if (flecs_expr_node_to_str(v, node->left)) {
+        return -1;
+    }
+
+    ecs_strbuf_appendlit(v->buf, "[");
+    if (flecs_expr_node_to_str(v, node->index)) {
+        return -1;
+    }
+    ecs_strbuf_appendlit(v->buf, "]");
+    return 0;
+}
+
+static
+int flecs_expr_match_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_match_t *node)
+{
+    if (node->node.type) {
+        flecs_expr_color_to_str(v, ECS_BLUE);
+        const char *name = ecs_get_name(v->world, node->node.type);
+        if (name) {
+            ecs_strbuf_appendstr(v->buf, name);
+        } else {
+            char *path = ecs_get_path(v->world, node->node.type);
+            ecs_strbuf_appendstr(v->buf, path);
+            ecs_os_free(path);
+        }
+        flecs_expr_color_to_str(v, ECS_NORMAL);
+        ecs_strbuf_appendlit(v->buf, "(");
+    }
+
+    flecs_expr_color_to_str(v, ECS_BLUE);
+    ecs_strbuf_appendlit(v->buf, "match ");
+    flecs_expr_color_to_str(v, ECS_GREEN);
+    if (flecs_expr_node_to_str(v, node->expr)) {
+        return -1;
+    }
+
+    ecs_strbuf_appendlit(v->buf, " {\n");
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_match_element_t *elems = ecs_vec_first(&node->elements);
+
+    for (i = 0; i < count; i ++) {
+        ecs_strbuf_appendlit(v->buf, "  ");
+
+        ecs_expr_match_element_t *elem = &elems[i];
+        if (flecs_expr_node_to_str(v, elem->compare)) {
+            return -1;
+        }
+
+        ecs_strbuf_appendlit(v->buf, ": ");
+
+        if (flecs_expr_node_to_str(v, elem->expr)) {
+            return -1;
+        }
+
+        ecs_strbuf_appendlit(v->buf, "\n");
+    }
+
+    ecs_strbuf_appendlit(v->buf, "}");
+
+    if (node->node.type) {
+        ecs_strbuf_appendlit(v->buf, ")");
+    }
+
+    ecs_strbuf_appendlit(v->buf, "\n");
+
+    return 0;
+}
+
+static
+int flecs_expr_cast_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_cast_t *node)
+{
+    ecs_entity_t type = node->node.type;
+    
+    flecs_expr_color_to_str(v, ECS_BLUE);
+    const char *name = ecs_get_name(v->world, type);
+    if (name) {
+        ecs_strbuf_appendstr(v->buf, name);
+    } else {
+        char *path = ecs_get_path(v->world, type);
+        ecs_strbuf_appendstr(v->buf, path);
+        ecs_os_free(path);
+    }
+    flecs_expr_color_to_str(v, ECS_NORMAL);
+    ecs_strbuf_appendlit(v->buf, "(");
+
+    if (flecs_expr_node_to_str(v, node->expr)) {
+        return -1;
+    }
+
+    ecs_strbuf_append(v->buf, ")");
+
+    return 0;
+}
+
+static
+int flecs_expr_node_to_str(
+    ecs_expr_str_visitor_t *v,
+    const ecs_expr_node_t *node)
+{
+    ecs_assert(node != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    switch(node->kind) {
+    case EcsExprValue:
+        if (flecs_expr_value_to_str(v, 
+            (const ecs_expr_value_node_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprInterpolatedString:
+        if (flecs_expr_interpolated_string_to_str(v, 
+            (const ecs_expr_interpolated_string_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprInitializer:
+    case EcsExprEmptyInitializer:
+        if (flecs_expr_initializer_to_str(v, 
+            (const ecs_expr_initializer_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprUnary:
+        if (flecs_expr_unary_to_str(v, 
+            (const ecs_expr_unary_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprBinary:
+        if (flecs_expr_binary_to_str(v, 
+            (const ecs_expr_binary_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprIdentifier:
+        if (flecs_expr_identifier_to_str(v, 
+            (const ecs_expr_identifier_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprVariable:
+    case EcsExprGlobalVariable:
+        if (flecs_expr_variable_to_str(v, 
+            (const ecs_expr_variable_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprFunction:
+    case EcsExprMethod:
+        if (flecs_expr_function_to_str(v, 
+            (const ecs_expr_function_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMember:
+        if (flecs_expr_member_to_str(v, 
+            (const ecs_expr_member_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprElement:
+    case EcsExprComponent:
+        if (flecs_expr_element_to_str(v, 
+            (const ecs_expr_element_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMatch:
+        if (flecs_expr_match_to_str(v, 
+            (const ecs_expr_match_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprCast:
+    case EcsExprCastNumber:
+        if (flecs_expr_cast_to_str(v, 
+            (const ecs_expr_cast_t*)node)) 
+        {
+            goto error;
+        }
+        break;
+    default:
+        ecs_abort(ECS_INTERNAL_ERROR, "invalid node kind");
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+void flecs_expr_to_str_buf(
+    const ecs_world_t *world,
+    const ecs_expr_node_t *expr,
+    ecs_strbuf_t *buf,
+    bool colors)
+{
+    ecs_expr_str_visitor_t v = { .world = world, .buf = buf, .colors = colors };
+    if (flecs_expr_node_to_str(&v, expr)) {
+        ecs_strbuf_reset(buf);
+    }
+}
+
+#endif
+
+/**
+ * @file addons/script/expr_ast.c
+ * @brief Script expression AST implementation.
+ */
+
+
+#ifdef FLECS_SCRIPT
+
+static
+int flecs_expr_visit_type_priv(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc);
+
+bool flecs_expr_is_type_integer(
+    ecs_entity_t type)
+{
+         if (type == ecs_id(ecs_u8_t))     return true;
+    else if (type == ecs_id(ecs_u16_t))    return true;
+    else if (type == ecs_id(ecs_u32_t))    return true;
+    else if (type == ecs_id(ecs_u64_t))    return true;
+    else if (type == ecs_id(ecs_uptr_t))   return true;
+    else if (type == ecs_id(ecs_i8_t))     return true;
+    else if (type == ecs_id(ecs_i16_t))    return true;
+    else if (type == ecs_id(ecs_i32_t))    return true;
+    else if (type == ecs_id(ecs_i64_t))    return true;
+    else if (type == ecs_id(ecs_iptr_t))   return true;
+    else return false;
+}
+
+bool flecs_expr_is_type_number(
+    ecs_entity_t type)
+{
+         if (flecs_expr_is_type_integer(type)) return true;
+    else if (type == ecs_id(ecs_f32_t))        return true;
+    else if (type == ecs_id(ecs_f64_t))        return true;
+    else return false;
+}
+
+/* Returns how expressive a type is. This is used to determine whether an 
+ * implicit cast is allowed, where only casts from less to more expressive types
+ * are valid. */
+static
+int32_t flecs_expr_expressiveness_score(
+    ecs_entity_t type)
+{
+    if      (type == ecs_id(ecs_bool_t))   return 1;
+    else if (type == ecs_id(ecs_char_t))   return 2;
+
+    else if (type == ecs_id(ecs_u8_t))     return 2;
+    else if (type == ecs_id(ecs_u16_t))    return 3;
+    else if (type == ecs_id(ecs_u32_t))    return 4;
+    else if (type == ecs_id(ecs_uptr_t))   return 5;
+    else if (type == ecs_id(ecs_u64_t))    return 6;
+
+    else if (type == ecs_id(ecs_i8_t))     return 7;
+    else if (type == ecs_id(ecs_i16_t))    return 8;
+    else if (type == ecs_id(ecs_i32_t))    return 9;
+    else if (type == ecs_id(ecs_iptr_t))   return 10;
+    else if (type == ecs_id(ecs_i64_t))    return 11;
+
+    else if (type == ecs_id(ecs_f32_t))    return 12;
+    else if (type == ecs_id(ecs_f64_t))    return 13;
+
+    else if (type == ecs_id(ecs_string_t)) return -1;
+    else if (type == ecs_id(ecs_entity_t)) return -1;
+    else return false;
+}
+
+/* Returns a score based on the storage size of a type. This is used in 
+ * combination with expressiveness to determine whether a type can be implicitly
+ * casted. An implicit cast is only valid if the destination type is both more
+ * expressive and has a larger storage size. */
+static
+ecs_size_t flecs_expr_storage_score(
+    ecs_entity_t type)
+{
+    if      (type == ecs_id(ecs_bool_t))   return 1;
+    else if (type == ecs_id(ecs_char_t))   return 1;
+
+    /* Unsigned integers have a larger storage size than signed integers, since
+     * the unsigned range of a signed integer is smaller. */
+    else if (type == ecs_id(ecs_u8_t))     return 2;
+    else if (type == ecs_id(ecs_u16_t))    return 3;
+    else if (type == ecs_id(ecs_u32_t))    return 4;
+    else if (type == ecs_id(ecs_uptr_t))   return 6;
+    else if (type == ecs_id(ecs_u64_t))    return 7;
+
+    else if (type == ecs_id(ecs_i8_t))     return 1;
+    else if (type == ecs_id(ecs_i16_t))    return 2;
+    else if (type == ecs_id(ecs_i32_t))    return 3;
+    else if (type == ecs_id(ecs_iptr_t))   return 5;
+    else if (type == ecs_id(ecs_i64_t))    return 6;
+
+    /* Floating points have a smaller storage score, since the largest integer 
+     * that can be represented exactly is lower than the actual storage size. */
+    else if (type == ecs_id(ecs_f32_t))    return 3;
+    else if (type == ecs_id(ecs_f64_t))    return 4;
+
+    else if (type == ecs_id(ecs_string_t)) return -1;
+    else if (type == ecs_id(ecs_entity_t)) return -1;
+    else return false;
+}
+
+/* This function returns true if an type can be casted without changing the 
+ * precision of the value. It is used to determine a type for operands in a 
+ * binary expression in case they are of different types. */
+static
+bool flecs_expr_implicit_cast_allowed(
+    ecs_entity_t from,
+    ecs_entity_t to)
+{
+    int32_t from_e = flecs_expr_expressiveness_score(from);
+    int32_t to_e = flecs_expr_expressiveness_score(to);
+    if (from_e == -1 || to_e == -1) {
+        return false;
+    }
+
+    if (to_e >= from_e) {
+        return flecs_expr_storage_score(to) >= flecs_expr_storage_score(from);
+    }
+
+    return false;
+}
+
+static
+ecs_entity_t flecs_expr_cast_to_lvalue(
+    ecs_entity_t lvalue,
+    ecs_entity_t operand)
+{
+    if (flecs_expr_implicit_cast_allowed(operand, lvalue)) {
+        return lvalue;
+    }
+
+    return operand;
+}
+
+static
+ecs_entity_t flecs_expr_narrow_type(
+    ecs_entity_t lvalue,
+    ecs_expr_node_t *node)
+{
+    ecs_entity_t type = node->type;
+
+    if (node->kind != EcsExprValue) {
+        return type;
+    }
+
+    if (!flecs_expr_is_type_number(type)) {
+        return type;
+    }
+
+    void *ptr = ((ecs_expr_value_node_t*)node)->ptr;
+
+    uint64_t uval;
+
+    if (type == ecs_id(ecs_u8_t)) {
+        uval = *(ecs_u8_t*)ptr;
+    } else if (type == ecs_id(ecs_u16_t)) {
+        uval = *(ecs_u16_t*)ptr;
+    } else if (type == ecs_id(ecs_u32_t)) {
+        uval = *(ecs_u32_t*)ptr;
+    } else if (type == ecs_id(ecs_u64_t)) {
+        uval = *(ecs_u32_t*)ptr;
+    } else {
+        int64_t ival;
+
+        if (type == ecs_id(ecs_i8_t)) {
+            ival = *(ecs_i8_t*)ptr;
+        } else if (type == ecs_id(ecs_i16_t)) {
+            ival = *(ecs_i16_t*)ptr;
+        } else if (type == ecs_id(ecs_i32_t)) {
+            ival = *(ecs_i32_t*)ptr;
+        } else if (type == ecs_id(ecs_i64_t)) {
+            ival = *(ecs_i64_t*)ptr;
+        } else {
+            /* If the lvalue type is a floating point type we can narrow the
+             * literal to that since we'll lose double precision anyway. */
+            if (lvalue == ecs_id(ecs_f32_t)) {
+                return ecs_id(ecs_f32_t);
+            }
+            return type;
+        }
+
+        if (ival <= INT8_MAX && ival >= INT8_MIN) {
+            return ecs_id(ecs_i8_t);
+        } else if (ival <= INT16_MAX && ival >= INT16_MIN) {
+            return ecs_id(ecs_i16_t);
+        } else if (ival <= INT32_MAX && ival >= INT32_MIN) {
+            return ecs_id(ecs_i32_t);
+        } else {
+            return ecs_id(ecs_i64_t);
+        }
+    }
+
+    if (uval <= UINT8_MAX) {
+        return ecs_id(ecs_u8_t);
+    } else if (uval <= UINT16_MAX) {
+        return ecs_id(ecs_u16_t);
+    } else if (uval <= UINT32_MAX) {
+        return ecs_id(ecs_u32_t);
+    } else {
+        return ecs_id(ecs_u64_t);
+    }
+}
+
+static
+bool flecs_expr_oper_valid_for_type(
+    ecs_world_t *world,
+    ecs_entity_t type,
+    ecs_script_token_kind_t op)
+{
+    switch(op) {
+    case EcsTokAdd:
+    case EcsTokSub:
+    case EcsTokMul:
+    case EcsTokDiv:
+    case EcsTokMod:
+    case EcsTokAddAssign:
+    case EcsTokMulAssign:
+        return flecs_expr_is_type_number(type);
+    case EcsTokBitwiseAnd:
+    case EcsTokBitwiseOr:
+        if (ecs_get(world, type, EcsBitmask) != NULL) {
+            return true;
+        }
+
+        /* fall through */
+    case EcsTokShiftLeft:
+    case EcsTokShiftRight:
+        return flecs_expr_is_type_integer(type);
+    case EcsTokEq:
+    case EcsTokNeq:
+    case EcsTokAnd:
+    case EcsTokOr:
+    case EcsTokGt:
+    case EcsTokGtEq:
+    case EcsTokLt:
+    case EcsTokLtEq:
+        return flecs_expr_is_type_number(type) ||
+            (type == ecs_id(ecs_bool_t)) ||
+            (type == ecs_id(ecs_char_t)) ||
+            (type == ecs_id(ecs_entity_t));
+    case EcsTokUnknown:
+    case EcsTokScopeOpen:
+    case EcsTokScopeClose:
+    case EcsTokParenOpen:
+    case EcsTokParenClose:
+    case EcsTokBracketOpen:
+    case EcsTokBracketClose:
+    case EcsTokMember:
+    case EcsTokComma:
+    case EcsTokSemiColon:
+    case EcsTokColon:
+    case EcsTokAssign:
+    case EcsTokNot:
+    case EcsTokOptional:
+    case EcsTokAnnotation:
+    case EcsTokNewline:
+    case EcsTokMatch:
+    case EcsTokRange:
+    case EcsTokIdentifier:
+    case EcsTokString:
+    case EcsTokNumber:
+    case EcsTokKeywordModule:
+    case EcsTokKeywordUsing:
+    case EcsTokKeywordWith:
+    case EcsTokKeywordIf:
+    case EcsTokKeywordElse:
+    case EcsTokKeywordFor:
+    case EcsTokKeywordIn:
+    case EcsTokKeywordMatch:
+    case EcsTokKeywordTemplate:
+    case EcsTokKeywordProp:
+    case EcsTokKeywordConst:
+    case EcsTokEnd:
+    default: 
+        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+    }
+}
+
+static
+int flecs_expr_type_for_operator(
+    ecs_script_t *script,
+    ecs_expr_node_t *node, /* Only used for error reporting */
+    ecs_entity_t node_type,
+    ecs_expr_node_t *left,
+    ecs_expr_node_t *right,
+    ecs_script_token_kind_t operator,
+    ecs_entity_t *operand_type,
+    ecs_entity_t *result_type)
+{
+    ecs_world_t *world = script->world;
+
+    if (operator == EcsTokDiv || operator == EcsTokMod) {
+        if (right->kind == EcsExprValue) {
+            ecs_expr_value_node_t *val = (ecs_expr_value_node_t*)right;
+            ecs_value_t v = { .type = val->node.type, .ptr = val->ptr };
+            if (flecs_value_is_0(&v)) {
+                flecs_expr_visit_error(script, node, 
+                    "invalid division by zero");
+                return -1;
+            }
+        }
+    }
+
+    switch(operator) {
+    case EcsTokDiv: 
+        /* Result type of a division is always a float */
+        if (left->type != ecs_id(ecs_f32_t) && left->type != ecs_id(ecs_f64_t)){
+            *operand_type = ecs_id(ecs_f64_t);
+            *result_type = ecs_id(ecs_f64_t);
+        } else {
+            *operand_type = left->type;
+            *result_type = left->type;
+        }
+
+        return 0;
+    case EcsTokMod:
+        /* Mod only accepts integer operands, and results in an integer. We 
+         * could disallow doing mod on floating point types, but in practice
+         * that would likely just result in code having to do a manual 
+         * conversion to an integer. */
+        *operand_type = ecs_id(ecs_i64_t);
+        *result_type = ecs_id(ecs_i64_t);
+        return 0;
+    case EcsTokAnd:
+    case EcsTokOr:
+        /* Result type of a condition operator is always a bool */
+        *operand_type = ecs_id(ecs_bool_t);
+        *result_type = ecs_id(ecs_bool_t);
+        return 0;
+    case EcsTokEq:
+    case EcsTokNeq:
+    case EcsTokGt:
+    case EcsTokGtEq:
+    case EcsTokLt:
+    case EcsTokLtEq:
+        /* Result type of equality operator is always bool, but operand types
+         * should not be casted to bool */
+        *result_type = ecs_id(ecs_bool_t);
+        break;
+    case EcsTokShiftLeft:
+    case EcsTokShiftRight:
+    case EcsTokBitwiseAnd:
+    case EcsTokBitwiseOr:
+    case EcsTokAdd:
+    case EcsTokSub:
+    case EcsTokMul:
+        break;
+    case EcsTokAddAssign:
+    case EcsTokMulAssign:
+    case EcsTokUnknown:
+    case EcsTokScopeOpen:
+    case EcsTokScopeClose:
+    case EcsTokParenOpen:
+    case EcsTokParenClose:
+    case EcsTokBracketOpen:
+    case EcsTokBracketClose:
+    case EcsTokMember:
+    case EcsTokComma:
+    case EcsTokSemiColon:
+    case EcsTokColon:
+    case EcsTokAssign:
+    case EcsTokNot:
+    case EcsTokOptional:
+    case EcsTokAnnotation:
+    case EcsTokNewline:
+    case EcsTokMatch:
+    case EcsTokRange:
+    case EcsTokIdentifier:
+    case EcsTokString:
+    case EcsTokNumber:
+    case EcsTokKeywordModule:
+    case EcsTokKeywordUsing:
+    case EcsTokKeywordWith:
+    case EcsTokKeywordIf:
+    case EcsTokKeywordElse:
+    case EcsTokKeywordFor:
+    case EcsTokKeywordIn:
+    case EcsTokKeywordMatch:
+    case EcsTokKeywordTemplate:
+    case EcsTokKeywordProp:
+    case EcsTokKeywordConst:
+    case EcsTokEnd:
+    default:
+        ecs_throw(ECS_INTERNAL_ERROR, "invalid operator");
+    }
+
+    /* If one of the types is an entity or id, the other one should be also */
+    if (left->type == ecs_id(ecs_entity_t) || 
+        right->type == ecs_id(ecs_entity_t)) 
+    {
+        *operand_type = ecs_id(ecs_entity_t);
+        goto done;
+    }
+
+    const EcsPrimitive *ltype_ptr = ecs_get(world, left->type, EcsPrimitive);
+    const EcsPrimitive *rtype_ptr = ecs_get(world, right->type, EcsPrimitive);
+    if (!ltype_ptr || !rtype_ptr) {
+        /* Only primitives, bitmask constants and enums are allowed */
+        if (left->type == right->type) {
+            if (ecs_get(world, left->type, EcsBitmask) != NULL) {
+                *operand_type = left->type;
+                goto done;
+            }
+        }
+
+        {
+            const EcsEnum *ptr = ecs_get(script->world, left->type, EcsEnum);
+            if (ptr) {
+                *operand_type = ptr->underlying_type;
+                goto done;
+            }
+        }
+
+        {
+            const EcsEnum *ptr = ecs_get(script->world, right->type, EcsEnum);
+            if (ptr) {
+                *operand_type = ptr->underlying_type;
+                goto done;
+            }
+        }
+
+        char *lname = ecs_get_path(world, left->type);
+        char *rname = ecs_get_path(world, right->type);
+        flecs_expr_visit_error(script, node, 
+            "invalid non-primitive type in expression (%s, %s)", 
+            lname, rname);
+        ecs_os_free(lname);
+        ecs_os_free(rname);
+        goto error;
+    }
+
+    /* If left and right type are the same, do nothing */
+    if (left->type == right->type) {
+        *operand_type = left->type;
+        goto done;
+    }
+
+    /* If types are not the same, find the smallest type for literals that can
+     * represent the value without losing precision. */
+    ecs_entity_t ltype = flecs_expr_narrow_type(node_type, left);
+    ecs_entity_t rtype = flecs_expr_narrow_type(node_type, right);
+
+    /* If types are not the same, try to implicitly cast to expression type */
+    ltype = flecs_expr_cast_to_lvalue(node_type, ltype);
+    rtype = flecs_expr_cast_to_lvalue(node_type, rtype);
+
+    if (ltype == rtype) {
+        *operand_type = ltype;
+        goto done;
+    }
+
+    if (operator == EcsTokEq || operator == EcsTokNeq) {
+        /* If this is an equality comparison and one of the operands is a bool, 
+         * cast the other operand to a bool as well. This ensures that 
+         * expressions such as true == 2 evaluate to true. */
+        if (ltype == ecs_id(ecs_bool_t) || rtype == ecs_id(ecs_bool_t)) {
+            *operand_type = ecs_id(ecs_bool_t);
+            goto done;
+        }
+
+        /* Equality comparisons between floating point types are invalid */
+        if (ltype == ecs_id(ecs_f32_t) || ltype == ecs_id(ecs_f64_t)) {
+            flecs_expr_visit_error(script, node,
+                "floating point value is invalid in equality comparison");
+            goto error;
+        }
+
+        if (rtype == ecs_id(ecs_f32_t) || rtype == ecs_id(ecs_f64_t)) {
+            flecs_expr_visit_error(script, node,
+                "floating point value is invalid in equality comparison");
+            goto error;
+        }
+    }
+
+    /* If after the implicit cast types are not the same, try to implicitly cast
+     * to the most expressive type. */
+    if (flecs_expr_expressiveness_score(ltype) >= 
+        flecs_expr_expressiveness_score(rtype)) 
+    {
+        if (flecs_expr_implicit_cast_allowed(rtype, ltype)) {
+            *operand_type = ltype;
+            goto done;
+        }
+    } else {
+        if (flecs_expr_implicit_cast_allowed(ltype, rtype)) {
+            *operand_type = rtype;
+            goto done;
+        }
+    }
+
+    /* If we get here one or both operands cannot be coerced to the same type
+     * while guaranteeing no loss of precision. Pick the type that's least 
+     * likely to cause trouble. */
+
+    if (flecs_expr_is_type_number(ltype) && flecs_expr_is_type_number(rtype)) {
+
+        /* If one of the types is a floating point, use f64 */
+        if (ltype == ecs_id(ecs_f32_t) || ltype == ecs_id(ecs_f64_t) ||
+            rtype == ecs_id(ecs_f32_t) || rtype == ecs_id(ecs_f64_t))
+        {
+            *operand_type = ecs_id(ecs_f64_t);
+            goto done;
+        }
+
+        /* If one of the types is an integer, use i64 */
+        if (ltype == ecs_id(ecs_i8_t) || ltype == ecs_id(ecs_i16_t) ||
+            ltype == ecs_id(ecs_i32_t) || ltype == ecs_id(ecs_i64_t))
+        {
+            *operand_type = ecs_id(ecs_i64_t);
+            goto done;
+        }
+        if (rtype == ecs_id(ecs_i8_t) || rtype == ecs_id(ecs_i16_t) ||
+            rtype == ecs_id(ecs_i32_t) || rtype == ecs_id(ecs_i64_t))
+        {
+            *operand_type = ecs_id(ecs_i64_t);
+            goto done;
+        }
+    }
+
+    /* If all of that didn't work, give up */
+
+    char *ltype_str = ecs_id_str(world, ltype);
+    char *rtype_str = ecs_id_str(world, rtype);
+    flecs_expr_visit_error(script, node,
+        "incompatible types in expression (%s vs %s)", 
+            ltype_str, rtype_str);
+    ecs_os_free(ltype_str);
+    ecs_os_free(rtype_str);
+error:
+    return -1;
+
+done:
+    if (operator == EcsTokSub && *operand_type == ecs_id(ecs_u64_t)) {
+        /* Result of subtracting two unsigned ints can be negative */
+        *operand_type = ecs_id(ecs_i64_t);
+    }
+
+    if (!*result_type) {
+        *result_type = *operand_type;
+    }
+
+    if (ecs_get(script->world, *result_type, EcsBitmask) != NULL) {
+        *operand_type = ecs_id(ecs_u64_t);
+    }
+
+    return 0;
+}
+
+static
+int flecs_expr_type_for_binary_expr(
+    ecs_script_t *script,
+    ecs_expr_binary_t *node,
+    ecs_entity_t *operand_type,
+    ecs_entity_t *result_type)
+{
+    return flecs_expr_type_for_operator(script, (ecs_expr_node_t*)node, 
+        node->node.type, node->left, node->right, node->operator, 
+        operand_type, result_type);
+}
+
+static
+int flecs_expr_interpolated_string_visit_type(
+    ecs_script_t *script,
+    ecs_expr_interpolated_string_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    char *ptr, *frag = NULL;
+    char ch;
+
+    for (ptr = node->value; (ch = ptr[0]); ptr ++) {
+        if (ch == '\\') {
+            ptr ++;
+            /* Next character is escaped, ignore */
+            continue;
+        }
+
+        if ((ch == '$') && (isspace(ptr[1]) || !ptr[1])) {
+            /* $ by itself */
+            continue;
+        }
+
+        if (ch == '$' || ch == '{') {
+            if (!frag) {
+                frag = node->value;
+            }
+
+            char *frag_end = ptr;
+
+            ecs_expr_node_t *result = NULL;
+
+            if (ch == '$') {
+                char *var_name = ++ ptr;
+                ptr = ECS_CONST_CAST(char*, flecs_script_identifier(
+                    NULL, ptr, NULL));
+                if (!ptr) {
+                    goto error;
+                }
+
+                /* Fiddly, but reduces need for allocations */
+                ecs_size_t var_name_pos = flecs_ito(int32_t, var_name - node->value);
+                var_name = &node->buffer[var_name_pos];
+                ecs_size_t var_name_end = flecs_ito(int32_t, ptr - node->value);
+                node->buffer[var_name_end] = '\0';
+
+                ecs_expr_variable_t *var = flecs_expr_variable_from(
+                    script, (ecs_expr_node_t*)node, var_name);
+                if (!var) {
+                    goto error;
+                }
+
+                result = (ecs_expr_node_t*)var;
+            } else {
+                ecs_script_impl_t *impl = flecs_script_impl(script);
+
+                ecs_script_parser_t parser = {
+                    .script = impl,
+                    .scope = impl->root,
+                    .significant_newline = false,
+                    .token_cur = impl->token_remaining
+                };
+
+                ptr = ECS_CONST_CAST(char*, flecs_script_parse_expr(
+                    &parser, ptr + 1, 0, &result));
+                if (!ptr) {
+                    goto error;
+                }
+
+                if (ptr[0] != '}') {
+                    flecs_expr_visit_error(script, node,
+                        "expected '}' at end of interpolated expression");
+                    goto error;
+                }
+
+                ptr ++;
+            }
+
+            ecs_assert(result != NULL, ECS_INTERNAL_ERROR, NULL);
+
+            ecs_expr_eval_desc_t priv_desc = *desc;
+            priv_desc.type = ecs_id(ecs_string_t); /* String output */
+
+            if (flecs_expr_visit_type_priv(script, result, cur, &priv_desc)) {
+                flecs_expr_visit_free(script, result);
+                goto error;
+            }
+
+            if (result->type != ecs_id(ecs_string_t)) {
+                result = (ecs_expr_node_t*)flecs_expr_cast(script, 
+                    (ecs_expr_node_t*)result, ecs_id(ecs_string_t));
+                if (!result) {
+                    /* Cast failed */
+                    goto error;
+                }
+            }
+
+            ecs_vec_append_t(&((ecs_script_impl_t*)script)->allocator, 
+                &node->expressions, ecs_expr_node_t*)[0] = result;
+
+            frag_end[0] = '\0';
+
+            if (frag != frag_end) {
+                ecs_vec_append_t(&((ecs_script_impl_t*)script)->allocator, 
+                    &node->fragments, char*)[0] = frag;
+            }
+
+            ecs_vec_append_t(&((ecs_script_impl_t*)script)->allocator, 
+                &node->fragments, char*)[0] = NULL;
+
+            frag = ptr; /* Point to next fragment */
+            if (!ptr[0]) {
+                break; /* We already parsed the end of the string */
+            }
+        }
+    }
+
+    /* This would mean it's not an interpolated string, which means the parser
+     * messed up when creating the node. */
+    ecs_assert(frag != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    /* Add remaining fragment */
+    if (frag != ptr) {
+        ecs_vec_append_t(&((ecs_script_impl_t*)script)->allocator, 
+            &node->fragments, char*)[0] = frag;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_collection_check(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    ecs_meta_cursor_t *cur)
+{
+    if (cur) {
+        if (ecs_meta_is_collection(cur) != node->is_collection) {
+            char *type_str = ecs_get_path(script->world, node->node.type);
+            if (node->is_collection) {
+                flecs_expr_visit_error(script, node, 
+                    "invalid collection literal for non-collection type '%s'", 
+                        type_str);
+            } else {
+                flecs_expr_visit_error(script, node, 
+                    "invalid object literal for collection type '%s'",
+                        type_str);
+            }
+
+            ecs_os_free(type_str);
+            goto error;
+        }
+    }
+
+    ecs_entity_t type = node->node.type;
+    if (type) {
+        const EcsOpaque *op = ecs_get(script->world, type, EcsOpaque);
+        if (op) {
+            type = op->as_type;
+        }
+
+        const EcsType *ptr = ecs_get(script->world, type, EcsType);
+        if (ptr) {
+            ecs_type_kind_t kind = ptr->kind;
+            if (node->is_collection) {
+                /* Only do this check if no cursor is provided. Cursors also 
+                 * handle inline arrays. */
+                if (!cur) {
+                    if (kind != EcsArrayType && kind != EcsVectorType) {
+                        char *type_str = ecs_get_path(
+                            script->world, node->node.type);
+                        flecs_expr_visit_error(script, node, 
+                            "invalid collection literal for type '%s'",
+                                type_str);
+                        ecs_os_free(type_str);
+                        goto error;
+                    }
+                }
+            } else {
+                if (kind != EcsStructType) {
+                    char *type_str = ecs_get_path(
+                        script->world, node->node.type);
+                    flecs_expr_visit_error(script, node, 
+                        "invalid object literal for type '%s'", type_str);
+                    ecs_os_free(type_str);
+                    goto error;
+                }
+            }
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_empty_initializer_visit_type(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)desc;
+
+    node->node.type = ecs_meta_get_type(cur);
+    if (!node->node.type) {
+        flecs_expr_visit_error(script, node, 
+            "unknown type for initializer");
+        goto error;
+    }
+
+    if (ecs_meta_push(cur)) {
+        goto error;
+    }
+
+    if (flecs_expr_initializer_collection_check(script, node, cur)) {
+        goto error;
+    }
+
+    if (ecs_meta_pop(cur)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_initializer_visit_type(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    if (!cur || !cur->valid) {
+        flecs_expr_visit_error(script, node, "missing type for initializer");
+        goto error;
+    }
+
+    ecs_entity_t type = ecs_meta_get_type(cur);
+    ecs_assert(type != 0, ECS_INTERNAL_ERROR, NULL);
+
+    /* Opaque types do not have deterministic offsets */
+    bool is_opaque = ecs_get(script->world, type, EcsOpaque) != NULL;
+    node->is_dynamic = is_opaque;
+
+    if (ecs_meta_push(cur)) {
+        goto error;
+    }
+
+    if (flecs_expr_initializer_collection_check(script, node, cur)) {
+        goto error;
+    }
+
+
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+    for (i = 0; i < count; i ++) {
+        if (i) {
+            if (ecs_meta_next(cur)) { /* , */
+                goto error;
+            }
+        }
+
+        ecs_expr_initializer_element_t *elem = &elems[i];
+        if (elem->member) {
+            if (ecs_meta_dotmember(cur, elem->member)) { /* x: */
+                flecs_expr_visit_error(script, node, "cannot resolve member");
+                goto error;
+            }
+        }
+
+        /* Check for "member: $" syntax */
+        if (elem->value->kind == EcsExprVariable) {
+            ecs_expr_variable_t *var = (ecs_expr_variable_t*)elem->value;
+            if (var->name && !var->name[0]) {
+                var->name = ecs_meta_get_member(cur);
+                if (!var->name) {
+                    flecs_expr_visit_error(script, node, 
+                        "cannot deduce variable name: not a member");
+                    goto error;
+                }
+            }
+        }
+
+        ecs_entity_t elem_type = ecs_meta_get_type(cur);
+        ecs_meta_cursor_t elem_cur = *cur;
+        if (flecs_expr_visit_type_priv(
+            script, elem->value, &elem_cur, desc)) 
+        {
+            goto error;
+        }
+
+        if (elem->value->type != elem_type) {
+            ecs_expr_node_t *cast = (ecs_expr_node_t*)flecs_expr_cast(
+                script, elem->value, elem_type);
+            if (!cast) {
+                goto error;
+            }
+            elem->value = cast;
+        }
+
+        if (elem->operator) {
+            if (!flecs_expr_oper_valid_for_type(
+                script->world, elem_type, elem->operator))
+            {
+                char *type_str = ecs_get_path(script->world, elem_type);
+                flecs_expr_visit_error(script, node, 
+                    "invalid operator for type '%s'", type_str);
+                ecs_os_free(type_str);
+                goto error;
+            }
+        }
+
+        if (!is_opaque) {
+            elem->offset = (uintptr_t)ecs_meta_get_ptr(cur);
+        }
+    }
+
+    node->node.type = type;
+
+    if (ecs_meta_pop(cur)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_unary_visit_type(
+    ecs_script_t *script,
+    ecs_expr_unary_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    if (flecs_expr_visit_type_priv(script, node->expr, cur, desc)) {
+        goto error;
+    }
+
+    /* The only supported unary expression is not (!) which returns a bool */
+    node->node.type = ecs_id(ecs_bool_t);
+
+    if (node->expr->type != ecs_id(ecs_bool_t)) {
+        node->expr = (ecs_expr_node_t*)flecs_expr_cast(
+            script, node->expr, ecs_id(ecs_bool_t));
+        if (!node->expr) {
+            goto error;
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_binary_visit_type(
+    ecs_script_t *script,
+    ecs_expr_binary_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{    
+    /* Operands must be of this type or casted to it */
+    ecs_entity_t operand_type = 0;
+
+    /* Resulting type of binary expression */
+    ecs_entity_t result_type = 0;
+
+    if (cur->valid) {
+        /* Provides a hint to the type visitor. The lvalue type will be used to
+         * reduce the number of casts where possible. */
+        node->node.type = ecs_meta_get_type(cur);
+
+        /* If the result of the binary expression is a boolean it's likely a 
+         * conditional expression. We don't want to hint that the operands 
+         * of conditional expressions should be casted to booleans. */
+        if (node->node.type == ecs_id(ecs_bool_t)) {
+            ecs_os_zeromem(cur);
+        }
+    }
+
+    if (flecs_expr_visit_type_priv(script, node->left, cur, desc)) {
+        goto error;
+    }
+
+    if (flecs_expr_visit_type_priv(script, node->right, cur, desc)) {
+        goto error;
+    }
+
+    if (flecs_expr_type_for_binary_expr(
+        script, node, &operand_type, &result_type)) 
+    {
+        goto error;
+    }
+
+    if (!flecs_expr_oper_valid_for_type(
+        script->world, result_type, node->operator)) 
+    {
+        char *type_str = ecs_get_path(script->world, result_type);
+        flecs_expr_visit_error(script, node, "invalid operator %s for type '%s'",
+            flecs_script_token_str(node->operator), type_str);
+        ecs_os_free(type_str);
+        goto error;
+    }
+
+    if (operand_type != node->left->type) {
+        node->left = (ecs_expr_node_t*)flecs_expr_cast(
+            script, node->left, operand_type);
+        if (!node->left) {
+            goto error;
+        }
+    }
+
+    if (operand_type != node->right->type) {
+        node->right = (ecs_expr_node_t*)flecs_expr_cast(
+            script, node->right, operand_type);
+        if (!node->right) {
+            goto error;
+        }
+    }
+
+    node->node.type = result_type;
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_constant_identifier_visit_type(
+    ecs_script_t *script,
+    ecs_expr_identifier_t *node)
+{
+    ecs_expr_value_node_t *result = flecs_expr_value_from(
+        script, (ecs_expr_node_t*)node, node->node.type);
+
+    ecs_meta_cursor_t expr_cur = ecs_meta_cursor(
+        script->world, node->node.type, &result->storage.u64);
+    if (ecs_meta_set_string(&expr_cur, node->value)) {
+        flecs_expr_visit_free(script, (ecs_expr_node_t*)result);
+        goto error;
+    }
+
+    result->ptr = &result->storage.u64;
+    node->expr = (ecs_expr_node_t*)result;
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_identifier_visit_type(
+    ecs_script_t *script,
+    ecs_expr_identifier_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)desc;
+
+    ecs_entity_t type = node->node.type;
+    if (cur->valid) {
+        type = ecs_meta_get_type(cur);
+    }
+
+    const EcsType *type_ptr = NULL;
+    if (type) {
+        type_ptr = ecs_get(script->world, type, EcsType);
+        ecs_assert(type_ptr != NULL, ECS_INTERNAL_ERROR, NULL);
+    }
+
+    if (type_ptr && 
+       (type_ptr->kind == EcsEnumType || type_ptr->kind == EcsBitmaskType)) 
+    {
+        /* If the requested type is an enum or bitmask, use cursor to resolve 
+        * identifier to correct type constant. This lets us type 'Red' in places
+        * where we expect a value of type Color, instead of Color.Red. */
+        node->node.type = type;
+        if (flecs_expr_constant_identifier_visit_type(script, node)) {
+            goto error;
+        }
+
+        return 0;
+    } else {
+        /* If not, try to resolve the identifier as entity */
+        ecs_entity_t e = desc->lookup_action(
+            script->world, node->value, desc->lookup_ctx);
+        if (e) {
+            const EcsScriptConstVar *global = ecs_get(
+                script->world, e, EcsScriptConstVar);
+            if (!global) {
+                if (!type) {
+                    type = ecs_id(ecs_entity_t);
+                }
+
+                ecs_expr_value_node_t *result = flecs_expr_value_from(
+                    script, (ecs_expr_node_t*)node, type);
+                result->storage.entity = e;
+                result->ptr = &result->storage.entity;
+                node->expr = (ecs_expr_node_t*)result;
+                node->node.type = type;
+            } else {
+                ecs_expr_variable_t *var_node = flecs_expr_variable_from(
+                    script, (ecs_expr_node_t*)node, node->value);
+                node->expr = (ecs_expr_node_t*)var_node;
+                node->node.type = global->value.type;
+
+                ecs_meta_cursor_t tmp_cur; ecs_os_zeromem(&tmp_cur);
+                if (flecs_expr_visit_type_priv(
+                    script, (ecs_expr_node_t*)var_node, &tmp_cur, desc))
+                {
+                    goto error;
+                }
+            }
+
+            return 0;
+        }
+
+        /* If identifier could not be resolved as entity, try as variable */
+        int32_t var_sp = -1;
+        ecs_script_var_t *var = flecs_script_find_var(
+            desc->vars, node->value, &var_sp);
+        if (var) {
+            ecs_expr_variable_t *var_node = flecs_expr_variable_from(
+                script, (ecs_expr_node_t*)node, node->value);
+            node->expr = (ecs_expr_node_t*)var_node;
+            node->node.type = var->value.type;
+
+            ecs_meta_cursor_t tmp_cur; ecs_os_zeromem(&tmp_cur);
+            if (flecs_expr_visit_type_priv(
+                script, (ecs_expr_node_t*)var_node, &tmp_cur, desc))
+            {
+                goto error;
+            }
+
+            return 0;
+        }
+
+        /* If unresolved identifiers aren't allowed here, throw error */
+        if (!desc->allow_unresolved_identifiers) {
+            flecs_expr_visit_error(script, node, 
+                "unresolved identifier '%s'", node->value);
+            goto error;
+        }
+
+        /* Identifier will be resolved at eval time, default to entity */
+        node->node.type = ecs_id(ecs_entity_t);
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_global_variable_resolve(
+    ecs_script_t *script,
+    ecs_expr_variable_t *node,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_world_t *world = script->world;
+    ecs_entity_t global = desc->lookup_action(
+        world, node->name, desc->lookup_ctx);
+    if (!global) {
+        flecs_expr_visit_error(script, node, "unresolved variable '%s'",
+            node->name);
+        goto error;
+    }
+
+    const EcsScriptConstVar *v = ecs_get(world, global, EcsScriptConstVar);
+    if (!v) {
+        char *str = ecs_get_path(world, global);
+        flecs_expr_visit_error(script, node, 
+            "entity '%s' is not a variable", node->name);
+        ecs_os_free(str);
+        goto error;
+    }
+
+    node->node.kind = EcsExprGlobalVariable;
+    node->node.type = v->value.type;
+    node->global_value = v->value;
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_variable_visit_type(
+    ecs_script_t *script,
+    ecs_expr_variable_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_script_var_t *var = flecs_script_find_var(
+        desc->vars, node->name, &node->sp);
+    if (var) {
+        node->node.type = var->value.type;
+        if (!node->node.type) {
+            flecs_expr_visit_error(script, node, 
+                "variable '%s' is not initialized", node->name);
+            goto error;
+        }
+    } else {
+        if (flecs_expr_global_variable_resolve(script, node, desc)) {
+            goto error;
+        }
+    }
+
+    *cur = ecs_meta_cursor(script->world, node->node.type, NULL);
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_global_variable_visit_type(
+    ecs_script_t *script,
+    ecs_expr_variable_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    (void)cur;
+
+    if (flecs_expr_global_variable_resolve(script, node, desc)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_arguments_visit_type(
+    ecs_script_t *script,
+    ecs_expr_initializer_t *node,
+    const ecs_expr_eval_desc_t *desc,
+    const ecs_vec_t *param_vec)
+{
+    ecs_expr_initializer_element_t *elems = ecs_vec_first(&node->elements);
+    int32_t i, count = ecs_vec_count(&node->elements);
+
+    if (count != ecs_vec_count(param_vec)) {
+        flecs_expr_visit_error(script, node, "expected %d arguments, got %d",
+            ecs_vec_count(param_vec), count);
+        goto error;
+    }
+
+    ecs_script_parameter_t *params = ecs_vec_first(param_vec);
+
+    for (i = 0; i < count; i ++) {
+        ecs_expr_initializer_element_t *elem = &elems[i];
+
+        ecs_meta_cursor_t cur = ecs_meta_cursor(
+            script->world, params[i].type, NULL);
+
+        if (flecs_expr_visit_type_priv(script, elem->value, &cur, desc)){
+            goto error;
+        }
+
+        if (elem->value->type != params[i].type) {
+            elem->value = (ecs_expr_node_t*)flecs_expr_cast(
+                script, elem->value, params[i].type);
+            if (!elem->value) {
+                goto error;
+            }
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_function_visit_type(
+    ecs_script_t *script,
+    ecs_expr_function_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    bool is_method = false;
+    char *last_elem = NULL;
+    const char *func_identifier = NULL;
+
+    if (node->left->kind == EcsExprIdentifier) {
+        /* If identifier contains '.' separator(s), this is a method call, 
+         * otherwise it's a regular function. */
+        ecs_expr_identifier_t *ident = (ecs_expr_identifier_t*)node->left;
+        func_identifier = ident->value;
+
+        last_elem = strrchr(func_identifier, '.');
+        if (last_elem && last_elem != ident->value && last_elem[-1] != '\\') {
+            node->function_name = last_elem + 1;
+            last_elem[0] = '\0';
+            is_method = true;
+        } else {
+            node->function_name = ident->value;   
+        }
+
+    } else if (node->left->kind == EcsExprMember) {
+        /* This is a method. Just like identifiers, method strings can contain
+         * separators. Split off last separator to get the method. */
+        ecs_expr_member_t *member = (ecs_expr_member_t*)node->left;
+        last_elem = strrchr(member->member_name, '.');
+        if (!last_elem) {
+            node->left = member->left;
+            node->function_name = member->member_name;
+
+            member->left = NULL; /* Prevent cleanup */
+            flecs_expr_visit_free(script, (ecs_expr_node_t*)member);
+        } else {
+            node->function_name = last_elem + 1;
+            last_elem[0] = '\0';
+        }
+        is_method = true;
+    }
+
+    /* Left of function expression should not inherit lvalue type, since the
+     * function return type is what's going to be assigned. */
+    ecs_os_zeromem(cur);
+
+    if (flecs_expr_visit_type_priv(script, node->left, cur, desc)) {
+        goto error;
+    }
+
+    ecs_world_t *world = script->world;
+    const ecs_vec_t *params = NULL;
+
+    /* If this is a method, lookup function entity in scope of type */
+    if (is_method) {
+        ecs_entity_t func = ecs_lookup_from(
+            world, node->left->type, node->function_name);
+        if (!func) {
+            /* If identifier could be a function (not a method) try that */
+            if (func_identifier) {
+                is_method = false;
+                last_elem[0] = '.';
+                node->function_name = func_identifier;
+                goto try_function;
+            }
+
+            char *type_str = ecs_get_path(world, node->left->type);
+            flecs_expr_visit_error(script, node, 
+                "unresolved method identifier '%s' for type '%s'", 
+                node->function_name, type_str);
+            ecs_os_free(type_str);
+            goto error;
+        }
+
+        const EcsScriptMethod *func_data = ecs_get(
+            world, func, EcsScriptMethod);
+        if (!func_data) {
+            char *path = ecs_get_path(world, func);
+            flecs_expr_visit_error(script, node, 
+                "entity '%s' is not a valid method", path);
+            ecs_os_free(path);
+            goto error;
+        }
+
+        node->node.kind = EcsExprMethod;
+        node->node.type = func_data->return_type;
+        node->calldata.function = func;
+        node->calldata.callback = func_data->callback;
+        node->calldata.ctx = func_data->ctx;
+        params = &func_data->params;
+    }
+
+try_function:
+    if (!is_method) {
+        ecs_entity_t func = desc->lookup_action(
+            world, node->function_name, desc->lookup_ctx);
+        if (!func) {
+            flecs_expr_visit_error(script, node, 
+                "unresolved function identifier '%s'", 
+                node->function_name);
+            goto error;
+        }
+
+        const EcsScriptFunction *func_data = ecs_get(
+            world, func, EcsScriptFunction);
+        if (!func_data) {
+            char *path = ecs_get_path(world, func);
+            flecs_expr_visit_error(script, node, 
+                "entity '%s' is not a valid method", path);
+            ecs_os_free(path);
+            goto error;
+        }
+
+        node->node.type = func_data->return_type;
+        node->calldata.function = func;
+        node->calldata.callback = func_data->callback;
+        node->calldata.ctx = func_data->ctx;
+        params = &func_data->params;
+    }
+
+    if (flecs_expr_arguments_visit_type(script, node->args, desc, params)) {
+        goto error;
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_member_visit_type(
+    ecs_script_t *script,
+    ecs_expr_member_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    if (flecs_expr_visit_type_priv(script, node->left, cur, desc)) {
+        goto error;
+    }
+
+    ecs_world_t *world = script->world;
+    ecs_entity_t left_type = node->left->type;
+
+    const EcsType *type = ecs_get(world, left_type, EcsType);
+    if (!type) {
+        char *type_str = ecs_get_path(world, left_type);
+        flecs_expr_visit_error(script, node, 
+            "cannot resolve member on value of type '%s' "
+                "(missing reflection data)", type_str);
+        ecs_os_free(type_str);
+        goto error;
+    }
+
+    if (type->kind != EcsStructType) {
+        char *type_str = ecs_get_path(world, left_type);
+        flecs_expr_visit_error(script, node, 
+            "cannot resolve member on non-struct type '%s'", type_str);
+        ecs_os_free(type_str);
+        goto error;
+    }
+
+    if (ecs_meta_push(cur)) {
+        goto error;
+    }
+
+    int prev_log = ecs_log_set_level(-4);
+    if (ecs_meta_dotmember(cur, node->member_name)) {
+        ecs_log_set_level(prev_log);
+        char *type_str = ecs_get_path(world, left_type);
+        flecs_expr_visit_error(script, node, 
+            "unresolved member '%s' for type '%s'", 
+                node->member_name, type_str);
+        ecs_os_free(type_str);
+        goto error;
+    }
+    ecs_log_set_level(prev_log);
+
+    node->node.type = ecs_meta_get_type(cur);
+#ifdef FLECS_DEBUG
+    const EcsMember *m = ecs_get(world, ecs_meta_get_member_id(cur), EcsMember);
+    ecs_assert(m != NULL, ECS_INTERNAL_ERROR, NULL);
+#endif
+    node->offset = (uintptr_t)ecs_meta_get_ptr(cur);
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_element_visit_type(
+    ecs_script_t *script,
+    ecs_expr_element_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    if (flecs_expr_visit_type_priv(script, node->left, cur, desc)) {
+        goto error;
+    }
+
+    ecs_meta_cursor_t index_cur = {0};
+    if (flecs_expr_visit_type_priv(
+        script, node->index, &index_cur, desc)) 
+    {
+        goto error;
+    }
+
+    ecs_world_t *world = script->world;
+    ecs_entity_t left_type = node->left->type;
+
+    const EcsType *type = ecs_get(world, left_type, EcsType);
+    if (!type) {
+        char *type_str = ecs_get_path(world, left_type);
+        flecs_expr_visit_error(script, node, 
+            "cannot use [] on value of type '%s' (missing reflection data)",
+                type_str);
+        ecs_os_free(type_str);
+        goto error;
+    }
+
+    bool is_entity_type = false;
+
+    if (type->kind == EcsPrimitiveType) {
+        const EcsPrimitive *ptype = ecs_get(world, left_type, EcsPrimitive);
+        if (ptype->kind == EcsEntity) {
+            is_entity_type = true;
+        }
+    }
+
+    if (is_entity_type) {
+        if (node->index->kind == EcsExprIdentifier) {
+            ecs_expr_identifier_t *ident = (ecs_expr_identifier_t*)node->index;
+            node->node.type = desc->lookup_action(
+                script->world, ident->value, desc->lookup_ctx);
+            if (!node->node.type) {
+                flecs_expr_visit_error(script, node, 
+                    "unresolved component identifier '%s'",
+                        ident->value);
+                goto error;
+            }
+
+            node->node.kind = EcsExprComponent;
+
+            *cur = ecs_meta_cursor(script->world, node->node.type, NULL);
+        } else {
+            flecs_expr_visit_error(script, node, 
+                "invalid component expression");
+            goto error;
+        }
+    } else {
+        if (ecs_meta_push(cur)) {
+            goto not_a_collection;
+        }
+
+        if (!ecs_meta_is_collection(cur)) {
+            goto not_a_collection;
+        }
+
+        node->node.type = ecs_meta_get_type(cur);
+
+        const ecs_type_info_t *elem_ti = ecs_get_type_info(
+            script->world, node->node.type);
+        node->elem_size = elem_ti->size;
+    }
+
+    return 0;
+
+not_a_collection: {
+    char *type_str = ecs_get_path(script->world, node->left->type);
+    flecs_expr_visit_error(script, node, 
+        "invalid usage of [] on non collection/entity type '%s'", type_str);
+    ecs_os_free(type_str);
+}
+error:
+    return -1;
+}
+
+static
+bool flecs_expr_identifier_is_any(
+    ecs_expr_node_t *node)
+{
+    if (node->kind == EcsExprIdentifier) {
+        ecs_expr_identifier_t *id = (ecs_expr_identifier_t*)node;
+        if (id->value && !ecs_os_strcmp(id->value, "_")) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static
+int flecs_expr_match_visit_type(
+    ecs_script_t *script,
+    ecs_expr_match_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_assert(node != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    ecs_meta_cursor_t expr_cur;
+    ecs_os_zeromem(&expr_cur);
+    if (flecs_expr_visit_type_priv(script, node->expr, &expr_cur, desc)) {
+        goto error;
+    }
+
+    int32_t i, count = ecs_vec_count(&node->elements);
+    ecs_expr_match_element_t *elems = ecs_vec_first(&node->elements);
+
+    if (!count) {
+        flecs_expr_visit_error(script, node, 
+            "match statement must have at least one case");
+        goto error;
+    }
+
+    /* Determine most expressive type of all elements */
+    node->node.type = ecs_meta_get_type(cur);
+
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+
+        if (node->node.type) {
+            expr_cur = ecs_meta_cursor(script->world, node->node.type, NULL);
+        } else {
+            ecs_os_zeromem(&expr_cur);
+        }
+
+        if (flecs_expr_visit_type_priv(script, elem->expr, &expr_cur, desc)) {
+            goto error;
+        }
+
+        if (!node->node.type) {
+            node->node.type = elem->expr->type;
+            continue;
+        }
+
+        if (flecs_expr_is_type_number(node->node.type)) {
+            ecs_entity_t result_type = 0, operand_type = 0;
+            if (flecs_expr_type_for_operator(script, (ecs_expr_node_t*)node, 0, 
+                (ecs_expr_node_t*)node, elem->expr, 
+                EcsTokAdd, /* Use operator that doesn't change types */
+                &operand_type, &result_type))
+            {
+                goto error;
+            }
+
+            /* "Accumulate" most expressive type in result node */
+            node->node.type = result_type;
+        } else {
+            /* If type is not a number it must match exactly */
+            if (elem->expr->type != node->node.type) {
+                char *got = ecs_get_path(script->world, elem->expr->type);
+                char *expect = ecs_get_path(script->world, node->node.type);
+                flecs_expr_visit_error(script, node, 
+                    "invalid type for case %d in match (got %s, expected %s)",
+                        i + 1, got, expect);
+                ecs_os_free(got);
+                ecs_os_free(expect);
+                goto error;
+            }
+        }
+    }
+
+    /* Loop over elements again, cast values to result type */
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+        if (elem->expr->type != node->node.type) {
+            elem->expr = (ecs_expr_node_t*)
+                flecs_expr_cast(script, elem->expr, node->node.type);
+            if (!elem->expr) {
+                goto error;
+            }
+        }
+    }
+
+    /* If this is an enum type, cast to the underlying type. This is necessary
+     * because the compare operation executed by the match evaluation code isn't
+     * implemented for enums. */
+    ecs_entity_t expr_type = node->expr->type;
+    const EcsEnum *ptr = ecs_get(script->world, expr_type, EcsEnum);
+    if (ptr) {
+        node->expr = (ecs_expr_node_t*)
+            flecs_expr_cast(script, node->expr, ptr->underlying_type);
+    }
+
+    /* Make sure that case values match the input type */
+    for (i = 0; i < count; i ++) {
+        ecs_expr_match_element_t *elem = &elems[i];
+
+        if (flecs_expr_identifier_is_any(elem->compare)) {
+            if (i != count - 1) {
+                flecs_expr_visit_error(script, node, 
+                    "any (_) must be the last case in match");
+                goto error;
+            }
+
+            node->any.compare = elem->compare;
+            node->any.expr = elem->expr;
+            ecs_vec_remove_last(&node->elements);
+        } else {
+            expr_cur = ecs_meta_cursor(script->world, expr_type, NULL);
+            if (flecs_expr_visit_type_priv(
+                script, elem->compare, &expr_cur, desc)) 
+            {
+                goto error;
+            }
+
+            ecs_expr_node_t *compare = elem->compare;
+            if (compare->type != node->expr->type) {
+                elem->compare = (ecs_expr_node_t*)
+                    flecs_expr_cast(script, compare, node->expr->type);
+                if (!elem->compare) {
+                    goto error;
+                }
+            }
+        }
+    }
+
+    return 0;
+error:
+    return -1;
+}
+
+static
+int flecs_expr_visit_type_priv(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    ecs_meta_cursor_t *cur,
+    const ecs_expr_eval_desc_t *desc)
+{
+    ecs_assert(node != NULL, ECS_INVALID_PARAMETER, NULL);
+
+    switch(node->kind) {
+    case EcsExprValue:
+        break;
+    case EcsExprInterpolatedString:
+        if (flecs_expr_interpolated_string_visit_type(
+            script, (ecs_expr_interpolated_string_t*)node, cur, desc))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprEmptyInitializer:
+        if (flecs_expr_empty_initializer_visit_type(
+            script, (ecs_expr_initializer_t*)node, cur, desc))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprInitializer:
+        if (flecs_expr_initializer_visit_type(
+            script, (ecs_expr_initializer_t*)node, cur, desc))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprUnary:
+        if (flecs_expr_unary_visit_type(
+            script, (ecs_expr_unary_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprBinary:
+        if (flecs_expr_binary_visit_type(
+            script, (ecs_expr_binary_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprIdentifier:
+        if (flecs_expr_identifier_visit_type(
+            script, (ecs_expr_identifier_t*)node, cur, desc))
+        {
+            goto error;
+        }
+        break;
+    case EcsExprVariable:
+        if (flecs_expr_variable_visit_type(
+            script, (ecs_expr_variable_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprGlobalVariable:
+        if (flecs_expr_global_variable_visit_type(
+            script, (ecs_expr_variable_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprFunction:
+        if (flecs_expr_function_visit_type(
+            script, (ecs_expr_function_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMember:
+        if (flecs_expr_member_visit_type(
+            script, (ecs_expr_member_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprElement:
+        if (flecs_expr_element_visit_type(
+            script, (ecs_expr_element_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprMatch:
+        if (flecs_expr_match_visit_type(
+            script, (ecs_expr_match_t*)node, cur, desc)) 
+        {
+            goto error;
+        }
+        break;
+    case EcsExprCast:
+    case EcsExprCastNumber:
+        break;
+    case EcsExprMethod:
+    case EcsExprComponent:
+        /* Expressions are derived by type visitor */
+        ecs_abort(ECS_INTERNAL_ERROR, NULL);
+    }
+
+    ecs_assert(node->type != 0, ECS_INTERNAL_ERROR, NULL);
+    node->type_info = ecs_get_type_info(script->world, node->type);
+    ecs_assert(node->type_info != NULL, ECS_INTERNAL_ERROR, NULL);
+
+    return 0;
+error:
+    return -1;
+}
+
+int flecs_expr_visit_type(
+    ecs_script_t *script,
+    ecs_expr_node_t *node,
+    const ecs_expr_eval_desc_t *desc)
+{
+    if (node->kind == EcsExprEmptyInitializer) {
+        node->type = desc->type;
+        if (node->type) {
+            if (flecs_expr_initializer_collection_check(
+                script, (ecs_expr_initializer_t*)node, NULL))
+            {
+                return -1;
+            }
+
+            node->type_info = ecs_get_type_info(script->world, node->type);
+            return 0;
+        }
+    }
+
+    if (desc->type) {
+        ecs_meta_cursor_t cur = ecs_meta_cursor(
+            script->world, desc->type, NULL);
+        return flecs_expr_visit_type_priv(script, node, &cur, desc);
+    } else {
+        ecs_meta_cursor_t cur;
+        ecs_os_zeromem(&cur);
+        return flecs_expr_visit_type_priv(script, node, &cur, desc);
+    }
+}
+
+#endif
 

--- a/libs/flecs/flecs.h
+++ b/libs/flecs/flecs.h
@@ -33,9 +33,10 @@
  */
 
 /* Flecs version macros */
+// NOTE(zflecs): flecs 4.0.2 incorrectly specified version 4.0.1.
 #define FLECS_VERSION_MAJOR 4  /**< Flecs major version. */
 #define FLECS_VERSION_MINOR 0  /**< Flecs minor version. */
-#define FLECS_VERSION_PATCH 1  /**< Flecs patch version. */
+#define FLECS_VERSION_PATCH 2  /**< Flecs patch version. */
 
 /** Flecs version. */
 #define FLECS_VERSION FLECS_VERSION_IMPL(\
@@ -72,6 +73,13 @@
  * applications, at the cost of increased overhead.
  */
 // #define FLECS_ACCURATE_COUNTERS
+
+/** @def FLECS_DISABLE_COUNTERS
+ * Disables counters used for statistics. Improves performance, but
+ * will prevent some features that rely on statistics from working,
+ * like the statistics pages in the explorer.
+ */
+// #define FLECS_DISABLE_COUNTERS
 
 /* Make sure provided configuration is valid */
 #if defined(FLECS_DEBUG) && defined(FLECS_NDEBUG)
@@ -199,6 +207,7 @@
 #define FLECS_HTTP          /**< Tiny HTTP server for connecting to remote UI */
 #define FLECS_REST          /**< REST API for querying application data */
 // #define FLECS_JOURNAL    /**< Journaling addon (disabled by default) */
+// #define FLECS_PERF_TRACE /**< Enable performance tracing (disabled by default) */
 #endif // ifndef FLECS_CUSTOM_BUILD
 
 /** @def FLECS_LOW_FOOTPRINT
@@ -337,7 +346,7 @@ extern "C" {
 #define EcsWorldMeasureFrameTime      (1u << 5)
 #define EcsWorldMeasureSystemTime     (1u << 6)
 #define EcsWorldMultiThreaded         (1u << 7)
-
+#define EcsWorldFrameInProgress       (1u << 8)
 
 ////////////////////////////////////////////////////////////////////////////////
 //// OS API flags
@@ -392,12 +401,12 @@ extern "C" {
 #define EcsIdHasOnAdd                  (1u << 16) /* Same values as table flags */
 #define EcsIdHasOnRemove               (1u << 17) 
 #define EcsIdHasOnSet                  (1u << 18)
-#define EcsIdHasOnTableFill            (1u << 20)
-#define EcsIdHasOnTableEmpty           (1u << 21)
-#define EcsIdHasOnTableCreate          (1u << 22)
-#define EcsIdHasOnTableDelete          (1u << 23)
-#define EcsIdIsSparse                  (1u << 24)
-#define EcsIdIsUnion                   (1u << 25)
+#define EcsIdHasOnTableFill            (1u << 19)
+#define EcsIdHasOnTableEmpty           (1u << 20)
+#define EcsIdHasOnTableCreate          (1u << 21)
+#define EcsIdHasOnTableDelete          (1u << 22)
+#define EcsIdIsSparse                  (1u << 23)
+#define EcsIdIsUnion                   (1u << 24)
 #define EcsIdEventMask\
     (EcsIdHasOnAdd|EcsIdHasOnRemove|EcsIdHasOnSet|\
         EcsIdHasOnTableFill|EcsIdHasOnTableEmpty|EcsIdHasOnTableCreate|\
@@ -460,17 +469,18 @@ extern "C" {
 #define EcsQueryMatchOnlyThis         (1u << 12u) /* Query only has terms with $this source */
 #define EcsQueryMatchOnlySelf         (1u << 13u) /* Query has no terms with up traversal */
 #define EcsQueryMatchWildcards        (1u << 14u) /* Query matches wildcards */
-#define EcsQueryHasCondSet            (1u << 15u) /* Query has conditionally set fields */
-#define EcsQueryHasPred               (1u << 16u) /* Query has equality predicates */
-#define EcsQueryHasScopes             (1u << 17u) /* Query has query scopes */
-#define EcsQueryHasRefs               (1u << 18u) /* Query has terms with static source */
-#define EcsQueryHasOutTerms           (1u << 19u) /* Query has [out] terms */
-#define EcsQueryHasNonThisOutTerms    (1u << 20u) /* Query has [out] terms with no $this source */
-#define EcsQueryHasMonitor            (1u << 21u) /* Query has monitor for change detection */
-#define EcsQueryIsTrivial             (1u << 22u) /* Query can use trivial evaluation function */
-#define EcsQueryHasCacheable          (1u << 23u) /* Query has cacheable terms */
-#define EcsQueryIsCacheable           (1u << 24u) /* All terms of query are cacheable */
-#define EcsQueryHasTableThisVar       (1u << 25u) /* Does query have $this table var */
+#define EcsQueryMatchNothing          (1u << 15u) /* Query matches nothing */
+#define EcsQueryHasCondSet            (1u << 16u) /* Query has conditionally set fields */
+#define EcsQueryHasPred               (1u << 17u) /* Query has equality predicates */
+#define EcsQueryHasScopes             (1u << 18u) /* Query has query scopes */
+#define EcsQueryHasRefs               (1u << 19u) /* Query has terms with static source */
+#define EcsQueryHasOutTerms           (1u << 20u) /* Query has [out] terms */
+#define EcsQueryHasNonThisOutTerms    (1u << 21u) /* Query has [out] terms with no $this source */
+#define EcsQueryHasMonitor            (1u << 22u) /* Query has monitor for change detection */
+#define EcsQueryIsTrivial             (1u << 23u) /* Query can use trivial evaluation function */
+#define EcsQueryHasCacheable          (1u << 24u) /* Query has cacheable terms */
+#define EcsQueryIsCacheable           (1u << 25u) /* All terms of query are cacheable */
+#define EcsQueryHasTableThisVar       (1u << 26u) /* Does query have $this table var */
 #define EcsQueryCacheYieldEmptyTables (1u << 27u) /* Does query cache empty tables */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -501,7 +511,8 @@ extern "C" {
 #define EcsObserverIsMonitor           (1u << 2u)  /* Is observer a monitor */
 #define EcsObserverIsDisabled          (1u << 3u)  /* Is observer entity disabled */
 #define EcsObserverIsParentDisabled    (1u << 4u)  /* Is module parent of observer disabled  */
-#define EcsObserverBypassQuery         (1u << 5u)
+#define EcsObserverBypassQuery         (1u << 5u)  /* Don't evaluate query for multi-component observer*/
+#define EcsObserverYieldOnDelete       (1u << 6u)  /* Yield matching entities when deleting observer */
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Table flags (used by ecs_table_t::flags)
@@ -526,22 +537,24 @@ extern "C" {
 #define EcsTableHasOnAdd               (1u << 16u) /* Same values as id flags */
 #define EcsTableHasOnRemove            (1u << 17u)
 #define EcsTableHasOnSet               (1u << 18u)
-#define EcsTableHasOnTableFill         (1u << 20u)
-#define EcsTableHasOnTableEmpty        (1u << 21u)
-#define EcsTableHasOnTableCreate       (1u << 22u)
-#define EcsTableHasOnTableDelete       (1u << 23u)
-#define EcsTableHasSparse              (1u << 24u)
-#define EcsTableHasUnion               (1u << 25u)
+#define EcsTableHasOnTableFill         (1u << 19u)
+#define EcsTableHasOnTableEmpty        (1u << 20u)
+#define EcsTableHasOnTableCreate       (1u << 21u)
+#define EcsTableHasOnTableDelete       (1u << 22u)
+#define EcsTableHasSparse              (1u << 23u)
+#define EcsTableHasUnion               (1u << 24u)
 
 #define EcsTableHasTraversable         (1u << 26u)
 #define EcsTableMarkedForDelete        (1u << 30u)
 
 /* Composite table flags */
-#define EcsTableHasLifecycle        (EcsTableHasCtors | EcsTableHasDtors)
-#define EcsTableIsComplex           (EcsTableHasLifecycle | EcsTableHasToggle | EcsTableHasSparse)
-#define EcsTableHasAddActions       (EcsTableHasIsA | EcsTableHasCtors | EcsTableHasOnAdd | EcsTableHasOnSet)
-#define EcsTableHasRemoveActions    (EcsTableHasIsA | EcsTableHasDtors | EcsTableHasOnRemove)
-
+#define EcsTableHasLifecycle     (EcsTableHasCtors | EcsTableHasDtors)
+#define EcsTableIsComplex        (EcsTableHasLifecycle | EcsTableHasToggle | EcsTableHasSparse)
+#define EcsTableHasAddActions    (EcsTableHasIsA | EcsTableHasCtors | EcsTableHasOnAdd | EcsTableHasOnSet)
+#define EcsTableHasRemoveActions (EcsTableHasIsA | EcsTableHasDtors | EcsTableHasOnRemove)
+#define EcsTableEdgeFlags        (EcsTableHasOnAdd | EcsTableHasOnRemove | EcsTableHasSparse | EcsTableHasUnion)
+#define EcsTableAddEdgeFlags     (EcsTableHasOnAdd | EcsTableHasSparse | EcsTableHasUnion)
+#define EcsTableRemoveEdgeFlags  (EcsTableHasOnRemove | EcsTableHasSparse | EcsTableHasUnion)
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Aperiodic action flags (used by ecs_run_aperiodic)
@@ -650,9 +663,6 @@ extern "C" {
 /* Filenames aren't consistent across targets as they can use different casing 
  * (e.g. WinSock2 vs winsock2). */
 #pragma clang diagnostic ignored "-Wnonportable-system-include-path"
-/* Enum reflection relies on testing constant values that may not be valid for
- * the enumeration. */
-#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
 /* Very difficult to workaround this warning in C, especially for an ECS. */
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 /* This warning gets thrown when trying to cast pointer returned from dlproc */
@@ -664,6 +674,11 @@ extern "C" {
  * code paths are reached where values are uninitialized. */
 #ifdef FLECS_SOFT_ASSERT
 #pragma clang diagnostic ignored "-Wsometimes-uninitialized"
+#endif
+
+/* Allows for enum reflection support on legacy compilers */
+#if __clang_major__ < 16
+#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
 #endif
 
 #elif defined(ECS_TARGET_GNU)
@@ -685,6 +700,11 @@ extern "C" {
 /* Produces false positives in queries/src/cache.c */
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #pragma GCC diagnostic ignored "-Wrestrict"
+#endif
+
+/* Allows for enum reflection support on legacy compilers */
+#if defined(__GNUC__) && __GNUC__ <= 10
+#pragma GCC diagnostic ignored "-Wconversion"
 #endif
 
 /* Standard library dependencies */
@@ -810,6 +830,8 @@ typedef struct ecs_allocator_t ecs_allocator_t;
 #elif defined(ECS_TARGET_MSVC)
 #define ECS_ALIGNOF(T) (int64_t)__alignof(T)
 #elif defined(ECS_TARGET_GNU)
+#define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
+#elif defined(ECS_TARGET_CLANG)
 #define ECS_ALIGNOF(T) (int64_t)__alignof__(T)
 #else
 #define ECS_ALIGNOF(T) ((int64_t)&((struct { char c; T d; } *)0)->d)
@@ -2424,6 +2446,12 @@ typedef
 char* (*ecs_os_api_module_to_path_t)(
     const char *module_id);
 
+/* Performance tracing */
+typedef void (*ecs_os_api_perf_trace_t)(
+    const char *filename,
+    size_t line,
+    const char *name);
+
 /* Prefix members of struct with 'ecs_' as some system headers may define
  * macros for functions like "strdup", "log" or "_free" */
 
@@ -2499,6 +2527,12 @@ typedef struct ecs_os_api_t {
     /* Overridable function that translates from a logical module id to a
      * path that contains module-specif resources or assets */
     ecs_os_api_module_to_path_t module_to_etc_;    /**< module_to_etc callback. */
+
+    /* Performance tracing */
+    ecs_os_api_perf_trace_t perf_trace_push_;
+
+    /* Performance tracing */
+    ecs_os_api_perf_trace_t perf_trace_pop_;
 
     int32_t log_level_;                            /**< Tracing level. */
     int32_t log_indent_;                           /**< Tracing indentation level. */
@@ -2689,6 +2723,7 @@ void ecs_os_set_api_defaults(void);
 #define ecs_os_now() ecs_os_api.now_()
 #define ecs_os_get_time(time_out) ecs_os_api.get_time_(time_out)
 
+#ifndef FLECS_DISABLE_COUNTERS
 #ifdef FLECS_ACCURATE_COUNTERS
 #define ecs_os_inc(v)  (ecs_os_ainc(v))
 #define ecs_os_linc(v) (ecs_os_lainc(v))
@@ -2700,6 +2735,13 @@ void ecs_os_set_api_defaults(void);
 #define ecs_os_dec(v)  (--(*v))
 #define ecs_os_ldec(v) (--(*v))
 #endif
+#else
+#define ecs_os_inc(v)
+#define ecs_os_linc(v)
+#define ecs_os_dec(v)
+#define ecs_os_ldec(v)
+#endif
+
 
 #ifdef ECS_TARGET_MINGW
 /* mingw bug: without this a conversion error is thrown, but isnan/isinf should
@@ -2809,6 +2851,25 @@ FLECS_API
 void ecs_os_strset(
     char **str, 
     const char *value);
+
+/* Profile tracing */
+#ifdef FLECS_PERF_TRACE
+#define ecs_os_perf_trace_push(name) ecs_os_perf_trace_push_(__FILE__, __LINE__, name)
+#define ecs_os_perf_trace_pop(name) ecs_os_perf_trace_pop_(__FILE__, __LINE__, name)
+#else
+#define ecs_os_perf_trace_push(name)
+#define ecs_os_perf_trace_pop(name)
+#endif
+
+void ecs_os_perf_trace_push_(
+    const char *file,
+    size_t line,
+    const char *name);
+
+void ecs_os_perf_trace_pop_(
+    const char *file,
+    size_t line,
+    const char *name);
 
 /** Sleep with floating point time. 
  * 
@@ -3391,6 +3452,7 @@ struct ecs_query_t {
 
     /* Bitmasks for quick field information lookups */
     ecs_termset_t fixed_fields; /**< Fields with a fixed source */
+    ecs_termset_t var_fields;   /**< Fields with non-$this variable source */
     ecs_termset_t static_id_fields; /**< Fields with a static (component) id */
     ecs_termset_t data_fields;  /**< Fields that have data */
     ecs_termset_t write_fields; /**< Fields that write data */
@@ -3486,11 +3548,14 @@ struct ecs_type_hooks_t {
      * destructor is invoked. */
     ecs_iter_action_t on_remove;
 
-    void *ctx;                       /**< User defined context */
-    void *binding_ctx;               /**< Language binding context */
+    void *ctx;                         /**< User defined context */
+    void *binding_ctx;                 /**< Language binding context */
+    void *lifecycle_ctx;               /**< Component lifecycle context (see meta add-on)*/
 
-    ecs_ctx_free_t ctx_free;         /**< Callback to free ctx */
-    ecs_ctx_free_t binding_ctx_free; /**< Callback to free binding_ctx */
+    ecs_ctx_free_t ctx_free;           /**< Callback to free ctx */
+    ecs_ctx_free_t binding_ctx_free;   /**< Callback to free binding_ctx */
+    ecs_ctx_free_t lifecycle_ctx_free; /**< Callback to free lifecycle_ctx */
+
 };
 
 /** Type that contains component information (passed to ctors/dtors/...)
@@ -4510,6 +4575,7 @@ typedef struct ecs_world_info_t {
 
     int64_t frame_count_total;        /**< Total number of frames */
     int64_t merge_count_total;        /**< Total number of merges */
+    int64_t eval_comp_monitors_total; /**< Total number of monitor evaluations */
     int64_t rematch_count_total;      /**< Total number of rematches */
 
     int64_t id_create_total;          /**< Total number of times a new id was created */
@@ -7459,7 +7525,7 @@ FLECS_API
 const char* ecs_id_flag_str(
     ecs_id_t id_flags);
 
-/** Convert id to string.
+/** Convert (component) id to string.
  * This operation interprets the structure of an id and converts it to a string.
  *
  * @param world The world.
@@ -7471,7 +7537,7 @@ char* ecs_id_str(
     const ecs_world_t *world,
     ecs_id_t id);
 
-/** Write id string to buffer.
+/** Write (component) id string to buffer.
  * Same as ecs_id_str() but writes result to ecs_strbuf_t.
  *
  * @param world The world.
@@ -7483,6 +7549,18 @@ void ecs_id_str_buf(
     const ecs_world_t *world,
     ecs_id_t id,
     ecs_strbuf_t *buf);
+
+/** Convert string to a (component) id.
+ * This operation is the reverse of ecs_id_str(). The FLECS_SCRIPT addon
+ * is required for this operation to work.
+ *
+ * @param world The world.
+ * @param expr The string to convert to an id.
+ */
+FLECS_API
+ecs_id_t ecs_id_from_str(
+    const ecs_world_t *world,
+    const char *expr);
 
 /** @} */
 
@@ -9786,7 +9864,7 @@ int ecs_value_move_ctor(
     ecs_ref_init_id(world, entity, ecs_id(T))
 
 #define ecs_ref_get(world, ref, T)\
-    (ECS_CAST(const T*, ecs_ref_get_id(world, ref, ecs_id(T))))
+    (ECS_CAST(T*, ecs_ref_get_id(world, ref, ecs_id(T))))
 
 /** @} */
 
@@ -12114,6 +12192,9 @@ typedef struct ecs_system_t {
     /** Is system ran in immediate mode */
     bool immediate;
 
+    /** Cached system name (for perf tracing) */
+    const char *name;
+
     /** Userdata for system */
     void *ctx;
 
@@ -13685,37 +13766,37 @@ extern "C" {
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsUnitPrefixes); /**< Parent scope for prefixes. */
+FLECS_API extern ecs_entity_t EcsUnitPrefixes; /**< Parent scope for prefixes. */
 
-FLECS_API extern ECS_DECLARE(EcsYocto);  /**< Yocto unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsZepto);  /**< Zepto unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsAtto);   /**< Atto unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsFemto);  /**< Femto unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsPico);   /**< Pico unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsNano);   /**< Nano unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsMicro);  /**< Micro unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsMilli);  /**< Milli unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsCenti);  /**< Centi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsDeci);   /**< Deci unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsDeca);   /**< Deca unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsHecto);  /**< Hecto unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsKilo);   /**< Kilo unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsMega);   /**< Mega unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsGiga);   /**< Giga unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsTera);   /**< Tera unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsPeta);   /**< Peta unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsExa);    /**< Exa unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsZetta);  /**< Zetta unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsYotta);  /**< Yotta unit prefix. */
+FLECS_API extern ecs_entity_t EcsYocto;  /**< Yocto unit prefix. */
+FLECS_API extern ecs_entity_t EcsZepto;  /**< Zepto unit prefix. */
+FLECS_API extern ecs_entity_t EcsAtto;   /**< Atto unit prefix. */
+FLECS_API extern ecs_entity_t EcsFemto;  /**< Femto unit prefix. */
+FLECS_API extern ecs_entity_t EcsPico;   /**< Pico unit prefix. */
+FLECS_API extern ecs_entity_t EcsNano;   /**< Nano unit prefix. */
+FLECS_API extern ecs_entity_t EcsMicro;  /**< Micro unit prefix. */
+FLECS_API extern ecs_entity_t EcsMilli;  /**< Milli unit prefix. */
+FLECS_API extern ecs_entity_t EcsCenti;  /**< Centi unit prefix. */
+FLECS_API extern ecs_entity_t EcsDeci;   /**< Deci unit prefix. */
+FLECS_API extern ecs_entity_t EcsDeca;   /**< Deca unit prefix. */
+FLECS_API extern ecs_entity_t EcsHecto;  /**< Hecto unit prefix. */
+FLECS_API extern ecs_entity_t EcsKilo;   /**< Kilo unit prefix. */
+FLECS_API extern ecs_entity_t EcsMega;   /**< Mega unit prefix. */
+FLECS_API extern ecs_entity_t EcsGiga;   /**< Giga unit prefix. */
+FLECS_API extern ecs_entity_t EcsTera;   /**< Tera unit prefix. */
+FLECS_API extern ecs_entity_t EcsPeta;   /**< Peta unit prefix. */
+FLECS_API extern ecs_entity_t EcsExa;    /**< Exa unit prefix. */
+FLECS_API extern ecs_entity_t EcsZetta;  /**< Zetta unit prefix. */
+FLECS_API extern ecs_entity_t EcsYotta;  /**< Yotta unit prefix. */
 
-FLECS_API extern ECS_DECLARE(EcsKibi);   /**< Kibi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsMebi);   /**< Mebi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsGibi);   /**< Gibi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsTebi);   /**< Tebi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsPebi);   /**< Pebi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsExbi);   /**< Exbi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsZebi);   /**< Zebi unit prefix. */
-FLECS_API extern ECS_DECLARE(EcsYobi);   /**< Yobi unit prefix. */
+FLECS_API extern ecs_entity_t EcsKibi;   /**< Kibi unit prefix. */
+FLECS_API extern ecs_entity_t EcsMebi;   /**< Mebi unit prefix. */
+FLECS_API extern ecs_entity_t EcsGibi;   /**< Gibi unit prefix. */
+FLECS_API extern ecs_entity_t EcsTebi;   /**< Tebi unit prefix. */
+FLECS_API extern ecs_entity_t EcsPebi;   /**< Pebi unit prefix. */
+FLECS_API extern ecs_entity_t EcsExbi;   /**< Exbi unit prefix. */
+FLECS_API extern ecs_entity_t EcsZebi;   /**< Zebi unit prefix. */
+FLECS_API extern ecs_entity_t EcsYobi;   /**< Yobi unit prefix. */
 
 /** @} */
 
@@ -13725,15 +13806,15 @@ FLECS_API extern ECS_DECLARE(EcsYobi);   /**< Yobi unit prefix. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsDuration);         /**< Duration quantity. */
-FLECS_API extern     ECS_DECLARE(EcsPicoSeconds);  /**< PicoSeconds duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsNanoSeconds);  /**< NanoSeconds duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsMicroSeconds); /**< MicroSeconds duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsMilliSeconds); /**< MilliSeconds duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsSeconds);      /**< Seconds duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsMinutes);      /**< Minutes duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsHours);        /**< Hours duration unit. */
-FLECS_API extern     ECS_DECLARE(EcsDays);         /**< Days duration unit. */
+FLECS_API extern ecs_entity_t EcsDuration;         /**< Duration quantity. */
+FLECS_API extern     ecs_entity_t EcsPicoSeconds;  /**< PicoSeconds duration unit. */
+FLECS_API extern     ecs_entity_t EcsNanoSeconds;  /**< NanoSeconds duration unit. */
+FLECS_API extern     ecs_entity_t EcsMicroSeconds; /**< MicroSeconds duration unit. */
+FLECS_API extern     ecs_entity_t EcsMilliSeconds; /**< MilliSeconds duration unit. */
+FLECS_API extern     ecs_entity_t EcsSeconds;      /**< Seconds duration unit. */
+FLECS_API extern     ecs_entity_t EcsMinutes;      /**< Minutes duration unit. */
+FLECS_API extern     ecs_entity_t EcsHours;        /**< Hours duration unit. */
+FLECS_API extern     ecs_entity_t EcsDays;         /**< Days duration unit. */
 
 /** @} */
 
@@ -13743,8 +13824,8 @@ FLECS_API extern     ECS_DECLARE(EcsDays);         /**< Days duration unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsTime);             /**< Time quantity. */
-FLECS_API extern     ECS_DECLARE(EcsDate);         /**< Date unit. */
+FLECS_API extern ecs_entity_t EcsTime;             /**< Time quantity. */
+FLECS_API extern     ecs_entity_t EcsDate;         /**< Date unit. */
 
 /** @} */
 
@@ -13754,9 +13835,9 @@ FLECS_API extern     ECS_DECLARE(EcsDate);         /**< Date unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsMass);             /**< Mass quantity. */
-FLECS_API extern     ECS_DECLARE(EcsGrams);        /**< Grams unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloGrams);    /**< KiloGrams unit. */
+FLECS_API extern ecs_entity_t EcsMass;             /**< Mass quantity. */
+FLECS_API extern     ecs_entity_t EcsGrams;        /**< Grams unit. */
+FLECS_API extern     ecs_entity_t EcsKiloGrams;    /**< KiloGrams unit. */
 
 /** @} */
 
@@ -13766,8 +13847,8 @@ FLECS_API extern     ECS_DECLARE(EcsKiloGrams);    /**< KiloGrams unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsElectricCurrent);  /**< ElectricCurrent quantity. */
-FLECS_API extern     ECS_DECLARE(EcsAmpere);       /**< Ampere unit. */
+FLECS_API extern ecs_entity_t EcsElectricCurrent;  /**< ElectricCurrent quantity. */
+FLECS_API extern     ecs_entity_t EcsAmpere;       /**< Ampere unit. */
 
 /** @} */
 
@@ -13777,8 +13858,8 @@ FLECS_API extern     ECS_DECLARE(EcsAmpere);       /**< Ampere unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsAmount);           /**< Amount quantity. */
-FLECS_API extern     ECS_DECLARE(EcsMole);         /**< Mole unit. */
+FLECS_API extern ecs_entity_t EcsAmount;           /**< Amount quantity. */
+FLECS_API extern     ecs_entity_t EcsMole;         /**< Mole unit. */
 
 /** @} */
 
@@ -13788,8 +13869,8 @@ FLECS_API extern     ECS_DECLARE(EcsMole);         /**< Mole unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsLuminousIntensity); /**< LuminousIntensity quantity. */
-FLECS_API extern     ECS_DECLARE(EcsCandela);       /**< Candela unit. */
+FLECS_API extern ecs_entity_t EcsLuminousIntensity; /**< LuminousIntensity quantity. */
+FLECS_API extern     ecs_entity_t EcsCandela;       /**< Candela unit. */
 
 /** @} */
 
@@ -13799,8 +13880,8 @@ FLECS_API extern     ECS_DECLARE(EcsCandela);       /**< Candela unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsForce);            /**< Force quantity. */
-FLECS_API extern     ECS_DECLARE(EcsNewton);       /**< Newton unit. */
+FLECS_API extern ecs_entity_t EcsForce;            /**< Force quantity. */
+FLECS_API extern     ecs_entity_t EcsNewton;       /**< Newton unit. */
 
 /** @} */
 
@@ -13810,16 +13891,16 @@ FLECS_API extern     ECS_DECLARE(EcsNewton);       /**< Newton unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsLength);              /**< Length quantity. */
-FLECS_API extern     ECS_DECLARE(EcsMeters);          /**< Meters unit. */
-FLECS_API extern         ECS_DECLARE(EcsPicoMeters);  /**< PicoMeters unit. */
-FLECS_API extern         ECS_DECLARE(EcsNanoMeters);  /**< NanoMeters unit. */
-FLECS_API extern         ECS_DECLARE(EcsMicroMeters); /**< MicroMeters unit. */
-FLECS_API extern         ECS_DECLARE(EcsMilliMeters); /**< MilliMeters unit. */
-FLECS_API extern         ECS_DECLARE(EcsCentiMeters); /**< CentiMeters unit. */
-FLECS_API extern         ECS_DECLARE(EcsKiloMeters);  /**< KiloMeters unit. */
-FLECS_API extern     ECS_DECLARE(EcsMiles);           /**< Miles unit. */
-FLECS_API extern     ECS_DECLARE(EcsPixels);          /**< Pixels unit. */
+FLECS_API extern ecs_entity_t EcsLength;              /**< Length quantity. */
+FLECS_API extern     ecs_entity_t EcsMeters;          /**< Meters unit. */
+FLECS_API extern         ecs_entity_t EcsPicoMeters;  /**< PicoMeters unit. */
+FLECS_API extern         ecs_entity_t EcsNanoMeters;  /**< NanoMeters unit. */
+FLECS_API extern         ecs_entity_t EcsMicroMeters; /**< MicroMeters unit. */
+FLECS_API extern         ecs_entity_t EcsMilliMeters; /**< MilliMeters unit. */
+FLECS_API extern         ecs_entity_t EcsCentiMeters; /**< CentiMeters unit. */
+FLECS_API extern         ecs_entity_t EcsKiloMeters;  /**< KiloMeters unit. */
+FLECS_API extern     ecs_entity_t EcsMiles;           /**< Miles unit. */
+FLECS_API extern     ecs_entity_t EcsPixels;          /**< Pixels unit. */
 
 /** @} */
 
@@ -13829,9 +13910,9 @@ FLECS_API extern     ECS_DECLARE(EcsPixels);          /**< Pixels unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsPressure);          /**< Pressure quantity. */
-FLECS_API extern     ECS_DECLARE(EcsPascal);        /**< Pascal unit. */
-FLECS_API extern     ECS_DECLARE(EcsBar);           /**< Bar unit. */
+FLECS_API extern ecs_entity_t EcsPressure;          /**< Pressure quantity. */
+FLECS_API extern     ecs_entity_t EcsPascal;        /**< Pascal unit. */
+FLECS_API extern     ecs_entity_t EcsBar;           /**< Bar unit. */
 
 /** @} */
 
@@ -13841,11 +13922,11 @@ FLECS_API extern     ECS_DECLARE(EcsBar);           /**< Bar unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsSpeed);                   /**< Speed quantity. */
-FLECS_API extern     ECS_DECLARE(EcsMetersPerSecond);     /**< MetersPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloMetersPerSecond); /**< KiloMetersPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloMetersPerHour);   /**< KiloMetersPerHour unit. */
-FLECS_API extern     ECS_DECLARE(EcsMilesPerHour);        /**< MilesPerHour unit. */
+FLECS_API extern ecs_entity_t EcsSpeed;                   /**< Speed quantity. */
+FLECS_API extern     ecs_entity_t EcsMetersPerSecond;     /**< MetersPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsKiloMetersPerSecond; /**< KiloMetersPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsKiloMetersPerHour;   /**< KiloMetersPerHour unit. */
+FLECS_API extern     ecs_entity_t EcsMilesPerHour;        /**< MilesPerHour unit. */
 
 /** @} */
 
@@ -13855,10 +13936,10 @@ FLECS_API extern     ECS_DECLARE(EcsMilesPerHour);        /**< MilesPerHour unit
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsTemperature);       /**< Temperature quantity. */
-FLECS_API extern     ECS_DECLARE(EcsKelvin);        /**< Kelvin unit. */
-FLECS_API extern     ECS_DECLARE(EcsCelsius);       /**< Celsius unit. */
-FLECS_API extern     ECS_DECLARE(EcsFahrenheit);    /**< Fahrenheit unit. */
+FLECS_API extern ecs_entity_t EcsTemperature;       /**< Temperature quantity. */
+FLECS_API extern     ecs_entity_t EcsKelvin;        /**< Kelvin unit. */
+FLECS_API extern     ecs_entity_t EcsCelsius;       /**< Celsius unit. */
+FLECS_API extern     ecs_entity_t EcsFahrenheit;    /**< Fahrenheit unit. */
 
 /** @} */
 
@@ -13868,18 +13949,18 @@ FLECS_API extern     ECS_DECLARE(EcsFahrenheit);    /**< Fahrenheit unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsData);               /**< Data quantity. */
-FLECS_API extern     ECS_DECLARE(EcsBits);           /**< Bits unit. */
-FLECS_API extern         ECS_DECLARE(EcsKiloBits);   /**< KiloBits unit. */
-FLECS_API extern         ECS_DECLARE(EcsMegaBits);   /**< MegaBits unit. */
-FLECS_API extern         ECS_DECLARE(EcsGigaBits);   /**< GigaBits unit. */
-FLECS_API extern     ECS_DECLARE(EcsBytes);          /**< Bytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsKiloBytes);  /**< KiloBytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsMegaBytes);  /**< MegaBytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsGigaBytes);  /**< GigaBytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsKibiBytes);  /**< KibiBytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsMebiBytes);  /**< MebiBytes unit. */
-FLECS_API extern         ECS_DECLARE(EcsGibiBytes);  /**< GibiBytes unit. */
+FLECS_API extern ecs_entity_t EcsData;               /**< Data quantity. */
+FLECS_API extern     ecs_entity_t EcsBits;           /**< Bits unit. */
+FLECS_API extern         ecs_entity_t EcsKiloBits;   /**< KiloBits unit. */
+FLECS_API extern         ecs_entity_t EcsMegaBits;   /**< MegaBits unit. */
+FLECS_API extern         ecs_entity_t EcsGigaBits;   /**< GigaBits unit. */
+FLECS_API extern     ecs_entity_t EcsBytes;          /**< Bytes unit. */
+FLECS_API extern         ecs_entity_t EcsKiloBytes;  /**< KiloBytes unit. */
+FLECS_API extern         ecs_entity_t EcsMegaBytes;  /**< MegaBytes unit. */
+FLECS_API extern         ecs_entity_t EcsGigaBytes;  /**< GigaBytes unit. */
+FLECS_API extern         ecs_entity_t EcsKibiBytes;  /**< KibiBytes unit. */
+FLECS_API extern         ecs_entity_t EcsMebiBytes;  /**< MebiBytes unit. */
+FLECS_API extern         ecs_entity_t EcsGibiBytes;  /**< GibiBytes unit. */
 
 /** @} */
 
@@ -13889,15 +13970,15 @@ FLECS_API extern         ECS_DECLARE(EcsGibiBytes);  /**< GibiBytes unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsDataRate);               /**< DataRate quantity. */
-FLECS_API extern     ECS_DECLARE(EcsBitsPerSecond);      /**< BitsPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloBitsPerSecond);  /**< KiloBitsPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsMegaBitsPerSecond);  /**< MegaBitsPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsGigaBitsPerSecond);  /**< GigaBitsPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsBytesPerSecond);     /**< BytesPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloBytesPerSecond); /**< KiloBytesPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsMegaBytesPerSecond); /**< MegaBytesPerSecond unit. */
-FLECS_API extern     ECS_DECLARE(EcsGigaBytesPerSecond); /**< GigaBytesPerSecond unit. */
+FLECS_API extern ecs_entity_t EcsDataRate;               /**< DataRate quantity. */
+FLECS_API extern     ecs_entity_t EcsBitsPerSecond;      /**< BitsPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsKiloBitsPerSecond;  /**< KiloBitsPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsMegaBitsPerSecond;  /**< MegaBitsPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsGigaBitsPerSecond;  /**< GigaBitsPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsBytesPerSecond;     /**< BytesPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsKiloBytesPerSecond; /**< KiloBytesPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsMegaBytesPerSecond; /**< MegaBytesPerSecond unit. */
+FLECS_API extern     ecs_entity_t EcsGigaBytesPerSecond; /**< GigaBytesPerSecond unit. */
 
 /** @} */
 
@@ -13907,9 +13988,9 @@ FLECS_API extern     ECS_DECLARE(EcsGigaBytesPerSecond); /**< GigaBytesPerSecond
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsAngle);            /**< Angle quantity. */
-FLECS_API extern     ECS_DECLARE(EcsRadians);      /**< Radians unit. */
-FLECS_API extern     ECS_DECLARE(EcsDegrees);      /**< Degrees unit. */
+FLECS_API extern ecs_entity_t EcsAngle;            /**< Angle quantity. */
+FLECS_API extern     ecs_entity_t EcsRadians;      /**< Radians unit. */
+FLECS_API extern     ecs_entity_t EcsDegrees;      /**< Degrees unit. */
 
 /** @} */
 
@@ -13919,11 +14000,11 @@ FLECS_API extern     ECS_DECLARE(EcsDegrees);      /**< Degrees unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsFrequency);        /**< Frequency quantity. */
-FLECS_API extern     ECS_DECLARE(EcsHertz);        /**< Hertz unit. */
-FLECS_API extern     ECS_DECLARE(EcsKiloHertz);    /**< KiloHertz unit. */
-FLECS_API extern     ECS_DECLARE(EcsMegaHertz);    /**< MegaHertz unit. */
-FLECS_API extern     ECS_DECLARE(EcsGigaHertz);    /**< GigaHertz unit. */
+FLECS_API extern ecs_entity_t EcsFrequency;        /**< Frequency quantity. */
+FLECS_API extern     ecs_entity_t EcsHertz;        /**< Hertz unit. */
+FLECS_API extern     ecs_entity_t EcsKiloHertz;    /**< KiloHertz unit. */
+FLECS_API extern     ecs_entity_t EcsMegaHertz;    /**< MegaHertz unit. */
+FLECS_API extern     ecs_entity_t EcsGigaHertz;    /**< GigaHertz unit. */
 
 /** @} */
 
@@ -13933,10 +14014,10 @@ FLECS_API extern     ECS_DECLARE(EcsGigaHertz);    /**< GigaHertz unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsUri);              /**< URI quantity. */
-FLECS_API extern     ECS_DECLARE(EcsUriHyperlink); /**< UriHyperlink unit. */
-FLECS_API extern     ECS_DECLARE(EcsUriImage);     /**< UriImage unit. */
-FLECS_API extern     ECS_DECLARE(EcsUriFile);      /**< UriFile unit. */
+FLECS_API extern ecs_entity_t EcsUri;              /**< URI quantity. */
+FLECS_API extern     ecs_entity_t EcsUriHyperlink; /**< UriHyperlink unit. */
+FLECS_API extern     ecs_entity_t EcsUriImage;     /**< UriImage unit. */
+FLECS_API extern     ecs_entity_t EcsUriFile;      /**< UriFile unit. */
 
 /** @} */
 
@@ -13946,18 +14027,18 @@ FLECS_API extern     ECS_DECLARE(EcsUriFile);      /**< UriFile unit. */
  * @{
  */
 
-FLECS_API extern ECS_DECLARE(EcsColor);            /**< Color quantity. */
-FLECS_API extern     ECS_DECLARE(EcsColorRgb);     /**< ColorRgb unit. */
-FLECS_API extern     ECS_DECLARE(EcsColorHsl);     /**< ColorHsl unit. */
-FLECS_API extern     ECS_DECLARE(EcsColorCss);     /**< ColorCss unit. */
+FLECS_API extern ecs_entity_t EcsColor;            /**< Color quantity. */
+FLECS_API extern     ecs_entity_t EcsColorRgb;     /**< ColorRgb unit. */
+FLECS_API extern     ecs_entity_t EcsColorHsl;     /**< ColorHsl unit. */
+FLECS_API extern     ecs_entity_t EcsColorCss;     /**< ColorCss unit. */
 
 /** @} */
 
 
-FLECS_API extern ECS_DECLARE(EcsAcceleration);     /**< Acceleration unit. */
-FLECS_API extern ECS_DECLARE(EcsPercentage);       /**< Percentage unit. */
-FLECS_API extern ECS_DECLARE(EcsBel);              /**< Bel unit. */
-FLECS_API extern ECS_DECLARE(EcsDeciBel);          /**< DeciBel unit. */
+FLECS_API extern ecs_entity_t EcsAcceleration;     /**< Acceleration unit. */
+FLECS_API extern ecs_entity_t EcsPercentage;       /**< Percentage unit. */
+FLECS_API extern ecs_entity_t EcsBel;              /**< Bel unit. */
+FLECS_API extern ecs_entity_t EcsDeciBel;          /**< DeciBel unit. */
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Module
@@ -17139,18 +17220,22 @@ struct string_view : string {
 #endif
 #endif
 
+#if defined(__clang__) && __clang_major__ >= 16
+// https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
+#define enum_cast(T, v) __builtin_bit_cast(T, v)
+#elif defined(__GNUC__) && __GNUC__ > 10
+#define enum_cast(T, v) __builtin_bit_cast(T, v)
+#else
+#define enum_cast(T, v) static_cast<T>(v)
+#endif
+
 namespace flecs {
 
 /** Int to enum */
 namespace _ {
 template <typename E, underlying_type_t<E> Value>
 struct to_constant {
-#if defined(__clang__) && __clang_major__ >= 16
-    // https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
-    static constexpr E value = __builtin_bit_cast(E, Value);
-#else
-    static constexpr E value = static_cast<E>(Value);
-#endif
+    static constexpr E value = enum_cast(E, Value);
 };
 
 template <typename E, underlying_type_t<E> Value>
@@ -17260,6 +17345,12 @@ constexpr bool enum_constant_is_valid() {
 }
 #endif
 
+/* Without this wrapper __builtin_bit_cast doesn't work */
+template <typename E, underlying_type_t<E> C>
+constexpr bool enum_constant_is_valid_wrap() {
+    return enum_constant_is_valid<E, enum_cast(E, C)>();
+}
+
 template <typename E, E C>
 struct enum_is_valid {
     static constexpr bool value = enum_constant_is_valid<E, C>();
@@ -17292,22 +17383,9 @@ struct enum_constant_data {
  * @tparam E The enum type.
  * @tparam Handler The handler for enum reflection operations.
  */
-template <typename E, template<typename> class Handler>
+template <typename E, typename Handler>
 struct enum_reflection {
-    template <E Value>
-    static constexpr underlying_type_t<E> to_int() {
-        return static_cast<underlying_type_t<E>>(Value);
-    }
-
-    template <underlying_type_t<E> Value>
-    static constexpr E from_int() {
-        return to_constant<E, Value>::value;
-    }
-
-    template <E Value>
-    static constexpr underlying_type_t<E> is_not_0() {
-        return static_cast<underlying_type_t<E>>(Value != from_int<0>());
-    }
+    using U = underlying_type_t<E>;
 
     /**
      * @brief Iterates over the range [Low, High] of enum values between Low and High.
@@ -17318,19 +17396,19 @@ struct enum_reflection {
      * 
      * @tparam Low The lower bound of the search range, inclusive.
      * @tparam High The upper bound of the search range, inclusive.
-     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @tparam Args Additional arguments to be passed through to Handler::handle_constant
      * @param last_value The last value processed in the iteration.
-     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
-     * @return constexpr underlying_type_t<E> The result of the iteration.
+     * @param args Additional arguments to be passed through to Handler::handle_constant
+     * @return constexpr U The result of the iteration.
      */
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_enum_range(underlying_type_t<E> last_value, Args... args) {
-        return to_int<High>() - to_int<Low>() <= 1
-            ? to_int<High>() == to_int<Low>()
-                ? Handler<E>::template handle_constant<Low>(last_value, args...)
-                : Handler<E>::template handle_constant<High>(Handler<E>::template handle_constant<Low>(last_value, args...), args...)
-            : each_enum_range<from_int<(to_int<Low>()+to_int<High>()) / 2 + 1>(), High>(
-                    each_enum_range<Low, from_int<(to_int<Low>()+to_int<High>()) / 2>()>(last_value, args...),
+    template <U Low, U High, typename... Args>
+    static constexpr U each_enum_range(U last_value, Args... args) {
+        return High - Low <= 1
+            ? High == Low
+                ? Handler::template handle_constant<Low>(last_value, args...)
+                : Handler::template handle_constant<High>(Handler::template handle_constant<Low>(last_value, args...), args...)
+            : each_enum_range<(Low + High) / 2 + 1, High>(
+                    each_enum_range<Low, (Low + High) / 2>(last_value, args...),
                     args...
               );
     }
@@ -17340,22 +17418,22 @@ struct enum_reflection {
      *
      * Recursively iterates the search space, looking for enums defined as multiple-of-2 
      * bitmasks. Each iteration, shifts bit to the right until it hits Low, then calls
-     * Handler<E>::handle_constant for each bitmask in ascending order.
+     * Handler::handle_constant for each bitmask in ascending order.
      * 
      * @tparam Low The lower bound of the search range, not inclusive
      * @tparam High The upper bound of the search range, inclusive.
-     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
+     * @tparam Args Additional arguments to be passed through to Handler::handle_constant
      * @param last_value The last value processed in the iteration.
-     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
-     * @return constexpr underlying_type_t<E> The result of the iteration.
+     * @param args Additional arguments to be passed through to Handler::handle_constant
+     * @return constexpr U The result of the iteration.
      */
-    template <E Low, E High, typename... Args>
-    static constexpr underlying_type_t<E> each_mask_range(underlying_type_t<E> last_value, Args... args) {
+    template <U Low, U High, typename... Args>
+    static constexpr U each_mask_range(U last_value, Args... args) {
         // If Low shares any bits with Current Flag, or if High is less than/equal to Low (and High isn't negative because max-flag signed)
-        return (to_int<Low>() & to_int<High>()) || (to_int<High>() <= to_int<Low>() && to_int<High>() != high_bit)
+        return (Low & High) || (High <= Low && High != high_bit)
             ? last_value
-            : Handler<E>::template handle_constant<High>(
-                each_mask_range<Low, from_int<((to_int<High>() >> 1) & ~high_bit)>()>(last_value, args...),
+            : Handler::template handle_constant<High>(
+                each_mask_range<Low, ((High >> 1) & ~high_bit)>(last_value, args...),
                 args...
               );
     }
@@ -17368,93 +17446,94 @@ struct enum_reflection {
      * (each_mask_range<Value, high_bit>).
      * 
      * @tparam Value The maximum enum value to iterate up to.
-     * @tparam Args Additional arguments to be passed through to Handler<E>::handle_constant
-     * @param args Additional arguments to be passed through to Handler<E>::handle_constant
-     * @return constexpr underlying_type_t<E> The result of the iteration.
+     * @tparam Args Additional arguments to be passed through to Handler::handle_constant
+     * @param args Additional arguments to be passed through to Handler::handle_constant
+     * @return constexpr U The result of the iteration.
      */
-    template <E Value = FLECS_ENUM_MAX(E), typename... Args>
-    static constexpr underlying_type_t<E> each_enum(Args... args) {
-        return each_mask_range<Value, from_int<high_bit>()>(each_enum_range<from_int<0>(), Value>(0, args...), args...);
+    template <U Value = static_cast<U>(FLECS_ENUM_MAX(E)), typename... Args>
+    static constexpr U each_enum(Args... args) {
+        return each_mask_range<Value, high_bit>(each_enum_range<0, Value>(0, args...), args...);
     }
 
-    static const underlying_type_t<E> high_bit = static_cast<underlying_type_t<E>>(1) << (sizeof(underlying_type_t<E>) * 8 - 1);
+    static const U high_bit = static_cast<U>(1) << (sizeof(U) * 8 - 1);
 };
 
 /** Enumeration type data */
 template<typename E>
 struct enum_data_impl {
 private:
+    using U = underlying_type_t<E>;
+
     /**
      * @brief Handler struct for generating compile-time count of enum constants.
      */
-    template<typename Enum>
     struct reflection_count {
-        template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> handle_constant(underlying_type_t<E> last_value) {
+        template <U Value, flecs::if_not_t< enum_constant_is_valid_wrap<E, Value>() > = 0>
+        static constexpr U handle_constant(U last_value) {
             return last_value;
         }
 
-        template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static constexpr underlying_type_t<Enum> handle_constant(underlying_type_t<E> last_value) {
+        template <U Value, flecs::if_t< enum_constant_is_valid_wrap<E, Value>() > = 0>
+        static constexpr U handle_constant(U last_value) {
             return 1 + last_value;
         }
     };
+
 public:
     flecs::entity_t id;
     int min;
     int max;
     bool has_contiguous;
 	// If enum constants start not-sparse, contiguous_until will be the index of the first sparse value, or end of the constants array
-    underlying_type_t<E> contiguous_until;
+    U contiguous_until;
 	// Compile-time generated count of enum constants.
-    static constexpr unsigned int constants_size = enum_reflection<E, reflection_count>::template each_enum< enum_last<E>::value >();
+    static constexpr unsigned int constants_size = enum_reflection<E, reflection_count>::template each_enum< static_cast<U>(enum_last<E>::value) >();
     // Constants array is sized to the number of found-constants, or 1 (to avoid 0-sized array)
-    enum_constant_data<underlying_type_t<E>> constants[constants_size? constants_size: 1];
+    enum_constant_data<U> constants[constants_size? constants_size: 1];
 };
 
 /** Class that scans an enum for constants, extracts names & creates entities */
 template <typename E>
 struct enum_type {
 private:
+    using U = underlying_type_t<E>;
+
     /**
      * @brief Helper struct for filling enum_type's static `enum_data_impl<E>` member with reflection data.
      *
      * Because reflection occurs in-order, we can use current value/last value to determine continuity, and
      * use that as a lookup heuristic later on.
-     * 
-     * @tparam Enum The enum type.
      */
-    template <typename Enum>
     struct reflection_init {
-        template <Enum Value, flecs::if_not_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static underlying_type_t<Enum> handle_constant(underlying_type_t<Enum> last_value, flecs::world_t*) {
+        template <U Value, flecs::if_not_t< enum_constant_is_valid_wrap<E, Value>() > = 0>
+        static U handle_constant(U last_value, flecs::world_t*) {
             // Search for constant failed. Pass last valid value through.
             return last_value;
         }
 
-        template <Enum Value, flecs::if_t< enum_constant_is_valid<Enum, Value>() > = 0>
-        static underlying_type_t<Enum> handle_constant(underlying_type_t<Enum> last_value, flecs::world_t *world) {
+        template <U Value, flecs::if_t< enum_constant_is_valid_wrap<E, Value>() > = 0>
+        static U handle_constant(U last_value, flecs::world_t *world) {
             // Constant is valid, so fill reflection data.
-            auto v = enum_reflection<E, reflection_init>::template to_int<Value>();
-            const char *name = enum_constant_to_name<Enum, Value>();
+            auto v = Value;
+            const char *name = enum_constant_to_name<E, enum_cast(E, Value)>();
             
-            ++enum_type<Enum>::data.max; // Increment cursor as we build constants array.
+            ++enum_type<E>::data.max; // Increment cursor as we build constants array.
 
             // If the enum was previously contiguous, and continues to be through the current value...
-            if (enum_type<Enum>::data.has_contiguous && static_cast<underlying_type_t<Enum>>(enum_type<Enum>::data.max) == v && enum_type<Enum>::data.contiguous_until == v) {
-                ++enum_type<Enum>::data.contiguous_until;
+            if (enum_type<E>::data.has_contiguous && static_cast<U>(enum_type<E>::data.max) == v && enum_type<E>::data.contiguous_until == v) {
+                ++enum_type<E>::data.contiguous_until;
             }
             // else, if the enum was never contiguous and hasn't been set as not contiguous...
-            else if (!enum_type<Enum>::data.contiguous_until && enum_type<Enum>::data.has_contiguous) {
-                enum_type<Enum>::data.has_contiguous = false;
+            else if (!enum_type<E>::data.contiguous_until && enum_type<E>::data.has_contiguous) {
+                enum_type<E>::data.has_contiguous = false;
             }
 
-            ecs_assert(!(last_value > 0 && v < std::numeric_limits<underlying_type_t<Enum>>::min() + last_value), ECS_UNSUPPORTED,
+            ecs_assert(!(last_value > 0 && v < std::numeric_limits<U>::min() + last_value), ECS_UNSUPPORTED,
                 "Signed integer enums causes integer overflow when recording offset from high positive to"
                 " low negative. Consider using unsigned integers as underlying type.");
-            enum_type<Enum>::data.constants[enum_type<Enum>::data.max].offset = v - last_value;
-            enum_type<Enum>::data.constants[enum_type<Enum>::data.max].id = ecs_cpp_enum_constant_register(
-                world, enum_type<Enum>::data.id, 0, name, static_cast<int32_t>(v));
+            enum_type<E>::data.constants[enum_type<E>::data.max].offset = v - last_value;
+            enum_type<E>::data.constants[enum_type<E>::data.max].id = ecs_cpp_enum_constant_register(
+                world, enum_type<E>::data.id, 0, name, static_cast<int32_t>(v));
             return v;
         }
     };
@@ -17490,10 +17569,9 @@ public:
         data.id = id;
 
         // Generate reflection data
-        enum_reflection<E, reflection_init>::template each_enum< enum_last<E>::value >(world);
+        enum_reflection<E, reflection_init>::template each_enum< static_cast<U>(enum_last<E>::value) >(world);
         ecs_log_pop();
     }
-
 };
 
 template <typename E>
@@ -17512,6 +17590,8 @@ inline static void init_enum(flecs::world_t*, flecs::entity_t) { }
 /** Enumeration type data wrapper with world pointer */
 template <typename E>
 struct enum_data {
+    using U = underlying_type_t<E>;
+
     enum_data(flecs::world_t *world, _::enum_data_impl<E>& impl)
         : world_(world)
         , impl_(impl) { }
@@ -17523,7 +17603,7 @@ struct enum_data {
      * @return true If the value is a valid enum value.
      * @return false If the value is not a valid enum value.
      */
-    bool is_valid(underlying_type_t<E> value) {
+    bool is_valid(U value) {
         int index = index_by_value(value);
         if (index < 0) {
             return false;
@@ -17539,7 +17619,7 @@ struct enum_data {
      * @return false If the value is not valid.
      */
     bool is_valid(E value) {
-        return is_valid(static_cast<underlying_type_t<E>>(value));
+        return is_valid(static_cast<U>(value));
     }
 
     /**
@@ -17548,7 +17628,7 @@ struct enum_data {
      * @param value The enum value.
      * @return int The index of the enum value.
      */
-    int index_by_value(underlying_type_t<E> value) const {
+    int index_by_value(U value) const {
         if (!impl_.max) {
             return -1;
         }
@@ -17556,7 +17636,7 @@ struct enum_data {
         if (impl_.has_contiguous && value < impl_.contiguous_until && value >= 0) {
             return static_cast<int>(value);
         }
-        underlying_type_t<E> accumulator = impl_.contiguous_until? impl_.contiguous_until - 1: 0;
+        U accumulator = impl_.contiguous_until? impl_.contiguous_until - 1: 0;
         for (int i = static_cast<int>(impl_.contiguous_until); i <= impl_.max; ++i) {
             accumulator += impl_.constants[i].offset;
             if (accumulator == value) {
@@ -17573,7 +17653,7 @@ struct enum_data {
      * @return int The index of the enum value.
      */
     int index_by_value(E value) const {
-        return index_by_value(static_cast<underlying_type_t<E>>(value));
+        return index_by_value(static_cast<U>(value));
     }
 
     int first() const {
@@ -17589,7 +17669,7 @@ struct enum_data {
     }
 
     flecs::entity entity() const;
-    flecs::entity entity(underlying_type_t<E> value) const;
+    flecs::entity entity(U value) const;
     flecs::entity entity(E value) const;
 
     flecs::world_t *world_;
@@ -17848,6 +17928,10 @@ struct id {
     explicit id(flecs::world_t *world, flecs::id_t first, flecs::id_t second)
         : world_(world)
         , id_(ecs_pair(first, second)) { }
+
+    explicit id(flecs::world_t *world, const char *expr)
+        : world_(world)
+        , id_(ecs_id_from_str(world, expr)) { }
 
     explicit id(flecs::id_t first, flecs::id_t second)
         : world_(nullptr)
@@ -20467,6 +20551,7 @@ struct world {
     }
 
     world& operator=(const world& obj) noexcept {
+        release();
         this->world_ = obj.world_;
         flecs_poly_claim(this->world_);
         return *this;
@@ -20478,12 +20563,15 @@ struct world {
     }
 
     world& operator=(world&& obj) noexcept {
+        release();
         world_ = obj.world_;
         obj.world_ = nullptr;
         return *this;
     }
 
-    ~world() {
+    /* Releases the underlying world object. If this is the last handle, the world
+       will be finalized. */
+    void release() {
         if (world_) {
             if (!flecs_poly_release(world_)) {
                 if (ecs_stage_get_id(world_) == -1) {
@@ -20496,7 +20584,12 @@ struct world {
                     ecs_fini(world_);
                 }
             }
-        }
+            world_ = nullptr;
+        }        
+    }
+
+    ~world() {
+        release();
     }
 
     /* Implicit conversion to world_t* */
@@ -22439,6 +22532,8 @@ public:
     flecs::type type() const;
 
     flecs::table table() const;
+
+    flecs::table other_table() const;
 
     flecs::table_range range() const;
 
@@ -25649,6 +25744,8 @@ private:
     void populate_self(const ecs_iter_t *iter, size_t index, T, Targs... comps) {
         fields_[index].ptr = ecs_field_w_size(iter, sizeof(A), 
             static_cast<int8_t>(index));
+        fields_[index].is_ref = false;
+        ecs_assert(iter->sources[index] == 0, ECS_INTERNAL_ERROR, NULL);
         populate_self(iter, index + 1, comps ...);
     }
 
@@ -25670,7 +25767,8 @@ struct each_field { };
 // Base class
 struct each_column_base {
     each_column_base(const _::field_ptr& field, size_t row) 
-        : field_(field), row_(row) { }
+        : field_(field), row_(row) {
+    }
 
 protected:
     const _::field_ptr& field_;
@@ -25766,7 +25864,6 @@ struct each_ref_field : public each_field<T> {
         }
     }
 };
-
 
 // Type that handles passing components to each callbacks
 template <typename Func, typename ... Components>
@@ -26370,6 +26467,7 @@ struct entity_with_delegate_impl<arg_list<Args ...>> {
                 elem = store_added(added, elem, prev, next, w.id<Args>()),
                 prev = next, 0
             )... });
+
             (void)dummy_before;
 
             // If table is different, move entity straight to it
@@ -26482,7 +26580,8 @@ inline const char* type_name() {
     static const size_t len = ECS_FUNC_TYPE_LEN(const char*, type_name, ECS_FUNC_NAME);
     static char result[len + 1] = {};
     static const size_t front_len = ECS_FUNC_NAME_FRONT(const char*, type_name);
-    return ecs_cpp_get_type_name(result, ECS_FUNC_NAME, len, front_len);
+    static const char* cppTypeName = ecs_cpp_get_type_name(result, ECS_FUNC_NAME, len, front_len);
+    return cppTypeName;
 }
 #else
 #error "implicit component registration not supported"
@@ -26494,7 +26593,8 @@ template <typename T>
 inline const char* symbol_name() {
     static const size_t len = ECS_FUNC_TYPE_LEN(const char*, symbol_name, ECS_FUNC_NAME);
     static char result[len + 1] = {};
-    return ecs_cpp_get_symbol_name(result, type_name<T>(), len);
+    static const char* cppSymbolName = ecs_cpp_get_symbol_name(result, type_name<T>(), len);
+    return cppSymbolName;
 }
 
 template <> inline const char* symbol_name<uint8_t>() {
@@ -27453,9 +27553,13 @@ struct ref {
         return get();
     }
 
-    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
-    operator bool() {       
+    bool has() {
         return !!try_get();
+    }
+
+    /** implicit conversion to bool.  return true if there is a valid T* being referred to **/
+    operator bool() {
+        return has();
     }
 
     flecs::entity entity() const;
@@ -29469,6 +29573,15 @@ struct query_builder_i : term_builder_i<Base> {
         return *this;
     }
 
+    Base& with(const char *r, entity_t o) {
+        this->term();
+        *this->term_ = flecs::term().first(r).second(o);
+        if (this->term_->inout == EcsInOutDefault) {
+            this->inout_none();
+        }
+        return *this;
+    }
+
     template<typename First>
     Base& with(id_t o) {
         return this->with(_::type<First>::id(this->world_v()), o);
@@ -30475,11 +30588,17 @@ ecs_entity_t do_import(world& world, const char *symbol) {
     // Initialize module component type & don't allow it to be registered as a
     // tag, as this would prevent calling emplace()
     auto c_ = component<T>(world, nullptr, false);
-    ecs_add_id(world, c_, EcsModule);
+
+    // Make module component sparse so that it'll never move in memory. This
+    // guarantees that a module destructor can be reliably used to cleanup
+    // module resources.
+    c_.add(flecs::Sparse);
 
     ecs_set_scope(world, c_);
     world.emplace<T>(world);
     ecs_set_scope(world, scope);
+
+    ecs_add_id(world, c_, EcsModule);
 
     // It should now be possible to lookup the module
     ecs_entity_t m = ecs_lookup_symbol(world, symbol, false, false);
@@ -30529,12 +30648,30 @@ flecs::entity import(world& world) {
 
 template <typename Module>
 inline flecs::entity world::module(const char *name) const {
-    flecs::id_t result = _::type<Module>::id(world_, nullptr, false);
+    flecs::entity result = this->entity(_::type<Module>::id(
+        world_, nullptr, false));
+
     if (name) {
+        flecs::entity prev_parent = result.parent();
         ecs_add_path_w_sep(world_, result, 0, name, "::", "::");
+        flecs::entity parent = result.parent();
+        if (prev_parent != parent) {
+            // Module was reparented, cleanup old parent(s)
+            flecs::entity cur = prev_parent, next;
+            do {
+                next = cur.parent();
+
+                ecs_iter_t it = ecs_each_id(world_, ecs_pair(EcsChildOf, cur));
+                if (!ecs_iter_is_true(&it)) {
+                    cur.destruct();
+                }
+
+                cur = next;
+            } while (cur);
+        }
     }
-    ecs_set_scope(world_, result);
-    return flecs::entity(world_, result);
+
+    return result;
 }
 
 template <typename Module>
@@ -31759,6 +31896,10 @@ inline units::units(flecs::world& world) {
 namespace flecs {
 
 inline stats::stats(flecs::world& world) {
+#ifdef FLECS_UNITS
+    world.import<flecs::units>();
+#endif
+
     /* Import C module  */
     FlecsStatsImport(world);
 
@@ -32284,6 +32425,10 @@ inline flecs::type iter::type() const {
 
 inline flecs::table iter::table() const {
     return flecs::table(iter_->real_world, iter_->table);
+}
+
+inline flecs::table iter::other_table() const {
+    return flecs::table(iter_->real_world, iter_->other_table);
 }
 
 inline flecs::table_range iter::range() const {

--- a/libs/flecs/flecs.h
+++ b/libs/flecs/flecs.h
@@ -33,10 +33,9 @@
  */
 
 /* Flecs version macros */
-// NOTE(zflecs): flecs 4.0.2 incorrectly specified version 4.0.1.
 #define FLECS_VERSION_MAJOR 4  /**< Flecs major version. */
 #define FLECS_VERSION_MINOR 0  /**< Flecs minor version. */
-#define FLECS_VERSION_PATCH 2  /**< Flecs patch version. */
+#define FLECS_VERSION_PATCH 3  /**< Flecs patch version. */
 
 /** Flecs version. */
 #define FLECS_VERSION FLECS_VERSION_IMPL(\
@@ -482,6 +481,7 @@ extern "C" {
 #define EcsQueryIsCacheable           (1u << 25u) /* All terms of query are cacheable */
 #define EcsQueryHasTableThisVar       (1u << 26u) /* Does query have $this table var */
 #define EcsQueryCacheYieldEmptyTables (1u << 27u) /* Does query cache empty tables */
+#define EcsQueryNested                (1u << 28u) /* Query created by a query (for observer, cache) */
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Term flags (used by ecs_term_t::flags_)
@@ -512,7 +512,9 @@ extern "C" {
 #define EcsObserverIsDisabled          (1u << 3u)  /* Is observer entity disabled */
 #define EcsObserverIsParentDisabled    (1u << 4u)  /* Is module parent of observer disabled  */
 #define EcsObserverBypassQuery         (1u << 5u)  /* Don't evaluate query for multi-component observer*/
-#define EcsObserverYieldOnDelete       (1u << 6u)  /* Yield matching entities when deleting observer */
+#define EcsObserverYieldOnCreate       (1u << 6u)  /* Yield matching entities when creating observer */
+#define EcsObserverYieldOnDelete       (1u << 7u)  /* Yield matching entities when deleting observer */
+
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Table flags (used by ecs_table_t::flags)
@@ -700,6 +702,11 @@ extern "C" {
 /* Produces false positives in queries/src/cache.c */
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #pragma GCC diagnostic ignored "-Wrestrict"
+
+#elif defined(ECS_TARGET_MSVC)
+/* recursive on all control paths, function will cause runtime stack overflow
+ * This warning is incorrectly thrown on enum reflection code. */
+#pragma warning(disable: 4717)
 #endif
 
 /* Allows for enum reflection support on legacy compilers */
@@ -5168,6 +5175,17 @@ FLECS_API
 ecs_entities_t ecs_get_entities(
     const ecs_world_t *world);
 
+/** Get flags set on the world.
+ * This operation returns the internal flags (see api_flags.h) that are
+ * set on the world.
+ *
+ * @param world The world.
+ * @return Flags set on the world.
+ */
+FLECS_API
+ecs_flags32_t ecs_world_get_flags(
+    const ecs_world_t *world);
+
 /** @} */
 
 /**
@@ -7185,7 +7203,8 @@ void ecs_get_path_w_sep_buf(
     ecs_entity_t child,
     const char *sep,
     const char *prefix,
-    ecs_strbuf_t *buf);
+    ecs_strbuf_t *buf,
+    bool escape);
 
 /** Find or create entity from path.
  * This operation will find or create an entity from a path, and will create any
@@ -8153,6 +8172,18 @@ ecs_query_count_t ecs_query_count(
  */
 FLECS_API
 bool ecs_query_is_true(
+    const ecs_query_t *query);
+
+/** Get query used to populate cache.
+ * This operation returns the query that is used to populate the query cache.
+ * For queries that are can be entirely cached, the returned query will be 
+ * equivalent to the query passed to ecs_query_get_cache_query().
+ *
+ * @param query The query.
+ * @return The query used to populate the cache, NULL if query is not cached.
+ */
+FLECS_API
+const ecs_query_t* ecs_query_get_cache_query(
     const ecs_query_t *query);
 
 /** @} */
@@ -9189,6 +9220,18 @@ int32_t ecs_search_relation(
     ecs_id_t *id_out,
     struct ecs_table_record_t **tr_out);
 
+/** Remove all entities in a table. Does not deallocate table memory. 
+ * Retaining table memory can be efficient when planning 
+ * to refill the table with operations like ecs_bulk_init
+ *
+ * @param world The world.
+ * @param table The table to clear.
+ */
+FLECS_API
+void ecs_table_clear_entities(
+    ecs_world_t* world,
+    ecs_table_t* table);
+    
 /** @} */
 
 /**
@@ -9962,7 +10005,7 @@ int ecs_value_move_ctor(
     ecs_get_path_w_sep(world, 0, child, ".", NULL)
 
 #define ecs_get_path_buf(world, child, buf)\
-    ecs_get_path_w_sep_buf(world, 0, child, ".", NULL, buf)
+    ecs_get_path_w_sep_buf(world, 0, child, ".", NULL, buf, false)
 
 #define ecs_new_from_path(world, parent, path)\
     ecs_new_from_path_w_sep(world, parent, path, ".", NULL)
@@ -10300,6 +10343,9 @@ int ecs_value_move_ctor(
 #endif
 #ifdef FLECS_NO_SYSTEM
 #undef FLECS_SYSTEM
+#endif
+#ifdef FLECS_NO_ALERTS
+#undef FLECS_ALERTS
 #endif
 #ifdef FLECS_NO_PIPELINE
 #undef FLECS_PIPELINE
@@ -14633,6 +14679,11 @@ extern "C" {
 
 FLECS_API extern const ecs_entity_t ecs_id(EcsDocDescription); /**< Component id for EcsDocDescription. */
 
+/** Tag for adding a UUID to entities. 
+ * Added to an entity as (EcsDocDescription, EcsUuid) by ecs_doc_set_uuid().
+ */
+FLECS_API extern const ecs_entity_t EcsDocUuid;
+
 /** Tag for adding brief descriptions to entities. 
  * Added to an entity as (EcsDocDescription, EcsBrief) by ecs_doc_set_brief().
  */
@@ -14664,6 +14715,23 @@ FLECS_API extern const ecs_entity_t EcsDocColor;
 typedef struct EcsDocDescription {
     char *value;
 } EcsDocDescription;
+
+/** Add UUID to entity.
+ * Associate entity with an (external) UUID.
+ *
+ * @param world The world.
+ * @param entity The entity to which to add the UUID.
+ * @param uuid The UUID to add.
+ *
+ * @see ecs_doc_get_uuid()
+ * @see flecs::doc::set_uuid()
+ * @see flecs::entity_builder::set_doc_uuid()
+ */
+FLECS_API
+void ecs_doc_set_uuid(
+    ecs_world_t *world,
+    ecs_entity_t entity,
+    const char *uuid);
 
 /** Add human-readable name to entity.
  * Contrary to entity names, human readable names do not have to be unique and
@@ -14747,6 +14815,20 @@ void ecs_doc_set_color(
     ecs_world_t *world,
     ecs_entity_t entity,
     const char *color);
+
+/** Get UUID from entity.
+ * @param world The world.
+ * @param entity The entity from which to get the UUID.
+ * @return The UUID.
+ *
+ * @see ecs_doc_set_uuid()
+ * @see flecs::doc::get_uuid()
+ * @see flecs::entity_view::get_doc_uuid()
+ */
+FLECS_API
+const char* ecs_doc_get_uuid(
+    const ecs_world_t *world,
+    ecs_entity_t entity);
 
 /** Get human readable name from entity.
  * If entity does not have an explicit human readable name, this operation will
@@ -17222,11 +17304,11 @@ struct string_view : string {
 
 #if defined(__clang__) && __clang_major__ >= 16
 // https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
-#define enum_cast(T, v) __builtin_bit_cast(T, v)
+#define flecs_enum_cast(T, v) __builtin_bit_cast(T, v)
 #elif defined(__GNUC__) && __GNUC__ > 10
-#define enum_cast(T, v) __builtin_bit_cast(T, v)
+#define flecs_enum_cast(T, v) __builtin_bit_cast(T, v)
 #else
-#define enum_cast(T, v) static_cast<T>(v)
+#define flecs_enum_cast(T, v) static_cast<T>(v)
 #endif
 
 namespace flecs {
@@ -17235,7 +17317,7 @@ namespace flecs {
 namespace _ {
 template <typename E, underlying_type_t<E> Value>
 struct to_constant {
-    static constexpr E value = enum_cast(E, Value);
+    static constexpr E value = flecs_enum_cast(E, Value);
 };
 
 template <typename E, underlying_type_t<E> Value>
@@ -17348,7 +17430,7 @@ constexpr bool enum_constant_is_valid() {
 /* Without this wrapper __builtin_bit_cast doesn't work */
 template <typename E, underlying_type_t<E> C>
 constexpr bool enum_constant_is_valid_wrap() {
-    return enum_constant_is_valid<E, enum_cast(E, C)>();
+    return enum_constant_is_valid<E, flecs_enum_cast(E, C)>();
 }
 
 template <typename E, E C>
@@ -17515,7 +17597,7 @@ private:
         static U handle_constant(U last_value, flecs::world_t *world) {
             // Constant is valid, so fill reflection data.
             auto v = Value;
-            const char *name = enum_constant_to_name<E, enum_cast(E, Value)>();
+            const char *name = enum_constant_to_name<E, flecs_enum_cast(E, Value)>();
             
             ++enum_type<E>::data.max; // Increment cursor as we build constants array.
 
@@ -18443,6 +18525,9 @@ namespace doc {
 
 /** flecs.doc.Description component */
 using Description = EcsDocDescription;
+
+/** flecs.doc.Uuid component */
+static const flecs::entity_t Uuid = EcsDocUuid;
 
 /** flecs.doc.Brief component */
 static const flecs::entity_t Brief = EcsDocBrief;
@@ -22790,6 +22875,14 @@ public:
         iter_->callback(iter_);
     }
 
+    /** Iterate targets for pair field.
+     * 
+     * @param index The field index.
+     * @param func Callback invoked for each target
+     */
+    template <typename Func>
+    void targets(int8_t index, const Func& func);
+
     /** Free iterator resources.
      * This operation only needs to be called when the iterator is not iterated
      * until completion (e.g. the last call to next() did not return false).
@@ -23198,11 +23291,11 @@ struct entity_view : public id {
      */
     template<typename First, typename Second, if_not_t< is_enum<Second>::value> = 0>
     const First* get(Second second) const {
-        auto comp_id = _::type<First>::id(world_);
+        auto first = _::type<First>::id(world_);
         ecs_assert(_::type<First>::size() != 0, ECS_INVALID_PARAMETER,
             "operation invalid for empty type");
         return static_cast<const First*>(
-            ecs_get_id(world_, id_, ecs_pair(comp_id, second)));
+            ecs_get_id(world_, id_, ecs_pair(first, second)));
     }
 
     /** Get a pair.
@@ -23295,6 +23388,10 @@ struct entity_view : public id {
     template<typename Second>
     const Second* get_second(flecs::entity_t first) const {
         auto second = _::type<Second>::id(world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         ecs_assert(_::type<Second>::size() != 0, ECS_INVALID_PARAMETER,
             "operation invalid for empty type");
         return static_cast<const Second*>(
@@ -23364,11 +23461,11 @@ struct entity_view : public id {
      */
     template<typename First, typename Second, if_not_t< is_enum<Second>::value> = 0>
     First* get_mut(Second second) const {
-        auto comp_id = _::type<First>::id(world_);
+        auto first = _::type<First>::id(world_);
         ecs_assert(_::type<First>::size() != 0, ECS_INVALID_PARAMETER, 
             "operation invalid for empty type");
         return static_cast<First*>(
-            ecs_get_mut_id(world_, id_, ecs_pair(comp_id, second)));
+            ecs_get_mut_id(world_, id_, ecs_pair(first, second)));
     }
 
     /** Get a mutable pair.
@@ -23416,6 +23513,10 @@ struct entity_view : public id {
     template<typename Second>
     Second* get_mut_second(flecs::entity_t first) const {
         auto second = _::type<Second>::id(world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         ecs_assert(_::type<Second>::size() != 0, ECS_INVALID_PARAMETER, 
             "operation invalid for empty type");
         return static_cast<Second*>(
@@ -23855,6 +23956,19 @@ const char* doc_link() const {
  */
 const char* doc_color() const {
     return ecs_doc_get_color(world_, id_);
+}
+
+/** Get UUID.
+ *
+ * @see ecs_doc_get_uuid()
+ * @see flecs::doc::get_uuid()
+ * @see flecs::entity_builder::set_doc_uuid()
+ *
+ * @memberof flecs::entity_view
+ * @ingroup cpp_addons_doc
+ */
+const char* doc_uuid() const {
+    return ecs_doc_get_uuid(world_, id_);
 }
 
 #   endif
@@ -24808,6 +24922,10 @@ struct entity_builder : entity_view {
     template <typename Second>
     const Self& set_second(entity_t first, const Second& value) const  {
         auto second = _::type<Second>::id(this->world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         flecs::set(this->world_, this->id_, value, 
             ecs_pair(first, second));
         return to_base();
@@ -24824,6 +24942,10 @@ struct entity_builder : entity_view {
     template <typename Second>
     const Self& set_second(entity_t first, Second&& value) const  {
         auto second = _::type<Second>::id(this->world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         flecs::set(this->world_, this->id_, FLECS_FWD(value), 
             ecs_pair(first, second));
         return to_base();
@@ -24893,16 +25015,22 @@ struct entity_builder : entity_view {
 
     template <typename First, typename ... Args>
     const Self& emplace_first(flecs::entity_t second, Args&&... args) const  {
+        auto first = _::type<First>::id(this->world_);
         flecs::emplace<First>(this->world_, this->id_, 
-            ecs_pair(_::type<First>::id(this->world_), second),
+            ecs_pair(first, second),
             FLECS_FWD(args)...);
         return to_base();
     }
 
     template <typename Second, typename ... Args>
     const Self& emplace_second(flecs::entity_t first, Args&&... args) const  {
+        auto second = _::type<Second>::id(this->world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         flecs::emplace<Second>(this->world_, this->id_, 
-            ecs_pair(first, _::type<Second>::id(this->world_)),
+            ecs_pair(first, second),
             FLECS_FWD(args)...);
         return to_base();
     }
@@ -25051,8 +25179,23 @@ const Self& set_doc_link(const char *link) const {
  * @memberof flecs::entity_builder
  * @ingroup cpp_addons_doc
  */
-const Self& set_doc_color(const char *link) const {
-    ecs_doc_set_color(world_, id_, link);
+const Self& set_doc_color(const char *color) const {
+    ecs_doc_set_color(world_, id_, color);
+    return to_base();
+}
+
+/** Set doc UUID.
+ * This adds `(flecs.doc.Description, flecs.doc.Uuid)` to the entity.
+ *
+ * @see ecs_doc_set_uuid()
+ * @see flecs::doc::set_uuid()
+ * @see flecs::entity_view::doc_uuid()
+ *
+ * @memberof flecs::entity_builder
+ * @ingroup cpp_addons_doc
+ */
+const Self& set_doc_uuid(const char *uuid) const {
+    ecs_doc_set_uuid(world_, id_, uuid);
     return to_base();
 }
 
@@ -25435,11 +25578,11 @@ struct entity : entity_builder<entity>
      */
     template <typename First>
     First& ensure(entity_t second) const {
-        auto comp_id = _::type<First>::id(world_);
+        auto first = _::type<First>::id(world_);
         ecs_assert(_::type<First>::size() != 0, ECS_INVALID_PARAMETER,
             "operation invalid for empty type");
         return *static_cast<First*>(
-            ecs_ensure_id(world_, id_, ecs_pair(comp_id, second)));
+            ecs_ensure_id(world_, id_, ecs_pair(first, second)));
     }
 
     /** Get mutable pointer for a pair (untyped).
@@ -25463,6 +25606,10 @@ struct entity : entity_builder<entity>
     template <typename Second>
     Second& ensure_second(entity_t first) const {
         auto second = _::type<Second>::id(world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
         ecs_assert(_::type<Second>::size() != 0, ECS_INVALID_PARAMETER,
             "operation invalid for empty type");
         return *static_cast<Second*>(
@@ -25488,9 +25635,13 @@ struct entity : entity_builder<entity>
      * @tparam First The first part of the pair.
      * @tparam Second the second part of the pair.
      */
-    template <typename First, typename Second>
+    template <typename First, typename Second, typename A = actual_type_t<flecs::pair<First, Second>>>
     void modified() const {
-        this->modified<First>(_::type<Second>::id(world_));
+        auto first = _::type<First>::id(world_);
+        auto second = _::type<Second>::id(world_);
+        ecs_assert(_::type<A>::size() != 0, ECS_INVALID_PARAMETER,
+            "operation invalid for empty type");
+        this->modified(first, second);
     }
 
     /** Signal that the first part of a pair was modified.
@@ -25558,20 +25709,23 @@ struct entity : entity_builder<entity>
         typename A = actual_type_t<P>>
     ref<A> get_ref() const {
         return ref<A>(world_, id_,
-            ecs_pair(_::type<First>::id(world_),
-                _::type<Second>::id(world_)));
+            ecs_pair(_::type<First>::id(world_), _::type<Second>::id(world_)));
     }
 
     template <typename First>
     ref<First> get_ref(flecs::entity_t second) const {
-        return ref<First>(world_, id_,
-            ecs_pair(_::type<First>::id(world_), second));
+        auto first = _::type<First>::id(world_);
+        return ref<First>(world_, id_, ecs_pair(first, second));
     }
 
     template <typename Second>
     ref<Second> get_ref_second(flecs::entity_t first) const {
-        return ref<Second>(world_, id_,
-            ecs_pair(first, _::type<Second>::id(world_)));
+        auto second = _::type<Second>::id(world_);
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second)) != NULL,
+            ECS_INVALID_PARAMETER, "pair is not a component");
+        ecs_assert( ecs_get_type_info(world_, ecs_pair(first, second))->component == second,
+            ECS_INVALID_PARAMETER, "type of pair is not Second");
+        return ref<Second>(world_, id_, ecs_pair(first, second));
     }
 
     /** Clear an entity.
@@ -30343,6 +30497,12 @@ struct observer_builder_i : query_builder_i<Base, Components ...> {
         return *this;
     }
 
+    /** Set observer flags */
+    Base& observer_flags(ecs_flags32_t flags) {
+        desc_->flags_ |= flags;
+        return *this;
+    }
+
     /** Set observer context */
     Base& ctx(void *ptr) {
         desc_->ctx = ptr;
@@ -30658,7 +30818,7 @@ inline flecs::entity world::module(const char *name) const {
         if (prev_parent != parent) {
             // Module was reparented, cleanup old parent(s)
             flecs::entity cur = prev_parent, next;
-            do {
+            while (cur) {
                 next = cur.parent();
 
                 ecs_iter_t it = ecs_each_id(world_, ecs_pair(EcsChildOf, cur));
@@ -30667,7 +30827,7 @@ inline flecs::entity world::module(const char *name) const {
                 }
 
                 cur = next;
-            } while (cur);
+            }
         }
     }
 
@@ -31340,6 +31500,18 @@ inline void timer_init(flecs::world& world) {
 namespace flecs {
 namespace doc {
 
+/** Get UUID for an entity.
+ *
+ * @see ecs_doc_get_uuid()
+ * @see flecs::doc::set_uuid()
+ * @see flecs::entity_view::doc_uuid()
+ *
+ * @ingroup cpp_addons_doc
+ */
+inline const char* get_uuid(const flecs::entity_view& e) {
+    return ecs_doc_get_uuid(e.world(), e);
+}
+
 /** Get human readable name for an entity.
  *
  * @see ecs_doc_get_name()
@@ -31398,6 +31570,18 @@ inline const char* get_link(const flecs::entity_view& e) {
  */
 inline const char* get_color(const flecs::entity_view& e) {
     return ecs_doc_get_color(e.world(), e);
+}
+
+/** Set UUID for an entity.
+ *
+ * @see ecs_doc_set_uuid()
+ * @see flecs::doc::get_uuid()
+ * @see flecs::entity_builder::set_doc_uuid()
+ *
+ * @ingroup cpp_addons_doc
+ */
+inline void set_uuid(flecs::entity& e, const char *uuid) {
+    ecs_doc_set_uuid(e.world(), e, uuid);
 }
 
 /** Set human readable name for an entity.
@@ -32471,6 +32655,24 @@ inline flecs::entity iter::get_var(const char *name) const {
     int var_id = ecs_query_find_var(q, name);
     ecs_assert(var_id != -1, ECS_INVALID_PARAMETER, name);
     return flecs::entity(iter_->world, ecs_iter_get_var(iter_, var_id));
+}
+
+template <typename Func>
+void iter::targets(int8_t index, const Func& func) {
+    ecs_assert(iter_->table != nullptr, ECS_INVALID_OPERATION, NULL);
+    ecs_assert(index < iter_->field_count, ECS_INVALID_PARAMETER, NULL);
+    ecs_assert(ecs_field_is_set(iter_, index), ECS_INVALID_PARAMETER, NULL);
+    const ecs_type_t *table_type = ecs_table_get_type(iter_->table);
+    const ecs_table_record_t *tr = iter_->trs[index];
+    int32_t i = tr->index, end = i + tr->count;
+    for (; i < end; i ++) {
+        ecs_id_t id = table_type->array[i];
+        ecs_assert(ECS_IS_PAIR(id), ECS_INVALID_PARAMETER, 
+            "field does not match a pair");
+        flecs::entity tgt(iter_->world, 
+            ecs_pair_second(iter_->real_world, id));
+        func(tgt);
+    }
 }
 
 } // namespace flecs

--- a/libs/flecs/flecs.h
+++ b/libs/flecs/flecs.h
@@ -35,7 +35,7 @@
 /* Flecs version macros */
 #define FLECS_VERSION_MAJOR 4  /**< Flecs major version. */
 #define FLECS_VERSION_MINOR 0  /**< Flecs minor version. */
-#define FLECS_VERSION_PATCH 3  /**< Flecs patch version. */
+#define FLECS_VERSION_PATCH 4  /**< Flecs patch version. */
 
 /** Flecs version. */
 #define FLECS_VERSION FLECS_VERSION_IMPL(\
@@ -136,7 +136,7 @@
  */
 // #define FLECS_KEEP_ASSERT
 
-/** \def FLECS_CPP_NO_AUTO_REGISTRATION
+/** @def FLECS_CPP_NO_AUTO_REGISTRATION
  * When set, the C++ API will require that components are registered before they
  * are used. This is useful in multithreaded applications, where components need
  * to be registered beforehand, and to catch issues in projects where component 
@@ -146,7 +146,7 @@
  */
 // #define FLECS_CPP_NO_AUTO_REGISTRATION
 
-/** \def FLECS_CUSTOM_BUILD
+/** @def FLECS_CUSTOM_BUILD
  * This macro lets you customize which addons to build flecs with.
  * Without any addons Flecs is just a minimal ECS storage, but addons add
  * features such as systems, scheduling and reflection. If an addon is disabled,
@@ -175,38 +175,29 @@
  */
 // #define FLECS_CUSTOM_BUILD
 
-/** @def FLECS_CPP_NO_AUTO_REGISTRATION
- * When set, the C++ API will require that components are registered before they
- * are used. This is useful in multithreaded applications, where components need
- * to be registered beforehand, and to catch issues in projects where component
- * registration is mandatory. Disabling automatic component registration also
- * slightly improves performance.
- * The C API is not affected by this feature.
- */
-// #define FLECS_CPP_NO_AUTO_REGISTRATION
-
 #ifndef FLECS_CUSTOM_BUILD
-// #define FLECS_C          /**< C API convenience macros, always enabled */
-#define FLECS_CPP           /**< C++ API */
-#define FLECS_MODULE        /**< Module support */
-#define FLECS_SCRIPT        /**< ECS data definition format */
-#define FLECS_STATS         /**< Track runtime statistics */
-#define FLECS_METRICS       /**< Expose component data as statistics */
-#define FLECS_ALERTS        /**< Monitor conditions for errors */
-#define FLECS_SYSTEM        /**< System support */
-#define FLECS_PIPELINE      /**< Pipeline support */
-#define FLECS_TIMER         /**< Timer support */
-#define FLECS_META          /**< Reflection support */
-#define FLECS_UNITS         /**< Builtin standard units */
-#define FLECS_JSON          /**< Parsing JSON to/from component values */
-#define FLECS_DOC           /**< Document entities & components */
-#define FLECS_LOG           /**< When enabled ECS provides more detailed logs */
-#define FLECS_APP           /**< Application addon */
-#define FLECS_OS_API_IMPL   /**< Default implementation for OS API */
-#define FLECS_HTTP          /**< Tiny HTTP server for connecting to remote UI */
-#define FLECS_REST          /**< REST API for querying application data */
-// #define FLECS_JOURNAL    /**< Journaling addon (disabled by default) */
-// #define FLECS_PERF_TRACE /**< Enable performance tracing (disabled by default) */
+#define FLECS_ALERTS         /**< Monitor conditions for errors */
+#define FLECS_APP            /**< Application addon */
+// #define FLECS_C           /**< C API convenience macros, always enabled */
+#define FLECS_CPP            /**< C++ API */
+#define FLECS_DOC            /**< Document entities & components */
+// #define FLECS_JOURNAL     /**< Journaling addon (disabled by default) */
+#define FLECS_JSON           /**< Parsing JSON to/from component values */
+#define FLECS_HTTP           /**< Tiny HTTP server for connecting to remote UI */
+#define FLECS_LOG            /**< When enabled ECS provides more detailed logs */
+#define FLECS_META           /**< Reflection support */
+#define FLECS_METRICS        /**< Expose component data as statistics */
+#define FLECS_MODULE         /**< Module support */
+#define FLECS_OS_API_IMPL    /**< Default implementation for OS API */
+// #define FLECS_PERF_TRACE  /**< Enable performance tracing (disabled by default) */
+#define FLECS_PIPELINE       /**< Pipeline support */
+#define FLECS_REST           /**< REST API for querying application data */
+#define FLECS_SCRIPT         /**< Flecs entity notation language */
+// #define FLECS_SCRIPT_MATH /**< Math functions for flecs script (may require linking with libm) */
+#define FLECS_SYSTEM         /**< System support */
+#define FLECS_STATS          /**< Track runtime statistics */
+#define FLECS_TIMER          /**< Timer support */
+#define FLECS_UNITS          /**< Builtin standard units */
 #endif // ifndef FLECS_CUSTOM_BUILD
 
 /** @def FLECS_LOW_FOOTPRINT
@@ -216,7 +207,7 @@
 #ifdef FLECS_LOW_FOOTPRINT
 #define FLECS_HI_COMPONENT_ID (16)
 #define FLECS_HI_ID_RECORD_ID (16)
-#define FLECS_SPARSE_PAGE_BITS (6)
+#define FLECS_SPARSE_PAGE_BITS (4)
 #define FLECS_ENTITY_PAGE_BITS (6)
 #define FLECS_USE_OS_ALLOC
 #endif
@@ -251,7 +242,7 @@
  * determines the page size, which is (1 << bits).
  * Lower values decrease memory utilization, at the cost of more allocations. */
 #ifndef FLECS_SPARSE_PAGE_BITS
-#define FLECS_SPARSE_PAGE_BITS (12)
+#define FLECS_SPARSE_PAGE_BITS (6)
 #endif
 
 /** @def FLECS_ENTITY_PAGE_BITS
@@ -272,7 +263,7 @@
 #define FLECS_ID_DESC_MAX (32)
 #endif
 
-/** \def FLECS_EVENT_DESC_MAX
+/** @def FLECS_EVENT_DESC_MAX
  * Maximum number of events in ecs_observer_desc_t */
 #ifndef FLECS_EVENT_DESC_MAX
 #define FLECS_EVENT_DESC_MAX (8)
@@ -282,19 +273,19 @@
  * Maximum number of query variables per query */
 #define FLECS_VARIABLE_COUNT_MAX (64)
 
-/** \def FLECS_TERM_COUNT_MAX 
+/** @def FLECS_TERM_COUNT_MAX 
  * Maximum number of terms in queries. Should not exceed 64. */
 #ifndef FLECS_TERM_COUNT_MAX
 #define FLECS_TERM_COUNT_MAX 32
 #endif
 
-/** \def FLECS_TERM_ARG_COUNT_MAX 
+/** @def FLECS_TERM_ARG_COUNT_MAX 
  * Maximum number of arguments for a term. */
 #ifndef FLECS_TERM_ARG_COUNT_MAX
 #define FLECS_TERM_ARG_COUNT_MAX (16)
 #endif
 
-/** \def FLECS_QUERY_VARIABLE_COUNT_MAX
+/** @def FLECS_QUERY_VARIABLE_COUNT_MAX
  * Maximum number of query variables per query. Should not exceed 128. */
 #ifndef FLECS_QUERY_VARIABLE_COUNT_MAX
 #define FLECS_QUERY_VARIABLE_COUNT_MAX (64)
@@ -304,6 +295,14 @@
  * Maximum nesting depth of query scopes */
 #ifndef FLECS_QUERY_SCOPE_NESTING_MAX
 #define FLECS_QUERY_SCOPE_NESTING_MAX (8)
+#endif
+
+/** @def FLECS_DAG_DEPTH_MAX
+ * Maximum of levels in a DAG (acyclic relationship graph). If a graph with a
+ * depth larger than this is encountered, a CYCLE_DETECTED panic is thrown.
+ */
+#ifndef FLECS_DAG_DEPTH_MAX
+#define FLECS_DAG_DEPTH_MAX (128)
 #endif
 
 /** @} */
@@ -562,7 +561,6 @@ extern "C" {
 //// Aperiodic action flags (used by ecs_run_aperiodic)
 ////////////////////////////////////////////////////////////////////////////////
 
-#define EcsAperiodicEmptyTables        (1u << 1u)  /* Process pending empty table events */
 #define EcsAperiodicComponentMonitors  (1u << 2u)  /* Process component monitors */
 #define EcsAperiodicEmptyQueries       (1u << 4u)  /* Process empty queries */
 
@@ -628,6 +626,13 @@ extern "C" {
     #endif
 #endif
 
+/* Define noreturn attribute only for GCC or Clang. */
+#if defined(ECS_TARGET_GNU) || defined(ECS_TARGET_CLANG)
+    #define ECS_NORETURN __attribute__((noreturn))
+#else
+    #define ECS_NORETURN
+#endif
+
 /* Ignored warnings */
 #if defined(ECS_TARGET_CLANG)
 /* Ignore unknown options so we don't have to care about the compiler version */
@@ -658,6 +663,11 @@ extern "C" {
 /* Useful, but not reliable enough. It can incorrectly flag macro's as unused
  * in standalone builds. */
 #pragma clang diagnostic ignored "-Wunused-macros"
+/* This warning gets thrown by clang even when a code is handling all case
+ * values but not all cases (for example, when the switch contains a LastValue
+ * case). Adding a "default" case fixes the warning, but silences future 
+ * warnings about unhandled cases, which is worse. */
+#pragma clang diagnostic ignored "-Wswitch-default"
 #if __clang_major__ == 13
 /* clang 13 can throw this warning for a define in ctype.h */
 #pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -1085,6 +1095,7 @@ typedef struct ecs_vec_t {
     int32_t size;
 #ifdef FLECS_SANITIZE
     ecs_size_t elem_size;
+    const char *type_name;
 #endif
 } ecs_vec_t;
 
@@ -1095,8 +1106,16 @@ void ecs_vec_init(
     ecs_size_t size,
     int32_t elem_count);
 
+FLECS_API
+void ecs_vec_init_w_dbg_info(
+    struct ecs_allocator_t *allocator,
+    ecs_vec_t *vec,
+    ecs_size_t size,
+    int32_t elem_count,
+    const char *type_name);
+
 #define ecs_vec_init_t(allocator, vec, T, elem_count) \
-    ecs_vec_init(allocator, vec, ECS_SIZEOF(T), elem_count)
+    ecs_vec_init_w_dbg_info(allocator, vec, ECS_SIZEOF(T), elem_count, "vec<"#T">")
 
 FLECS_API
 void ecs_vec_init_if(
@@ -1506,6 +1525,8 @@ void* ecs_sparse_get(
 #define FLECS_BLOCK_ALLOCATOR_H
 
 
+typedef struct ecs_map_t ecs_map_t;
+
 typedef struct ecs_block_allocator_block_t {
     void *memory;
     struct ecs_block_allocator_block_t *next;
@@ -1523,7 +1544,10 @@ typedef struct ecs_block_allocator_t {
     int32_t data_size;
     int32_t chunks_per_block;
     int32_t block_size;
+#ifdef FLECS_SANITIZE
     int32_t alloc_count;
+    ecs_map_t *outstanding;
+#endif
 } ecs_block_allocator_t;
 
 FLECS_API
@@ -1558,8 +1582,18 @@ void* flecs_balloc(
     ecs_block_allocator_t *allocator);
 
 FLECS_API
+void* flecs_balloc_w_dbg_info(
+    ecs_block_allocator_t *allocator,
+    const char *type_name);
+
+FLECS_API
 void* flecs_bcalloc(
     ecs_block_allocator_t *allocator);
+
+FLECS_API
+void* flecs_bcalloc_w_dbg_info(
+    ecs_block_allocator_t *allocator,
+    const char *type_name);
 
 FLECS_API
 void flecs_bfree(
@@ -1577,6 +1611,13 @@ void* flecs_brealloc(
     ecs_block_allocator_t *dst, 
     ecs_block_allocator_t *src, 
     void *memory);
+
+FLECS_API
+void* flecs_brealloc_w_dbg_info(
+    ecs_block_allocator_t *dst, 
+    ecs_block_allocator_t *src, 
+    void *memory,
+    const char *type_name);
 
 FLECS_API
 void* flecs_bdup(
@@ -1614,7 +1655,7 @@ typedef struct ecs_stack_cursor_t {
 } ecs_stack_cursor_t;
 
 typedef struct ecs_stack_t {
-    ecs_stack_page_t first;
+    ecs_stack_page_t *first;
     ecs_stack_page_t *tail_page;
     ecs_stack_cursor_t *tail_cursor;
 #ifdef FLECS_DEBUG
@@ -1707,7 +1748,7 @@ typedef struct ecs_bucket_t {
     ecs_bucket_entry_t *first;
 } ecs_bucket_t;
 
-typedef struct ecs_map_t {
+struct ecs_map_t {
     uint8_t bucket_shift;
     bool shared_allocator;
     ecs_bucket_t *buckets;
@@ -1715,7 +1756,7 @@ typedef struct ecs_map_t {
     int32_t count;
     struct ecs_block_allocator_t *entry_allocator;
     struct ecs_allocator_t *allocator;
-} ecs_map_t;
+};
 
 typedef struct ecs_map_iter_t {
     const ecs_map_t *map;
@@ -2004,12 +2045,14 @@ void* flecs_dup(
 #define flecs_allocator(obj) (&obj->allocators.dyn)
 
 #define flecs_alloc(a, size) flecs_balloc(flecs_allocator_get(a, size))
-#define flecs_alloc_t(a, T) flecs_alloc(a, ECS_SIZEOF(T))
-#define flecs_alloc_n(a, T, count) flecs_alloc(a, ECS_SIZEOF(T) * (count))
+#define flecs_alloc_w_dbg_info(a, size, type_name) flecs_balloc_w_dbg_info(flecs_allocator_get(a, size), type_name)
+#define flecs_alloc_t(a, T) flecs_alloc_w_dbg_info(a, ECS_SIZEOF(T), #T)
+#define flecs_alloc_n(a, T, count) flecs_alloc_w_dbg_info(a, ECS_SIZEOF(T) * (count), #T)
 
 #define flecs_calloc(a, size) flecs_bcalloc(flecs_allocator_get(a, size))
-#define flecs_calloc_t(a, T) flecs_calloc(a, ECS_SIZEOF(T))
-#define flecs_calloc_n(a, T, count) flecs_calloc(a, ECS_SIZEOF(T) * (count))
+#define flecs_calloc_w_dbg_info(a, size, type_name) flecs_bcalloc_w_dbg_info(flecs_allocator_get(a, size), type_name)
+#define flecs_calloc_t(a, T) flecs_calloc_w_dbg_info(a, ECS_SIZEOF(T), #T)
+#define flecs_calloc_n(a, T, count) flecs_calloc_w_dbg_info(a, ECS_SIZEOF(T) * (count), #T)
 
 #define flecs_free(a, size, ptr)\
     flecs_bfree((ptr) ? flecs_allocator_get(a, size) : NULL, ptr)
@@ -2023,6 +2066,11 @@ void* flecs_dup(
     flecs_brealloc(flecs_allocator_get(a, size_dst),\
     flecs_allocator_get(a, size_src),\
     ptr)
+#define flecs_realloc_w_dbg_info(a, size_dst, size_src, ptr, type_name)\
+    flecs_brealloc_w_dbg_info(flecs_allocator_get(a, size_dst),\
+    flecs_allocator_get(a, size_src),\
+    ptr,\
+    type_name)
 #define flecs_realloc_n(a, T, count_dst, count_src, ptr)\
     flecs_realloc(a, ECS_SIZEOF(T) * (count_dst), ECS_SIZEOF(T) * (count_src), ptr)
 
@@ -3159,7 +3207,6 @@ typedef struct ecs_table_cache_hdr_t {
     struct ecs_table_cache_t *cache;  /**< Table cache of element. Of type ecs_id_record_t* for component index elements. */
     ecs_table_t *table;               /**< Table associated with element. */
     struct ecs_table_cache_hdr_t *prev, *next; /**< Next/previous elements for id in table cache. */
-    bool empty;                       /**< Whether element is in empty list. */
 } ecs_table_cache_hdr_t;
 
 /** Metadata describing where a component id is stored in a table.
@@ -3517,6 +3564,40 @@ struct ecs_observer_t {
  *
  * @ingroup components
  */
+
+/* Flags that can be used to check which hooks a type has set */
+#define ECS_TYPE_HOOK_CTOR                   (1 << 0)
+#define ECS_TYPE_HOOK_DTOR                   (1 << 1)
+#define ECS_TYPE_HOOK_COPY                   (1 << 2)
+#define ECS_TYPE_HOOK_MOVE                   (1 << 3)
+#define ECS_TYPE_HOOK_COPY_CTOR              (1 << 4)
+#define ECS_TYPE_HOOK_MOVE_CTOR              (1 << 5)
+#define ECS_TYPE_HOOK_CTOR_MOVE_DTOR         (1 << 6)
+#define ECS_TYPE_HOOK_MOVE_DTOR              (1 << 7)
+
+/* Flags that can be used to set/check which hooks of a type are invalid */
+#define ECS_TYPE_HOOK_CTOR_ILLEGAL           (1 << 8)
+#define ECS_TYPE_HOOK_DTOR_ILLEGAL           (1 << 9)
+#define ECS_TYPE_HOOK_COPY_ILLEGAL           (1 << 10)
+#define ECS_TYPE_HOOK_MOVE_ILLEGAL           (1 << 11)
+#define ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL      (1 << 12)
+#define ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL      (1 << 13)
+#define ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL (1 << 14)
+#define ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL      (1 << 15)
+
+/* All valid hook flags */
+#define ECS_TYPE_HOOKS (ECS_TYPE_HOOK_CTOR|ECS_TYPE_HOOK_DTOR|\
+    ECS_TYPE_HOOK_COPY|ECS_TYPE_HOOK_MOVE|ECS_TYPE_HOOK_COPY_CTOR|\
+    ECS_TYPE_HOOK_MOVE_CTOR|ECS_TYPE_HOOK_CTOR_MOVE_DTOR|\
+    ECS_TYPE_HOOK_MOVE_DTOR)
+
+/* All invalid hook flags */
+#define ECS_TYPE_HOOKS_ILLEGAL (ECS_TYPE_HOOK_CTOR_ILLEGAL|\
+    ECS_TYPE_HOOK_DTOR_ILLEGAL|ECS_TYPE_HOOK_COPY_ILLEGAL|\
+    ECS_TYPE_HOOK_MOVE_ILLEGAL|ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL|\
+    ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL|ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL|\
+    ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL)
+
 struct ecs_type_hooks_t {
     ecs_xtor_t ctor;            /**< ctor */
     ecs_xtor_t dtor;            /**< dtor */
@@ -3541,6 +3622,12 @@ struct ecs_type_hooks_t {
      * not set explicitly it will be derived from other callbacks. */
     ecs_move_t move_dtor;
 
+    /** Hook flags.
+     * Indicates which hooks are set for the type, and which hooks are illegal.
+     * When an ILLEGAL flag is set when calling ecs_set_hooks() a hook callback
+     * will be set that panics when called. */
+    ecs_flags32_t flags;
+
     /** Callback that is invoked when an instance of a component is added. This
      * callback is invoked before triggers are invoked. */
     ecs_iter_action_t on_add;
@@ -3562,7 +3649,6 @@ struct ecs_type_hooks_t {
     ecs_ctx_free_t ctx_free;           /**< Callback to free ctx */
     ecs_ctx_free_t binding_ctx_free;   /**< Callback to free binding_ctx */
     ecs_ctx_free_t lifecycle_ctx_free; /**< Callback to free lifecycle_ctx */
-
 };
 
 /** Type that contains component information (passed to ctors/dtors/...)
@@ -3623,6 +3709,7 @@ struct ecs_observable_t {
     ecs_event_record_t on_set;
     ecs_event_record_t on_wildcard;
     ecs_sparse_t events;  /* sparse<event, ecs_event_record_t> */
+    uint64_t last_observer_id;
 };
 
 /** Range in table */
@@ -3669,7 +3756,8 @@ typedef struct ecs_worker_iter_t {
 /* Convenience struct to iterate table array for id */
 typedef struct ecs_table_cache_iter_t {
     struct ecs_table_cache_hdr_t *cur, *next;
-    struct ecs_table_cache_hdr_t *next_list;
+    bool iter_fill;
+    bool iter_empty;
 } ecs_table_cache_iter_t;
 
 /** Each iterator */
@@ -3891,39 +3979,6 @@ FLECS_DBG_API
 void flecs_dump_backtrace(
     void *stream);
 
-/* Suspend/resume readonly state. To fully support implicit registration of
- * components, it should be possible to register components while the world is
- * in readonly mode. It is not uncommon that a component is used first from
- * within a system, which are often ran while in readonly mode.
- * 
- * Suspending readonly mode is only allowed when the world is not multithreaded.
- * When a world is multithreaded, it is not safe to (even temporarily) leave
- * readonly mode, so a multithreaded application should always explicitly
- * register components in advance. 
- * 
- * These operations also suspend deferred mode.
- */
-typedef struct ecs_suspend_readonly_state_t {
-    bool is_readonly;
-    bool is_deferred;
-    int32_t defer_count;
-    ecs_entity_t scope;
-    ecs_entity_t with;
-    ecs_vec_t commands;
-    ecs_stack_t defer_stack;
-    ecs_stage_t *stage;
-} ecs_suspend_readonly_state_t;
-
-FLECS_API
-ecs_world_t* flecs_suspend_readonly(
-    const ecs_world_t *world,
-    ecs_suspend_readonly_state_t *state);
-
-FLECS_API
-void flecs_resume_readonly(
-    ecs_world_t *world,
-    ecs_suspend_readonly_state_t *state);
-
 FLECS_API
 int32_t flecs_poly_claim_(
     ecs_poly_t *poly);
@@ -3936,8 +3991,28 @@ FLECS_API
 int32_t flecs_poly_refcount(
     ecs_poly_t *poly);
 
+FLECS_API
+int32_t flecs_component_ids_index_get(void);
+
+FLECS_API
+ecs_entity_t flecs_component_ids_get(
+    const ecs_world_t *world, 
+    int32_t index);
+
+FLECS_API
+ecs_entity_t flecs_component_ids_get_alive(
+    const ecs_world_t *stage_world, 
+    int32_t index);
+
+FLECS_API
+void flecs_component_ids_set(
+    ecs_world_t *world, 
+    int32_t index,
+    ecs_entity_t id);
+
 #define flecs_poly_claim(poly) \
     flecs_poly_claim_(ECS_CONST_CAST(void*, reinterpret_cast<const void*>(poly)))
+
 #define flecs_poly_release(poly) \
     flecs_poly_release_(ECS_CONST_CAST(void*, reinterpret_cast<const void*>(poly)))
 
@@ -4598,7 +4673,6 @@ typedef struct ecs_world_info_t {
     int32_t pair_id_count;            /**< Number of pair ids in the world */
 
     int32_t table_count;              /**< Number of tables */
-    int32_t empty_table_count;        /**< Number of tables without entities */
 
     /* -- Command counts -- */
     struct {
@@ -4974,12 +5048,6 @@ FLECS_API extern const ecs_entity_t EcsOnTableCreate;
 
 /** Event that triggers when a table is deleted. */
 FLECS_API extern const ecs_entity_t EcsOnTableDelete;
-
-/** Event that triggers when a table becomes empty (doesn't emit on creation). */
-FLECS_API extern const ecs_entity_t EcsOnTableEmpty;
-
-/** Event that triggers when a table becomes non-empty. */
-FLECS_API extern const ecs_entity_t EcsOnTableFill;
 
 /** Relationship used for specifying cleanup behavior. */
 FLECS_API extern const ecs_entity_t EcsOnDelete;
@@ -5753,6 +5821,24 @@ void ecs_run_aperiodic(
     ecs_world_t *world,
     ecs_flags32_t flags);
 
+/** Used with ecs_delete_empty_tables(). */
+typedef struct ecs_delete_empty_tables_desc_t {
+    /** Optional component filter for the tables to evaluate. */
+    ecs_id_t id;
+
+    /** Free table data when generation > clear_generation. */
+    uint16_t clear_generation;
+
+    /** Delete table when generation > delete_generation. */
+    uint16_t delete_generation;
+
+    /** Minimum number of component ids the table should have. */
+    int32_t min_id_count;
+
+    /** Amount of time operation is allowed to spend. */
+    double time_budget_seconds;
+} ecs_delete_empty_tables_desc_t;
+
 /** Cleanup empty tables.
  * This operation cleans up empty tables that meet certain conditions. Having
  * large amounts of empty tables does not negatively impact performance of the
@@ -5779,21 +5865,13 @@ void ecs_run_aperiodic(
  * The time budget specifies how long the operation should take at most.
  *
  * @param world The world.
- * @param id Optional component filter for the tables to evaluate.
- * @param clear_generation Free table data when generation > clear_generation.
- * @param delete_generation Delete table when generation > delete_generation.
- * @param min_id_count Minimum number of component ids the table should have.
- * @param time_budget_seconds Amount of time operation is allowed to spend.
+ * @param desc Configuration parameters.
  * @return Number of deleted tables.
  */
 FLECS_API
 int32_t ecs_delete_empty_tables(
     ecs_world_t *world,
-    ecs_id_t id,
-    uint16_t clear_generation,
-    uint16_t delete_generation,
-    int32_t min_id_count,
-    double time_budget_seconds);
+    const ecs_delete_empty_tables_desc_t *desc);
 
 /** Get world from poly.
  *
@@ -8080,6 +8158,19 @@ FLECS_API
 bool ecs_query_changed(
     ecs_query_t *query);
 
+/** Get query object.
+ * Returns the query object. Can be used to access various information about
+ * the query.
+ *
+ * @param world The world.
+ * @param query The query.
+ * @return The query object.
+ */
+FLECS_API
+const ecs_query_t* ecs_query_get(
+    const ecs_world_t *world,
+    ecs_entity_t query);
+
 /** Skip a table while iterating.
  * This operation lets the query iterator know that a table was skipped while
  * iterating. A skipped table will not reset its changed state, and the query
@@ -10338,6 +10429,9 @@ int ecs_value_move_ctor(
 #ifdef FLECS_NO_SCRIPT
 #undef FLECS_SCRIPT
 #endif
+#ifdef FLECS_NO_SCRIPT_MATH
+#undef FLECS_SCRIPT_MATH
+#endif
 #ifdef FLECS_NO_STATS
 #undef FLECS_STATS
 #endif
@@ -10643,6 +10737,22 @@ void ecs_parser_errorv_(
     const char *fmt,
     va_list args);
 
+FLECS_API
+void ecs_parser_warning_(
+    const char *name,
+    const char *expr,
+    int64_t column,
+    const char *fmt,
+    ...);
+
+FLECS_API
+void ecs_parser_warningv_(
+    const char *name,
+    const char *expr,
+    int64_t column,
+    const char *fmt,
+    va_list args);
+
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Logging macros
@@ -10887,6 +10997,12 @@ void ecs_parser_errorv_(
 
 #define ecs_parser_errorv(name, expr, column, fmt, args)\
     ecs_parser_errorv_(name, expr, column, fmt, args)
+
+#define ecs_parser_warning(name, expr, column, ...)\
+    ecs_parser_warning_(name, expr, column, __VA_ARGS__)
+
+#define ecs_parser_warningv(name, expr, column, fmt, args)\
+    ecs_parser_warningv_(name, expr, column, fmt, args)
 
 #endif // FLECS_LEGACY
 
@@ -11387,6 +11503,7 @@ int ecs_http_server_request(
     ecs_http_server_t* srv,
     const char *method,
     const char *req,
+    const char *body,
     ecs_http_reply_t *reply_out);
 
 /** Get context provided in ecs_http_server_desc_t */
@@ -13587,7 +13704,9 @@ typedef struct ecs_entity_to_json_desc_t {
 } ecs_entity_to_json_desc_t;
 
 /** Utility used to initialize JSON entity serializer. */
+#ifndef __cplusplus
 #define ECS_ENTITY_TO_JSON_INIT (ecs_entity_to_json_desc_t){\
+    .serialize_entity_id = false, \
     .serialize_doc = false, \
     .serialize_full_paths = true, \
     .serialize_inherited = false, \
@@ -13598,6 +13717,20 @@ typedef struct ecs_entity_to_json_desc_t {
     .serialize_refs = 0, \
     .serialize_matches = false, \
 }
+#else
+#define ECS_ENTITY_TO_JSON_INIT {\
+    false, \
+    false, \
+    true, \
+    false, \
+    true, \
+    false, \
+    false, \
+    false, \
+    0, \
+    false, \
+}
+#endif
 
 /** Serialize entity into JSON string.
  * This creates a JSON object with the entity's (path) name, which components
@@ -13653,6 +13786,7 @@ typedef struct ecs_iter_to_json_desc_t {
 } ecs_iter_to_json_desc_t;
 
 /** Utility used to initialize JSON iterator serializer. */
+#ifndef __cplusplus
 #define ECS_ITER_TO_JSON_INIT (ecs_iter_to_json_desc_t){\
     .serialize_entity_ids =      false, \
     .serialize_values =          true, \
@@ -13671,7 +13805,30 @@ typedef struct ecs_iter_to_json_desc_t {
     .serialize_alerts =          false, \
     .serialize_refs =            false, \
     .serialize_matches =         false, \
+    .query =                     NULL \
 }
+#else
+#define ECS_ITER_TO_JSON_INIT {\
+    false, \
+    true, \
+    false, \
+    false, \
+    true, \
+    true, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    false, \
+    nullptr \
+}
+#endif
 
 /** Serialize iterator into JSON string.
  * This operation will iterate the contents of the iterator and serialize them
@@ -14114,6 +14271,68 @@ void FlecsUnitsImport(
 
 #endif
 
+#ifdef FLECS_SCRIPT_MATH
+#ifdef FLECS_NO_SCRIPT_MATH
+#error "FLECS_NO_SCRIPT_MATH failed: SCRIPT_MATH is required by other addons"
+#endif
+/**
+ * @file addons/script_math.h
+ * @brief Math functions for flecs script.
+ */
+
+#ifdef FLECS_SCRIPT_MATH
+
+#ifndef FLECS_SCRIPT
+#define FLECS_SCRIPT
+#endif
+
+/**
+ * @defgroup c_addons_script_math Script Math
+ * @ingroup c_addons
+ * Math functions for flecs script.
+ * @{
+ */
+
+#ifndef FLECS_SCRIPT_MATH_H
+#define FLECS_SCRIPT_MATH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FLECS_API
+extern ECS_COMPONENT_DECLARE(EcsScriptRng);
+
+/* Randon number generator */
+typedef struct {
+    uint64_t seed;
+    void *impl;
+} EcsScriptRng;
+
+/** Script math import function.
+ * Usage:
+ * @code
+ * ECS_IMPORT(world, FlecsScriptMath)
+ * @endcode
+ * 
+ * @param world The world.
+ */
+FLECS_API
+void FlecsScriptMathImport(
+    ecs_world_t *world);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/** @} */
+
+#endif
+
+#endif
+
 #ifdef FLECS_SCRIPT
 #ifdef FLECS_NO_SCRIPT
 #error "FLECS_NO_SCRIPT failed: SCRIPT is required by other addons"
@@ -14151,9 +14370,24 @@ void FlecsUnitsImport(
 extern "C" {
 #endif
 
+#define FLECS_SCRIPT_FUNCTION_ARGS_MAX (16)
+
 FLECS_API
 extern ECS_COMPONENT_DECLARE(EcsScript);
 
+FLECS_API
+extern ECS_DECLARE(EcsScriptTemplate);
+
+FLECS_API
+extern ECS_COMPONENT_DECLARE(EcsScriptConstVar);
+
+FLECS_API
+extern ECS_COMPONENT_DECLARE(EcsScriptFunction);
+
+FLECS_API
+extern ECS_COMPONENT_DECLARE(EcsScriptMethod);
+
+/* Script template. */
 typedef struct ecs_script_template_t ecs_script_template_t;
 
 /** Script variable. */
@@ -14161,11 +14395,15 @@ typedef struct ecs_script_var_t {
     const char *name;
     ecs_value_t value;
     const ecs_type_info_t *type_info;
+    int32_t sp;
+    bool is_const;
 } ecs_script_var_t;
 
 /** Script variable scope. */
 typedef struct ecs_script_vars_t {
     struct ecs_script_vars_t *parent;
+    int32_t sp;
+
     ecs_hashmap_t var_index;
     ecs_vec_t vars;
 
@@ -14182,6 +14420,9 @@ typedef struct ecs_script_t {
     const char *code;
 } ecs_script_t;
 
+/* Runtime for executing scripts */
+typedef struct ecs_script_runtime_t ecs_script_runtime_t;
+
 /** Script component. 
  * This component is added to the entities of managed scripts and templates.
  */
@@ -14190,33 +14431,100 @@ typedef struct EcsScript {
     ecs_script_template_t *template_; /* Only set for template scripts */
 } EcsScript;
 
+/** Script function context. */
+typedef struct ecs_function_ctx_t {
+    ecs_world_t *world;
+    ecs_entity_t function;
+    void *ctx;
+} ecs_function_ctx_t;
+
+/** Script function callback. */
+typedef void(*ecs_function_callback_t)(
+    const ecs_function_ctx_t *ctx,
+    int32_t argc,
+    const ecs_value_t *argv,
+    ecs_value_t *result);
+
+/** Function argument type. */
+typedef struct ecs_script_parameter_t {
+    const char *name;
+    ecs_entity_t type;
+} ecs_script_parameter_t;
+
+/** Const component.
+ * This component describes a const variable that can be used from scripts.
+ */
+typedef struct EcsScriptConstVar {
+    ecs_value_t value;
+    const ecs_type_info_t *type_info;
+} EcsScriptConstVar;
+
+/** Function component.
+ * This component describes a function that can be called from a script.
+ */
+typedef struct EcsScriptFunction {
+    ecs_entity_t return_type;
+    ecs_vec_t params; /* vec<ecs_script_parameter_t> */
+    ecs_function_callback_t callback;
+    void *ctx;
+} EcsScriptFunction;
+
+/** Method component. 
+ * This component describes a method that can be called from a script. Methods
+ * are functions that can be called on instances of a type. A method entity is
+ * stored in the scope of the type it belongs to.
+ */
+typedef struct EcsScriptMethod {
+    ecs_entity_t return_type;
+    ecs_vec_t params; /* vec<ecs_script_parameter_t> */
+    ecs_function_callback_t callback;
+    void *ctx;
+} EcsScriptMethod;
 
 /* Parsing & running scripts */
+
+/** Used with ecs_script_parse() and ecs_script_eval() */
+typedef struct ecs_script_eval_desc_t {
+    ecs_script_vars_t *vars;       /**< Variables used by script */
+    ecs_script_runtime_t *runtime; /**< Reusable runtime (optional) */
+} ecs_script_eval_desc_t;
 
 /** Parse script.
  * This operation parses a script and returns a script object upon success. To
  * run the script, call ecs_script_eval().
  * 
+ * If the script uses outside variables, an ecs_script_vars_t object must be
+ * provided in the vars member of the desc object that defines all variables 
+ * with the correct types.
+ * 
  * @param world The world.
  * @param name Name of the script (typically a file/module name).
  * @param code The script code.
+ * @param desc Parameters for script runtime.
  * @return Script object if success, NULL if failed.
 */
 FLECS_API
 ecs_script_t* ecs_script_parse(
     ecs_world_t *world,
     const char *name,
-    const char *code);
+    const char *code,
+    const ecs_script_eval_desc_t *desc);
 
 /** Evaluate script.
  * This operation evaluates (runs) a parsed script.
  * 
+ * If variables were provided to ecs_script_parse(), an application may pass
+ * a different ecs_script_vars_t object to ecs_script_eval(), as long as the
+ * object has all referenced variables and they are of the same type.
+ * 
  * @param script The script.
+ * @param desc Parameters for script runtime.
  * @return Zero if success, non-zero if failed.
 */
 FLECS_API
 int ecs_script_eval(
-    ecs_script_t *script);
+    const ecs_script_t *script,
+    const ecs_script_eval_desc_t *desc);
 
 /** Free script.
  * This operation frees a script object.
@@ -14266,6 +14574,31 @@ int ecs_script_run_file(
     ecs_world_t *world,
     const char *filename);
 
+/** Create runtime for script.
+ * A script runtime is a container for any data created during script 
+ * evaluation. By default calling ecs_script_run() or ecs_script_eval() will
+ * create a runtime on the spot. A runtime can be created in advance and reused
+ * across multiple script evaluations to improve performance.
+ * 
+ * When scripts are evaluated on multiple threads, each thread should have its
+ * own script runtime.
+ * 
+ * A script runtime must be deleted with ecs_script_runtime_free().
+ * 
+ * @return A new script runtime.
+ */
+FLECS_API
+ecs_script_runtime_t* ecs_script_runtime_new(void);
+
+/** Free script runtime.
+ * This operation frees a script runtime created by ecs_script_runtime_new().
+ * 
+ * @param runtime The runtime to free.
+ */
+FLECS_API
+void ecs_script_runtime_free(
+    ecs_script_runtime_t *runtime);
+
 /** Convert script AST to string.
  * This operation converts the script abstract syntax tree to a string, which
  * can be used to debug a script.
@@ -14277,7 +14610,8 @@ int ecs_script_run_file(
 FLECS_API
 int ecs_script_ast_to_buf(
     ecs_script_t *script,
-    ecs_strbuf_t *buf);
+    ecs_strbuf_t *buf,
+    bool colors);
 
 /** Convert script AST to string.
  * This operation converts the script abstract syntax tree to a string, which
@@ -14288,7 +14622,8 @@ int ecs_script_ast_to_buf(
  */
 FLECS_API
 char* ecs_script_ast_to_str(
-    ecs_script_t *script);
+    ecs_script_t *script,
+    bool colors);
 
 
 /* Managed scripts (script associated with entity that outlives the function) */
@@ -14459,6 +14794,45 @@ ecs_script_var_t* ecs_script_vars_lookup(
     const ecs_script_vars_t *vars,
     const char *name);
 
+/** Lookup a variable by stack pointer.
+ * This operation provides a faster way to lookup variables that are always 
+ * declared in the same order in a ecs_script_vars_t scope.
+ * 
+ * The stack pointer of a variable can be obtained from the ecs_script_var_t 
+ * type. The provided frame offset must be valid for the provided variable  
+ * stack. If the frame offset is not valid, this operation will panic.
+ * 
+ * @param vars The variable scope.
+ * @param sp The stack pointer to the variable.
+ * @return The variable.
+ */
+FLECS_API
+ecs_script_var_t* ecs_script_vars_from_sp(
+    const ecs_script_vars_t *vars,
+    int32_t sp);
+
+/** Print variables.
+ * This operation prints all variables in the vars scope and parent scopes.asm
+ * 
+ * @param vars The variable scope.
+ */
+FLECS_API
+void ecs_script_vars_print(
+    const ecs_script_vars_t *vars);
+
+/** Preallocate space for variables.
+ * This operation preallocates space for the specified number of variables. This
+ * is a performance optimization only, and is not necessary before declaring
+ * variables in a scope.
+ * 
+ * @param vars The variable scope.
+ * @param count The number of variables to preallocate space for.
+ */
+FLECS_API
+void ecs_script_vars_set_size(
+    ecs_script_vars_t *vars,
+    int32_t count);
+
 /** Convert iterator to vars
  * This operation converts an iterator to a variable array. This allows for
  * using iterator results in expressions. The operation only converts a
@@ -14500,38 +14874,88 @@ void ecs_script_vars_from_iter(
 
 /* Standalone expression evaluation */
 
-/** Used with ecs_script_expr_run(). */
-typedef struct ecs_script_expr_run_desc_t {
-    const char *name;
-    const char *expr;
-    ecs_entity_t (*lookup_action)(
+/** Used with ecs_expr_run(). */
+typedef struct ecs_expr_eval_desc_t {
+    const char *name;                /**< Script name */
+    const char *expr;                /**< Full expression string */
+    const ecs_script_vars_t *vars;   /**< Variables accessible in expression */
+    ecs_entity_t type;               /**< Type of parsed value (optional) */
+    ecs_entity_t (*lookup_action)(   /**< Function for resolving entity identifiers */
         const ecs_world_t*,
         const char *value,
         void *ctx);
-    void *lookup_ctx;
-    ecs_script_vars_t *vars;
-} ecs_script_expr_run_desc_t;
+    void *lookup_ctx;                /**< Context passed to lookup function */
 
-/** Parse standalone expression into value.
- * This operation parses a flecs expression into the provided pointer. The
- * memory pointed to must be large enough to contain a value of the used type.
+    /** Disable constant folding (slower evaluation, faster parsing) */
+    bool disable_folding;
+
+    /** This option instructs the expression runtime to lookup variables by 
+     * stack pointer instead of by name, which improves performance. Only enable 
+     * when provided variables are always declared in the same order. */
+    bool disable_dynamic_variable_binding;
+
+    /** Allow for unresolved identifiers when parsing. Useful when entities can
+     * be created in between parsing & evaluating. */
+    bool allow_unresolved_identifiers;
+
+    ecs_script_runtime_t *runtime;   /**< Reusable runtime (optional) */
+} ecs_expr_eval_desc_t;
+
+/** Run expression.
+ * This operation runs an expression and stores the result in the provided 
+ * value. If the value contains a type that is different from the type of the
+ * expression, the expression will be cast to the value.
  *
- * If no type and pointer are provided for the value argument, the operation
- * will discover the type from the expression and allocate storage for the
- * value. The allocated value must be freed with ecs_value_free().
+ * If the provided value for value.ptr is NULL, the value must be freed with 
+ * ecs_value_free() afterwards.
  *
  * @param world The world.
  * @param ptr The pointer to the expression to parse.
  * @param value The value containing type & pointer to write to.
- * @param desc Configuration parameters for deserializer.
+ * @param desc Configuration parameters for the parser.
  * @return Pointer to the character after the last one read, or NULL if failed.
  */
 FLECS_API
-const char* ecs_script_expr_run(
+const char* ecs_expr_run(
     ecs_world_t *world,
     const char *ptr,
     ecs_value_t *value,
-    const ecs_script_expr_run_desc_t *desc);
+    const ecs_expr_eval_desc_t *desc);
+
+/** Parse expression.
+ * This operation parses an expression and returns an object that can be 
+ * evaluated multiple times with ecs_expr_eval().
+ * 
+ * @param world The world.
+ * @param expr The expression string.
+ * @param desc Configuration parameters for the parser.
+ * @return A script object if parsing is successful, NULL if parsing failed.
+ */
+FLECS_API
+ecs_script_t* ecs_expr_parse(
+    ecs_world_t *world,
+    const char *expr,
+    const ecs_expr_eval_desc_t *desc);
+
+/** Evaluate expression.
+ * This operation evaluates an expression parsed with ecs_expr_parse() 
+ * and stores the result in the provided value. If the value contains a type 
+ * that is different from the type of the expression, the expression will be 
+ * cast to the value.
+ * 
+ * If the provided value for value.ptr is NULL, the value must be freed with 
+ * ecs_value_free() afterwards.
+ * 
+ * @param script The script containing the expression.
+ * @param value The value in which to store the expression result.
+ * @param desc Configuration parameters for the parser.
+ * @return Zero if successful, non-zero if failed.
+ */
+FLECS_API
+int ecs_expr_eval(
+    const ecs_script_t *script,
+    ecs_value_t *value,
+    const ecs_expr_eval_desc_t *desc);
 
 /** Evaluate interpolated expressions in string.
  * This operation evaluates expressions in a string, and replaces them with
@@ -14550,6 +14974,98 @@ char* ecs_script_string_interpolate(
     ecs_world_t *world,
     const char *str,
     const ecs_script_vars_t *vars);
+
+
+/* Global const variables */
+
+/** Used with ecs_const_var_init */
+typedef struct ecs_const_var_desc_t {
+    /* Variable name. */
+    const char *name;
+
+    /* Variable parent (namespace). */
+    ecs_entity_t parent;
+
+    /* Variable type. */
+    ecs_entity_t type;
+
+    /* Pointer to value of variable. The value will be copied to an internal
+     * storage and does not need to be kept alive. */
+    void *value;
+} ecs_const_var_desc_t;
+
+/** Create a const variable that can be accessed by scripts. 
+ * 
+ * @param world The world.
+ * @param desc Const var parameters.
+ * @return The const var, or 0 if failed.
+ */
+FLECS_API
+ecs_entity_t ecs_const_var_init(
+    ecs_world_t *world,
+    ecs_const_var_desc_t *desc);
+
+#define ecs_const_var(world, ...)\
+    ecs_const_var_init(world, &(ecs_const_var_desc_t)__VA_ARGS__)
+
+/* Functions */
+
+/** Used with ecs_function_init and ecs_method_init */
+typedef struct ecs_function_desc_t {
+    /** Function name. */
+    const char *name;
+    
+    /** Parent of function. For methods the parent is the type for which the 
+     * method will be registered. */
+    ecs_entity_t parent;
+
+    /** Function parameters. */
+    ecs_script_parameter_t params[FLECS_SCRIPT_FUNCTION_ARGS_MAX];
+
+    /** Function return type. */
+    ecs_entity_t return_type;
+
+    /** Function implementation. */
+    ecs_function_callback_t callback;
+
+    /** Context passed to function implementation. */
+    void *ctx;
+} ecs_function_desc_t;
+
+/** Create new function. 
+ * This operation creates a new function that can be called from a script.
+ * 
+ * @param world The world.
+ * @param desc Function init parameters.
+ * @return The function, or 0 if failed.
+*/
+FLECS_API
+ecs_entity_t ecs_function_init(
+    ecs_world_t *world,
+    const ecs_function_desc_t *desc);
+
+#define ecs_function(world, ...)\
+    ecs_function_init(world, &(ecs_function_desc_t)__VA_ARGS__)
+
+/** Create new method. 
+ * This operation creates a new method that can be called from a script. A 
+ * method is like a function, except that it can be called on every instance of
+ * a type.
+ * 
+ * Methods automatically receive the instance on which the method is invoked as
+ * first argument.
+ * 
+ * @param world Method The world.
+ * @param desc Method init parameters.
+ * @return The function, or 0 if failed.
+*/
+FLECS_API
+ecs_entity_t ecs_method_init(
+    ecs_world_t *world,
+    const ecs_function_desc_t *desc);
+
+#define ecs_method(world, ...)\
+    ecs_method_init(world, &(ecs_function_desc_t)__VA_ARGS__)
 
 
 /* Value serialization */
@@ -14617,6 +15133,8 @@ int ecs_ptr_to_str_buf(
     ecs_entity_t type,
     const void *data,
     ecs_strbuf_t *buf);
+
+typedef struct ecs_expr_node_t ecs_expr_node_t; 
 
 /** Script module import function.
  * Usage:
@@ -15222,7 +15740,10 @@ typedef struct ecs_enum_constant_t {
     const char *name;
 
     /** May be set when used with ecs_enum_desc_t */
-    int32_t value;
+    int64_t value;
+
+    /** For when the underlying type is unsigned */
+    uint64_t value_unsigned;
 
     /** Should not be set by ecs_enum_desc_t */
     ecs_entity_t constant;
@@ -15230,6 +15751,8 @@ typedef struct ecs_enum_constant_t {
 
 /** Component added to enum type entities */
 typedef struct EcsEnum {
+    ecs_entity_t underlying_type;
+
     /** Populated from child entities with Constant component */
     ecs_map_t constants; /**< map<i32_t, ecs_enum_constant_t> */
 } EcsEnum;
@@ -15240,7 +15763,10 @@ typedef struct ecs_bitmask_constant_t {
     const char *name;
 
     /** May be set when used with ecs_bitmask_desc_t */
-    ecs_flags32_t value;
+    ecs_flags64_t value;
+
+    /** Keep layout the same with ecs_enum_constant_t */
+    int64_t _unused;
 
     /** Should not be set by ecs_bitmask_desc_t */
     ecs_entity_t constant;
@@ -15909,6 +16435,7 @@ ecs_entity_t ecs_primitive_init(
 typedef struct ecs_enum_desc_t {
     ecs_entity_t entity;       /**< Existing entity to use for type (optional). */
     ecs_enum_constant_t constants[ECS_MEMBER_DESC_CACHE_SIZE]; /**< Enum constants. */
+    ecs_entity_t underlying_type;
 } ecs_enum_desc_t;
 
 /** Create a new enum type. 
@@ -16575,28 +17102,18 @@ const char* ecs_cpp_trim_module(
     const char *type_name);
 
 FLECS_API
-void ecs_cpp_component_validate(
+ecs_entity_t ecs_cpp_component_find(
     ecs_world_t *world,
     ecs_entity_t id,
     const char *name,
     const char *symbol,
     size_t size,
     size_t alignment,
-    bool implicit_name);
-
-FLECS_API
-ecs_entity_t ecs_cpp_component_register(
-    ecs_world_t *world,
-    ecs_entity_t id,
-    const char *name,
-    const char *symbol,
-    ecs_size_t size,
-    ecs_size_t alignment,
     bool implicit_name,
     bool *existing_out);
 
 FLECS_API
-ecs_entity_t ecs_cpp_component_register_explicit(
+ecs_entity_t ecs_cpp_component_register(
     ecs_world_t *world,
     ecs_entity_t s_id,
     ecs_entity_t id,
@@ -16611,7 +17128,8 @@ ecs_entity_t ecs_cpp_component_register_explicit(
 FLECS_API
 void ecs_cpp_enum_init(
     ecs_world_t *world,
-    ecs_entity_t id);
+    ecs_entity_t id,
+    ecs_entity_t underlying_type);
 
 FLECS_API
 ecs_entity_t ecs_cpp_enum_constant_register(
@@ -16619,13 +17137,9 @@ ecs_entity_t ecs_cpp_enum_constant_register(
     ecs_entity_t parent,
     ecs_entity_t id,
     const char *name,
-    int value);
-
-FLECS_API 
-int32_t ecs_cpp_reset_count_get(void);
-
-FLECS_API
-int32_t ecs_cpp_reset_count_inc(void);
+    void *value,
+    ecs_entity_t value_type,
+    size_t value_size);
 
 #ifdef FLECS_META
 FLECS_API
@@ -16910,9 +17424,9 @@ namespace _
 struct placement_new_tag_t{};
 constexpr placement_new_tag_t placement_new_tag{};
 template<class Ty> inline void destruct_obj(Ty* _ptr) { _ptr->~Ty(); }
-template<class Ty> inline void free_obj(Ty* _ptr) { 
+template<class Ty> inline void free_obj(void* _ptr) { 
     if (_ptr) {
-        destruct_obj(_ptr); 
+        destruct_obj(static_cast<Ty*>(_ptr)); 
         ecs_os_free(_ptr); 
     }
 }
@@ -17287,7 +17801,9 @@ struct string_view : string {
 #include <string.h>
 #include <limits>
 
-#define FLECS_ENUM_MAX(T) _::to_constant<T, 128>::value
+// 126, so that FLECS_ENUM_MAX_COUNT is 127 which is the largest value 
+// representable by an int8_t.
+#define FLECS_ENUM_MAX(T) _::to_constant<T, 126>::value
 #define FLECS_ENUM_MAX_COUNT (FLECS_ENUM_MAX(int) + 1)
 
 #ifndef FLECS_CPP_ENUM_REFLECTION_SUPPORT
@@ -17451,7 +17967,7 @@ static const char* enum_constant_to_name() {
 /** Enumeration constant data */
 template<typename T>
 struct enum_constant_data {
-    flecs::entity_t id;
+    int32_t index; // Global index used to obtain world local entity id
     T offset;
 };
 
@@ -17562,7 +18078,6 @@ private:
     };
 
 public:
-    flecs::entity_t id;
     int min;
     int max;
     bool has_contiguous;
@@ -17598,7 +18113,7 @@ private:
             // Constant is valid, so fill reflection data.
             auto v = Value;
             const char *name = enum_constant_to_name<E, flecs_enum_cast(E, Value)>();
-            
+
             ++enum_type<E>::data.max; // Increment cursor as we build constants array.
 
             // If the enum was previously contiguous, and continues to be through the current value...
@@ -17614,8 +18129,17 @@ private:
                 "Signed integer enums causes integer overflow when recording offset from high positive to"
                 " low negative. Consider using unsigned integers as underlying type.");
             enum_type<E>::data.constants[enum_type<E>::data.max].offset = v - last_value;
-            enum_type<E>::data.constants[enum_type<E>::data.max].id = ecs_cpp_enum_constant_register(
-                world, enum_type<E>::data.id, 0, name, static_cast<int32_t>(v));
+            if (!enum_type<E>::data.constants[enum_type<E>::data.max].index) {
+                enum_type<E>::data.constants[enum_type<E>::data.max].index = 
+                    flecs_component_ids_index_get();
+            }
+            
+            flecs::entity_t constant = ecs_cpp_enum_constant_register(
+                world, type<E>::id(world), 0, name, &v, type<U>::id(world), sizeof(U));
+            flecs_component_ids_set(world, 
+                enum_type<E>::data.constants[enum_type<E>::data.max].index, 
+                constant);
+
             return v;
         }
     };
@@ -17647,8 +18171,8 @@ public:
         data.contiguous_until = 0;
 
         ecs_log_push();
-        ecs_cpp_enum_init(world, id);
-        data.id = id;
+        ecs_cpp_enum_init(world, id, type<U>::id(world));
+        // data.id = id;
 
         // Generate reflection data
         enum_reflection<E, reflection_init>::template each_enum< static_cast<U>(enum_last<E>::value) >(world);
@@ -17690,7 +18214,7 @@ struct enum_data {
         if (index < 0) {
             return false;
         }
-        return impl_.constants[index].id != 0;
+        return impl_.constants[index].index != 0;
     }
 
     /**
@@ -17711,7 +18235,7 @@ struct enum_data {
      * @return int The index of the enum value.
      */
     int index_by_value(U value) const {
-        if (!impl_.max) {
+        if (impl_.max < 0) {
             return -1;
         }
         // Check if value is in contiguous lookup section
@@ -20104,37 +20628,6 @@ namespace flecs
 namespace _ 
 {
 
-inline void ecs_ctor_illegal(void *, int32_t, const ecs_type_info_t *ti) {
-    ecs_abort(ECS_INVALID_OPERATION, "invalid constructor for %s", ti->name);
-}
-
-inline void ecs_dtor_illegal(void *, int32_t, const ecs_type_info_t *ti) {
-    ecs_abort(ECS_INVALID_OPERATION, "invalid destructor for %s", ti->name);
-}
-
-inline void ecs_copy_illegal(
-    void *, const void *, int32_t, const ecs_type_info_t *ti)
-{
-    ecs_abort(ECS_INVALID_OPERATION, "invalid copy assignment for %s", ti->name);
-}
-
-inline void ecs_move_illegal(void *, void *, int32_t, const ecs_type_info_t *ti) {
-    ecs_abort(ECS_INVALID_OPERATION, "invalid move assignment for %s", ti->name);
-}
-
-inline void ecs_copy_ctor_illegal(
-    void *, const void *, int32_t, const ecs_type_info_t *ti)
-{
-    ecs_abort(ECS_INVALID_OPERATION, "invalid copy construct for %s", ti->name);
-}
-
-inline void ecs_move_ctor_illegal(
-    void *, void *, int32_t, const ecs_type_info_t *ti)
-{
-    ecs_abort(ECS_INVALID_OPERATION, "invalid move construct for %s", ti->name);
-}
-
-
 // T()
 // Can't coexist with T(flecs::entity) or T(flecs::world, flecs::entity)
 template <typename T>
@@ -20286,28 +20779,29 @@ namespace _
 
 // Trivially constructible
 template <typename T, if_t< std::is_trivially_constructible<T>::value > = 0>
-ecs_xtor_t ctor() {
+ecs_xtor_t ctor(ecs_flags32_t &) {
     return nullptr;
 }
 
 // Not constructible by flecs
 template <typename T, if_t< 
     ! std::is_default_constructible<T>::value > = 0>
-ecs_xtor_t ctor() {
-    return ecs_ctor_illegal;
+ecs_xtor_t ctor(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_CTOR_ILLEGAL;
+    return nullptr;
 }
 
 // Default constructible
 template <typename T, if_t<
     ! std::is_trivially_constructible<T>::value &&
     std::is_default_constructible<T>::value > = 0>
-ecs_xtor_t ctor() {
+ecs_xtor_t ctor(ecs_flags32_t &) {
     return ctor_impl<T>;
 }
 
 // No dtor
 template <typename T, if_t< std::is_trivially_destructible<T>::value > = 0>
-ecs_xtor_t dtor() {
+ecs_xtor_t dtor(ecs_flags32_t &) {
     return nullptr;
 }
 
@@ -20315,21 +20809,22 @@ ecs_xtor_t dtor() {
 template <typename T, if_t<
     std::is_destructible<T>::value &&
     ! std::is_trivially_destructible<T>::value > = 0>
-ecs_xtor_t dtor() {
+ecs_xtor_t dtor(ecs_flags32_t &) {
     return dtor_impl<T>;
 }
 
 // Assert when the type cannot be destructed
 template <typename T, if_not_t< std::is_destructible<T>::value > = 0>
-ecs_xtor_t dtor() {
+ecs_xtor_t dtor(ecs_flags32_t &flags) {
     flecs_static_assert(always_false<T>::value, 
         "component type must be destructible");
-    return ecs_dtor_illegal;
+    flags |= ECS_TYPE_HOOK_DTOR_ILLEGAL;
+    return nullptr;
 }
 
 // Trivially copyable
 template <typename T, if_t< std::is_trivially_copyable<T>::value > = 0>
-ecs_copy_t copy() {
+ecs_copy_t copy(ecs_flags32_t &) {
     return nullptr;
 }
 
@@ -20337,77 +20832,82 @@ ecs_copy_t copy() {
 template <typename T, if_t<
     ! std::is_trivially_copyable<T>::value &&
     ! std::is_copy_assignable<T>::value > = 0>
-ecs_copy_t copy() {
-    return ecs_copy_illegal;
+ecs_copy_t copy(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_COPY_ILLEGAL;
+    return nullptr;
 }
 
 // Copy assignment
 template <typename T, if_t<
     std::is_copy_assignable<T>::value &&
     ! std::is_trivially_copyable<T>::value > = 0>
-ecs_copy_t copy() {
+ecs_copy_t copy(ecs_flags32_t &) {
     return copy_impl<T>;
 }
 
 // Trivially move assignable
 template <typename T, if_t< std::is_trivially_move_assignable<T>::value > = 0>
-ecs_move_t move() {
+ecs_move_t move(ecs_flags32_t &) {
     return nullptr;
 }
 
 // Component types must be move assignable
 template <typename T, if_not_t< std::is_move_assignable<T>::value > = 0>
-ecs_move_t move() {
-    return ecs_move_illegal;
+ecs_move_t move(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_MOVE_ILLEGAL;
+    return nullptr;
 }
 
 // Move assignment
 template <typename T, if_t<
     std::is_move_assignable<T>::value &&
     ! std::is_trivially_move_assignable<T>::value > = 0>
-ecs_move_t move() {
+ecs_move_t move(ecs_flags32_t &) {
     return move_impl<T>;
 }
 
 // Trivially copy constructible
 template <typename T, if_t<
     std::is_trivially_copy_constructible<T>::value > = 0>
-ecs_copy_t copy_ctor() {
+ecs_copy_t copy_ctor(ecs_flags32_t &) {
     return nullptr;
 }
 
 // No copy ctor
 template <typename T, if_t< ! std::is_copy_constructible<T>::value > = 0>
-ecs_copy_t copy_ctor() {
-    return ecs_copy_ctor_illegal;
+ecs_copy_t copy_ctor(ecs_flags32_t &flags) {
+       flags |= ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL;
+    return nullptr;
+
 }
 
 // Copy ctor
 template <typename T, if_t<
     std::is_copy_constructible<T>::value &&
     ! std::is_trivially_copy_constructible<T>::value > = 0>
-ecs_copy_t copy_ctor() {
+ecs_copy_t copy_ctor(ecs_flags32_t &) {
     return copy_ctor_impl<T>;
 }
 
 // Trivially move constructible
 template <typename T, if_t<
     std::is_trivially_move_constructible<T>::value > = 0>
-ecs_move_t move_ctor() {
+ecs_move_t move_ctor(ecs_flags32_t &) {
     return nullptr;
 }
 
 // Component types must be move constructible
 template <typename T, if_not_t< std::is_move_constructible<T>::value > = 0>
-ecs_move_t move_ctor() {
-    return ecs_move_ctor_illegal;
+ecs_move_t move_ctor(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL;
+    return nullptr;
 }
 
 // Move ctor
 template <typename T, if_t<
     std::is_move_constructible<T>::value &&
     ! std::is_trivially_move_constructible<T>::value > = 0>
-ecs_move_t move_ctor() {
+ecs_move_t move_ctor(ecs_flags32_t &) {
     return move_ctor_impl<T>;
 }
 
@@ -20415,7 +20915,7 @@ ecs_move_t move_ctor() {
 template <typename T, if_t<
     std::is_trivially_move_constructible<T>::value  &&
     std::is_trivially_destructible<T>::value > = 0>
-ecs_move_t ctor_move_dtor() {
+ecs_move_t ctor_move_dtor(ecs_flags32_t &) {
     return nullptr;
 }
 
@@ -20423,8 +20923,9 @@ ecs_move_t ctor_move_dtor() {
 template <typename T, if_t<
     ! std::is_move_constructible<T>::value ||
     ! std::is_destructible<T>::value > = 0>
-ecs_move_t ctor_move_dtor() {
-    return ecs_move_ctor_illegal;
+ecs_move_t ctor_move_dtor(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL;
+    return nullptr;
 }
 
 // Merge ctor + dtor
@@ -20433,7 +20934,7 @@ template <typename T, if_t<
       std::is_trivially_destructible<T>::value) &&
     std::is_move_constructible<T>::value &&
     std::is_destructible<T>::value > = 0>
-ecs_move_t ctor_move_dtor() {
+ecs_move_t ctor_move_dtor(ecs_flags32_t &) {
     return ctor_move_dtor_impl<T>;
 }
 
@@ -20441,7 +20942,7 @@ ecs_move_t ctor_move_dtor() {
 template <typename T, if_t<
     std::is_trivially_move_assignable<T>::value  &&
     std::is_trivially_destructible<T>::value > = 0>
-ecs_move_t move_dtor() {
+ecs_move_t move_dtor(ecs_flags32_t &) {
     return nullptr;
 }
 
@@ -20449,8 +20950,9 @@ ecs_move_t move_dtor() {
 template <typename T, if_t<
     ! std::is_move_assignable<T>::value ||
     ! std::is_destructible<T>::value > = 0>
-ecs_move_t move_dtor() {
-    return ecs_move_ctor_illegal;
+ecs_move_t move_dtor(ecs_flags32_t &flags) {
+    flags |= ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL;
+    return nullptr;
 }
 
 // Merge assign + dtor
@@ -20459,7 +20961,7 @@ template <typename T, if_t<
       std::is_trivially_destructible<T>::value) &&
     std::is_move_assignable<T>::value &&
     std::is_destructible<T>::value > = 0>
-ecs_move_t move_dtor() {
+ecs_move_t move_dtor(ecs_flags32_t &) {
     return move_dtor_impl<T>;
 }
 
@@ -21624,6 +22126,14 @@ struct world {
      */
     flecs::entity make_alive(flecs::entity_t e) const;
 
+    /** Set version of entity to provided.
+     * 
+     * @see ecs_set_version()
+     */
+    void set_version(flecs::entity_t e) const {
+        ecs_set_version(world_, e);
+    }
+
     /* Run callback after completing frame */
     void run_post_frame(ecs_fini_action_t action, void *ctx) const {
         ecs_run_post_frame(world_, action, ctx);
@@ -22424,7 +22934,7 @@ struct untyped_field {
      * @return Reference to element.
      */
     void* operator[](size_t index) const {
-        ecs_assert(!is_shared_, ECS_INVALID_PARAMETER,
+        ecs_assert(!is_shared_ || !index, ECS_INVALID_PARAMETER,
             "invalid usage of [] operator for shared component field");
         ecs_assert(index < count_, ECS_COLUMN_INDEX_OUT_OF_RANGE,
             "index %d out of range for field", index);
@@ -22740,6 +23250,10 @@ public:
     /** Get readonly access to field data.
      * If the specified field index does not match with the provided type, the
      * function will assert.
+     * 
+     * This function should not be used in each() callbacks, unless it is to
+     * access a shared field. For access to non-shared fields in each(), use
+     * field_at.
      *
      * @tparam T Type of the field.
      * @param index The field index.
@@ -22752,6 +23266,10 @@ public:
     /** Get read/write access to field data.
      * If the matched id for the specified field does not match with the provided
      * type or if the field is readonly, the function will assert.
+     * 
+     * This function should not be used in each() callbacks, unless it is to
+     * access a shared field. For access to non-shared fields in each(), use
+     * field_at.
      *
      * @tparam T Type of the field.
      * @param index The field index.
@@ -22765,16 +23283,23 @@ public:
     /** Get unchecked access to field data.
      * Unchecked access is required when a system does not know the type of a
      * field at compile time.
+     * 
+     * This function should not be used in each() callbacks, unless it is to
+     * access a shared field. For access to non-shared fields in each(), use
+     * field_at.
      *
      * @param index The field index.
      */
     flecs::untyped_field field(int8_t index) const {
-        ecs_assert(!(iter_->flags & EcsIterCppEach), ECS_INVALID_OPERATION,
+        ecs_assert(!(iter_->flags & EcsIterCppEach) || 
+               ecs_field_src(iter_, index) != 0, ECS_INVALID_OPERATION,
             "cannot .field from .each, use .field_at(%d, row) instead", index);
         return get_unchecked_field(index);
     }
 
-    /** Get pointer to field at row. */
+    /** Get pointer to field at row. 
+     * This function may be used to access shared fields when row is set to 0.
+     */
     void* field_at(int8_t index, size_t row) const {
         if (iter_->row_fields & (1llu << index)) {
             return get_unchecked_field_at(index, row)[0];
@@ -22783,7 +23308,9 @@ public:
         }
     }
 
-    /** Get reference to field at row. */
+    /** Get reference to field at row. 
+     * This function may be used to access shared fields when row is set to 0.
+     */
     template <typename T, typename A = actual_type_t<T>,
         typename std::enable_if<std::is_const<T>::value, void>::type* = nullptr>
     const A& field_at(int8_t index, size_t row) const {
@@ -22794,7 +23321,9 @@ public:
         }
     }
 
-    /** Get reference to field at row. */
+    /** Get reference to field at row. 
+     * This function may be used to access shared fields when row is set to 0.
+     */
     template <typename T, typename A = actual_type_t<T>,
         typename std::enable_if<
             std::is_const<T>::value == false, void>::type* = nullptr>
@@ -24724,7 +25253,7 @@ struct entity_builder : entity_view {
      */
     template<typename First>
     const Self& enable(flecs::id_t second) const  {
-        return this->enable(_::type<First>::id(), second);
+        return this->enable(_::type<First>::id(world_), second);
     }
 
     /** Enable a pair.
@@ -24735,7 +25264,7 @@ struct entity_builder : entity_view {
      */
     template<typename First, typename Second>
     const Self& enable() const  {
-        return this->enable<First>(_::type<Second>::id());
+        return this->enable<First>(_::type<Second>::id(world_));
     }
 
     /** Disable an id.
@@ -24758,7 +25287,7 @@ struct entity_builder : entity_view {
      */
     template<typename T>
     const Self& disable() const  {
-        return this->disable(_::type<T>::id());
+        return this->disable(_::type<T>::id(world_));
     }
 
     /** Disable a pair.
@@ -24779,7 +25308,7 @@ struct entity_builder : entity_view {
      */
     template<typename First>
     const Self& disable(flecs::id_t second) const  {
-        return this->disable(_::type<First>::id(), second);
+        return this->disable(_::type<First>::id(world_), second);
     }
 
     /** Disable a pair.
@@ -24790,7 +25319,7 @@ struct entity_builder : entity_view {
      */
     template<typename First, typename Second>
     const Self& disable() const  {
-        return this->disable<First>(_::type<Second>::id());
+        return this->disable<First>(_::type<Second>::id(world_));
     }
 
     const Self& set_ptr(entity_t comp, size_t size, const void *ptr) const  {
@@ -26014,7 +26543,7 @@ struct each_ref_field : public each_field<T> {
 
         if (field.is_row) {
             field.ptr = ecs_field_at_w_size(iter, sizeof(T), field.index, 
-                static_cast<int8_t>(row));
+                static_cast<int32_t>(row));
         }
     }
 };
@@ -26062,7 +26591,7 @@ struct each_delegate : public delegate {
 
     // Function that can be used as callback to free delegate
     static void destruct(void *obj) {
-        _::free_obj<each_delegate>(static_cast<each_delegate*>(obj));
+        _::free_obj<each_delegate>(obj);
     }
 
     // Static function to call for component on_add hook
@@ -26100,9 +26629,6 @@ private:
     static void invoke_callback(
         ecs_iter_t *iter, const Func& func, size_t i, Args... comps) 
     {
-        ecs_assert(iter->count > 0, ECS_INVALID_OPERATION,
-            "no entities returned, use each() without flecs::entity argument");
-
         func(flecs::entity(iter->world, iter->entities[i]),
             (ColumnType< remove_reference_t<Components> >(iter, comps, i)
                 .get_row())...);
@@ -26218,9 +26744,6 @@ private:
         ecs_world_t *world = iter->world;
         size_t count = static_cast<size_t>(iter->count);
         flecs::entity result;
-
-        ecs_assert(count > 0, ECS_INVALID_OPERATION,
-            "no entities returned, use find() without flecs::entity argument");
 
         for (size_t i = 0; i < count; i ++) {
             if (func(flecs::entity(world, iter->entities[i]),
@@ -26801,34 +27324,25 @@ void register_lifecycle_actions(
     ecs_entity_t component)
 {
     ecs_type_hooks_t cl{};
-    cl.ctor = ctor<T>();
-    cl.dtor = dtor<T>();
+    cl.ctor = ctor<T>(cl.flags);
+    cl.dtor = dtor<T>(cl.flags);
 
-    cl.copy = copy<T>();
-    cl.copy_ctor = copy_ctor<T>();
-    cl.move = move<T>();
-    cl.move_ctor = move_ctor<T>();
+    cl.copy = copy<T>(cl.flags);
+    cl.copy_ctor = copy_ctor<T>(cl.flags);
+    cl.move = move<T>(cl.flags);
+    cl.move_ctor = move_ctor<T>(cl.flags);
 
-    cl.ctor_move_dtor = ctor_move_dtor<T>();
-    cl.move_dtor = move_dtor<T>();
+    cl.ctor_move_dtor = ctor_move_dtor<T>(cl.flags);
+    cl.move_dtor = move_dtor<T>(cl.flags);
 
-    ecs_set_hooks_id( world, component, &cl);
+    ecs_set_hooks_id(world, component, &cl);
 
-    if (cl.move == ecs_move_illegal || cl.move_ctor == ecs_move_ctor_illegal) {
+    if (cl.flags & (ECS_TYPE_HOOK_MOVE_ILLEGAL|ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL))
+    {
         ecs_add_id(world, component, flecs::Sparse);
     }
 }
 
-// Class that manages component ids across worlds & binaries.
-// The type class stores the component id for a C++ type in a static global
-// variable that is shared between worlds. Whenever a component is used this
-// class will check if it already has been registered (has the global id been
-// set), and if not, register the component with the world.
-//
-// If the id has been set, the class will ensure it is known by the world. If it
-// is not known the component has been registered by another world and will be
-// registered with the world using the same id. If the id does exist, the class
-// will register it as a component, and verify whether the input is consistent.
 template <typename T>
 struct type_impl {
     static_assert(is_pointer<T>::value == false,
@@ -26836,27 +27350,9 @@ struct type_impl {
 
     // Initialize component identifier
     static void init(
-        entity_t entity,
         bool allow_tag = true)
     {
-        if (s_reset_count != ecs_cpp_reset_count_get()) {
-            reset();
-        }
-
-        // If an identifier was already set, check for consistency
-        if (s_id) {
-            ecs_assert(s_id == entity, ECS_INCONSISTENT_COMPONENT_ID,
-                type_name<T>());
-            ecs_assert(allow_tag == s_allow_tag, ECS_INVALID_PARAMETER, NULL);
-
-            // Component was already registered and data is consistent with new
-            // identifier, so nothing else to be done.
-            return;
-        }
-
-        // Component wasn't registered yet, set the values. Register component
-        // name as the fully qualified flecs path.
-        s_id = entity;
+        s_index = flecs_component_ids_index_get();
         s_allow_tag = allow_tag;
         s_size = sizeof(T);
         s_alignment = alignof(T);
@@ -26864,161 +27360,158 @@ struct type_impl {
             s_size = 0;
             s_alignment = 0;
         }
-
-        s_reset_count = ecs_cpp_reset_count_get();
     }
 
-    // Obtain a component identifier for explicit component registration.
-    static entity_t id_explicit(world_t *world = nullptr,
-        const char *name = nullptr, bool allow_tag = true, flecs::id_t id = 0,
-        bool is_component = true, bool *existing = nullptr)
+    static void init_builtin(
+        flecs::world_t *world,
+        flecs::entity_t id,
+        bool allow_tag = true)
     {
-        if (!s_id) {
-            // If no world was provided the component cannot be registered
-            ecs_assert(world != nullptr, ECS_COMPONENT_NOT_REGISTERED, name);
-        } else {
-            ecs_assert(!id || s_id == id, ECS_INCONSISTENT_COMPONENT_ID, NULL);
+        init(allow_tag);
+        flecs_component_ids_set(world, s_index, id);
+    }
+
+    // Register component id.
+    static entity_t register_id(world_t *world,
+        const char *name = nullptr, bool allow_tag = true, flecs::id_t id = 0,
+        bool is_component = false, bool implicit_name = true, const char *n = nullptr, 
+        flecs::entity_t module = 0)
+    {
+        if (!s_index) {
+            // This is the first time (in this binary image) that this type is
+            // being used. Generate a static index that will identify the type
+            // across worlds.
+            init(allow_tag);
+            ecs_assert(s_index != 0, ECS_INTERNAL_ERROR, NULL);
         }
 
-        // If no id has been registered yet for the component (indicating the
-        // component has not yet been registered, or the component is used
-        // across more than one binary), or if the id does not exists in the
-        // world (indicating a multi-world application), register it.
-        if (!s_id || (world && !ecs_exists(world, s_id))) {
-            init(s_id ? s_id : id, allow_tag);
+        flecs::entity_t c = flecs_component_ids_get(world, s_index);
 
-            ecs_assert(!id || s_id == id, ECS_INTERNAL_ERROR, NULL);
+        if (!c || !ecs_is_alive(world, c)) {
+            // When a component is implicitly registered, ensure that it's not
+            // registered in the current scope of the application/that "with"
+            // components get added to the component entity.
+            ecs_entity_t prev_scope = ecs_set_scope(world, module);
+            ecs_entity_t prev_with = ecs_set_with(world, 0);
+
+            // At this point it is possible that the type was already registered
+            // with the world, just not for this binary. The registration code
+            // uses the type symbol to check if it was already registered. Note
+            // that the symbol is separate from the typename, as an application
+            // can override a component name when registering a type.
+            bool existing = false;
+            c = ecs_cpp_component_find(
+                world, id, n, symbol_name<T>(), size(), alignment(), 
+                implicit_name, &existing);
 
             const char *symbol = nullptr;
-            if (id) {
-                symbol = ecs_get_symbol(world, id);
+            if (c) {
+                symbol = ecs_get_symbol(world, c);
             }
             if (!symbol) {
                 symbol = symbol_name<T>();
             }
 
-            entity_t entity = ecs_cpp_component_register_explicit(
-                    world, s_id, id, name, type_name<T>(), symbol,
-                        s_size, s_alignment, is_component, existing);
+            c = ecs_cpp_component_register(world, c, c, name, type_name<T>(), 
+                symbol, size(), alignment(), is_component, &existing);
 
-            s_id = entity;
-
-            // If component is enum type, register constants
-            #if FLECS_CPP_ENUM_REFLECTION_SUPPORT
-            _::init_enum<T>(world, entity);
-            #endif
-        }
-
-        // By now the identifier must be valid and known with the world.
-        ecs_assert(s_id != 0 && ecs_exists(world, s_id),
-            ECS_INTERNAL_ERROR, NULL);
-
-        return s_id;
-    }
-
-    // Obtain a component identifier for implicit component registration. This
-    // is almost the same as id_explicit, except that this operation
-    // automatically registers lifecycle callbacks.
-    // Additionally, implicit registration temporarily resets the scope & with
-    // state of the world, so that the component is not implicitly created with
-    // the scope/with of the code it happens to be first used by.
-    static id_t id(world_t *world = nullptr, const char *name = nullptr,
-        bool allow_tag = true)
-    {
-        // If no id has been registered yet, do it now.
-#ifndef FLECS_CPP_NO_AUTO_REGISTRATION
-        if (!registered(world)) {
-            ecs_entity_t prev_scope = 0;
-            ecs_id_t prev_with = 0;
-
-            if (world) {
-                prev_scope = ecs_set_scope(world, 0);
-                prev_with = ecs_set_with(world, 0);
-            }
-
-            // This will register a component id, but will not register
-            // lifecycle callbacks.
-            bool existing;
-            id_explicit(world, name, allow_tag, 0, true, &existing);
+            ecs_set_with(world, prev_with);
+            ecs_set_scope(world, prev_scope);
 
             // Register lifecycle callbacks, but only if the component has a
             // size. Components that don't have a size are tags, and tags don't
             // require construction/destruction/copy/move's.
             if (size() && !existing) {
-                register_lifecycle_actions<T>(world, s_id);
+                register_lifecycle_actions<T>(world, c);
             }
 
-            if (prev_with) {
-                ecs_set_with(world, prev_with);
-            }
-            if (prev_scope) {
-                ecs_set_scope(world, prev_scope);
-            }
+            // Set world local component id
+            flecs_component_ids_set(world, s_index, c);
+
+            // If component is enum type, register constants. Make sure to do 
+            // this after setting the component id, because the enum code will
+            // be calling type<T>::id().
+            #if FLECS_CPP_ENUM_REFLECTION_SUPPORT
+            _::init_enum<T>(world, c);
+            #endif
         }
-#else
-        (void)world;
-        (void)name;
-        (void)allow_tag;
 
+        ecs_assert(c != 0, ECS_INTERNAL_ERROR, NULL);
+
+        return c;
+    }
+
+    // Get type (component) id.
+    // If type was not yet registered and automatic registration is allowed,
+    // this function will also register the type.
+    static entity_t id(world_t *world)
+    {
+#ifdef FLECS_CPP_NO_AUTO_REGISTRATION
         ecs_assert(registered(world), ECS_INVALID_OPERATION, 
-            "component '%s' was not registered before use",
+            "component '%s' must be registered before use",
             type_name<T>());
+
+        flecs::entity_t c = flecs_component_ids_get(world, s_index);
+        ecs_assert(c != 0, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(ecs_is_alive(world, c), ECS_INVALID_OPERATION,
+            "component '%s' was deleted, reregister before using",
+            type_name<T>());
+#else
+        flecs::entity_t c = flecs_component_ids_get_alive(world, s_index);
+        if (!c) {
+            c = register_id(world);
+        }
 #endif
-
-        // By now we should have a valid identifier
-        ecs_assert(s_id != 0, ECS_INTERNAL_ERROR, NULL);
-
-        return s_id;
+        return c;
     }
 
     // Return the size of a component.
     static size_t size() {
-        ecs_assert(s_id != 0, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(s_index != 0, ECS_INTERNAL_ERROR, NULL);
         return s_size;
     }
 
     // Return the alignment of a component.
     static size_t alignment() {
-        ecs_assert(s_id != 0, ECS_INTERNAL_ERROR, NULL);
+        ecs_assert(s_index != 0, ECS_INTERNAL_ERROR, NULL);
         return s_alignment;
     }
 
     // Was the component already registered.
     static bool registered(flecs::world_t *world) {
-        if (s_reset_count != ecs_cpp_reset_count_get()) {
-            reset();
-        }
-        if (s_id == 0) {
+        ecs_assert(world != nullptr, ECS_INVALID_PARAMETER, NULL);
+
+        if (s_index == 0) {
             return false;
         }
-        if (world && !ecs_exists(world, s_id)) {
+
+        if (!flecs_component_ids_get(world, s_index)) {
             return false;
         }
+
         return true;
     }
 
     // This function is only used to test cross-translation unit features. No
     // code other than test cases should invoke this function.
     static void reset() {
-        s_id = 0;
+        s_index = 0;
         s_size = 0;
         s_alignment = 0;
         s_allow_tag = true;
     }
 
-    static entity_t s_id;
+    static int32_t s_index;
     static size_t s_size;
     static size_t s_alignment;
     static bool s_allow_tag;
-    static int32_t s_reset_count;
 };
 
 // Global templated variables that hold component identifier and other info
-template <typename T> entity_t      type_impl<T>::s_id;
-template <typename T> size_t        type_impl<T>::s_size;
-template <typename T> size_t        type_impl<T>::s_alignment;
-template <typename T> bool          type_impl<T>::s_allow_tag( true );
-template <typename T> int32_t       type_impl<T>::s_reset_count;
+template <typename T> int32_t  type_impl<T>::s_index;
+template <typename T> size_t   type_impl<T>::s_size;
+template <typename T> size_t   type_impl<T>::s_alignment;
+template <typename T> bool     type_impl<T>::s_allow_tag( true );
 
 // Front facing class for implicitly registering a component & obtaining
 // static component data
@@ -27427,62 +27920,42 @@ struct component : untyped_component {
         if (!n) {
             n = _::type_name<T>();
 
-            /* Keep track of whether name was explicitly set. If not, and the
-            * component was already registered, just use the registered name.
-            *
-            * The registered name may differ from the typename as the registered
-            * name includes the flecs scope. This can in theory be different from
-            * the C++ namespace though it is good practice to keep them the same */
+            // Keep track of whether name was explicitly set. If not, and the
+            // component was already registered, just use the registered name.
+            // The registered name may differ from the typename as the registered
+            // name includes the flecs scope. This can in theory be different from
+            // the C++ namespace though it is good practice to keep them the same */
             implicit_name = true;
         }
 
-        if (_::type<T>::registered(world)) {
-            /* Obtain component id. Because the component is already registered,
-             * this operation does nothing besides returning the existing id */
-            id = _::type<T>::id_explicit(world, name, allow_tag, id);
+        // If component is registered by module, ensure it's registered in the
+        // scope of the module.
+        flecs::entity_t module = ecs_get_scope(world);
 
-            ecs_cpp_component_validate(world, id, n, _::symbol_name<T>(),
-                _::type<T>::size(),
-                _::type<T>::alignment(),
-                implicit_name);
-        } else {
-            /* If component is registered from an existing scope, ignore the
-             * namespace in the name of the component. */
-            if (implicit_name && (ecs_get_scope(world) != 0)) {
-                /* If the type is a template type, make sure to ignore ':'
-                 * inside the template parameter list. */
-                const char *start = strchr(n, '<'), *last_elem = NULL;
-                if (start) {
-                    const char *ptr = start;
-                    while (ptr[0] && (ptr[0] != ':') && (ptr > n)) {
-                        ptr --;
-                    }
-                    if (ptr[0] == ':') {
-                        last_elem = ptr;
-                    }
+        // Strip off the namespace part of the component name, unless a name was
+        // explicitly provided by the application.
+        if (module && implicit_name) {
+            // If the type is a template type, make sure to ignore
+            // inside the template parameter list.
+            const char *start = strchr(n, '<'), *last_elem = NULL;
+            if (start) {
+                const char *ptr = start;
+                while (ptr[0] && (ptr[0] != ':') && (ptr > n)) {
+                    ptr --;
                 }
-
-                if (last_elem) {
-                    name = last_elem + 1;
+                if (ptr[0] == ':') {
+                    last_elem = ptr;
                 }
             }
 
-            /* Find or register component */
-            bool existing;
-            id = ecs_cpp_component_register(world, id, n, _::symbol_name<T>(),
-                ECS_SIZEOF(T), ECS_ALIGNOF(T), implicit_name, &existing);
-
-            /* Initialize static component data */
-            id = _::type<T>::id_explicit(world, name, allow_tag, id);
-
-            /* Initialize lifecycle actions (ctor, dtor, copy, move) */
-            if (_::type<T>::size() && !existing) {
-                _::register_lifecycle_actions<T>(world, id);
+            if (last_elem) {
+                name = last_elem + 1;
             }
         }
 
         world_ = world;
-        id_ = id;
+        id_ = _::type<T>::register_id(
+            world, name, allow_tag, id, true, implicit_name, n, module);
     }
 
     /** Register on_add hook. */
@@ -27495,8 +27968,7 @@ struct component : untyped_component {
         BindingCtx *ctx = get_binding_ctx(h);
         h.on_add = Delegate::run_add;
         ctx->on_add = FLECS_NEW(Delegate)(FLECS_FWD(func));
-        ctx->free_on_add = reinterpret_cast<ecs_ctx_free_t>(
-            _::free_obj<Delegate>);
+        ctx->free_on_add = _::free_obj<Delegate>;
         ecs_set_hooks_id(world_, id_, &h);
         return *this;
     }
@@ -27512,8 +27984,7 @@ struct component : untyped_component {
         BindingCtx *ctx = get_binding_ctx(h);
         h.on_remove = Delegate::run_remove;
         ctx->on_remove = FLECS_NEW(Delegate)(FLECS_FWD(func));
-        ctx->free_on_remove = reinterpret_cast<ecs_ctx_free_t>(
-            _::free_obj<Delegate>);
+        ctx->free_on_remove = _::free_obj<Delegate>;
         ecs_set_hooks_id(world_, id_, &h);
         return *this;
     }
@@ -27529,8 +28000,7 @@ struct component : untyped_component {
         BindingCtx *ctx = get_binding_ctx(h);
         h.on_set = Delegate::run_set;
         ctx->on_set = FLECS_NEW(Delegate)(FLECS_FWD(func));
-        ctx->free_on_set = reinterpret_cast<ecs_ctx_free_t>(
-            _::free_obj<Delegate>);
+        ctx->free_on_set = _::free_obj<Delegate>;
         ecs_set_hooks_id(world_, id_, &h);
         return *this;
     }
@@ -27567,8 +28037,21 @@ flecs::opaque<T, ElemType> opaque(flecs::id_t as_type) {
 
 /** Add constant. */
 component<T>& constant(const char *name, T value) {
-    int32_t v = static_cast<int32_t>(value);
-    untyped_component::constant(name, v);
+    using U = typename std::underlying_type<T>::type;
+
+    ecs_add_id(world_, id_, _::type<flecs::Enum>::id(world_));
+
+    ecs_entity_desc_t desc = {};
+    desc.name = name;
+    desc.parent = id_;
+    ecs_entity_t eid = ecs_entity_init(world_, &desc);
+    ecs_assert(eid != 0, ECS_INTERNAL_ERROR, NULL);
+
+    flecs::id_t pair = ecs_pair(flecs::Constant, _::type<U>::id(world_));
+    U *ptr = static_cast<U*>(ecs_ensure_id(world_, eid, pair));
+    *ptr = static_cast<U>(value);
+    ecs_modified_id(world_, eid, pair);
+
     return *this;
 }
 
@@ -27582,8 +28065,7 @@ private:
         if (!result) {
             result = FLECS_NEW(BindingCtx);
             h.binding_ctx = result;
-            h.binding_ctx_free = reinterpret_cast<ecs_ctx_free_t>(
-                _::free_obj<BindingCtx>);
+            h.binding_ctx_free = _::free_obj<BindingCtx>;
         }
         return result;
     }
@@ -27597,43 +28079,6 @@ private:
         }
     }
 };
-
-/** Get id currently assigned to component. If no world has registered the
- * component yet, this operation will return 0. */
-template <typename T>
-flecs::entity_t type_id() {
-    if (_::type<T>::s_reset_count == ecs_cpp_reset_count_get()) {
-        return _::type<T>::s_id;
-    } else {
-        return 0;
-    }
-}
-
-/** Reset static component ids.
- * When components are registered their component ids are stored in a static
- * type specific variable. This stored id is passed into component registration
- * functions to ensure consistent ids across worlds.
- *
- * In some cases this can be undesirable, like when a process repeatedly creates
- * worlds with different components. A typical example where this can happen is
- * when running multiple tests in a single process, where each test registers
- * its own set of components.
- *
- * This operation can be used to prevent reusing of component ids and force
- * generating a new ids upon registration.
- *
- * Note that this operation should *never* be called while there are still
- * alive worlds in a process. Doing so results in undefined behavior.
- *
- * Also note that this operation does not actually change the static component
- * variables. It only ensures that the next time a component id is requested, a
- * new id will be generated.
- *
- * @ingroup cpp_components
- */
-inline void reset() {
-    ecs_cpp_reset_count_inc();
-}
 
 }
 
@@ -27785,12 +28230,20 @@ struct type {
         return flecs::id(world_, type_->array[index]);
     }
 
-    flecs::id_t* begin() const {
-        return type_->array;
+    const flecs::id_t* begin() const {
+        if (type_ && type_->count) {
+            return type_->array;
+        } else {
+            return &empty_;
+        }
     }
 
-    flecs::id_t* end() const {
-        return &type_->array[type_->count];
+    const flecs::id_t* end() const {
+        if (type_ && type_->count) {
+            return &type_->array[type_->count];
+        } else {
+            return &empty_;
+        }
     }
 
     /** Implicit conversion to type_t */
@@ -27800,6 +28253,7 @@ struct type {
 private:
     world_t *world_;
     const type_t *type_;
+    flecs::id_t empty_;
 };
 
 /** #} */
@@ -28271,34 +28725,34 @@ struct iterable {
         return this->iter().first();
     }
 
-    iter_iterable<Components...> set_var(int var_id, flecs::entity_t value) {
+    iter_iterable<Components...> set_var(int var_id, flecs::entity_t value) const {
         return this->iter().set_var(var_id, value);
     }
 
-    iter_iterable<Components...> set_var(const char *name, flecs::entity_t value) {
+    iter_iterable<Components...> set_var(const char *name, flecs::entity_t value) const {
         return this->iter().set_var(name, value);
     }
 
-    iter_iterable<Components...> set_var(const char *name, flecs::table_t *value) {
+    iter_iterable<Components...> set_var(const char *name, flecs::table_t *value) const {
         return this->iter().set_var(name, value);
     }
 
-    iter_iterable<Components...> set_var(const char *name, ecs_table_range_t value) {
+    iter_iterable<Components...> set_var(const char *name, ecs_table_range_t value) const {
         return this->iter().set_var(name, value);
     }
 
-    iter_iterable<Components...> set_var(const char *name, flecs::table_range value) {
+    iter_iterable<Components...> set_var(const char *name, flecs::table_range value) const {
         return this->iter().set_var(name, value);
     }
 
     // Limit results to tables with specified group id (grouped queries only)
-    iter_iterable<Components...> set_group(uint64_t group_id) {
+    iter_iterable<Components...> set_group(uint64_t group_id) const {
         return this->iter().set_group(group_id);
     }
 
     // Limit results to tables with specified group id (grouped queries only)
     template <typename Group>
-    iter_iterable<Components...> set_group() {
+    iter_iterable<Components...> set_group() const {
         return this->iter().template set_group<Group>();
     }
 
@@ -28666,11 +29120,16 @@ const T* entity_view::get() const {
     entity_t c = ecs_get_target(world_, id_, r, 0);
 
     if (c) {
-        // Get constant value from constant entity
-        const T* v = static_cast<const T*>(ecs_get_id(world_, c, r));
-        ecs_assert(v != NULL, ECS_INTERNAL_ERROR, 
-            "missing enum constant value");
+#ifdef FLECS_META
+        using U = typename std::underlying_type<T>::type;
+        const T* v = static_cast<const T*>(
+            ecs_get_id(world_, c, ecs_pair(flecs::Constant, _::type<U>::id(world_))));
+        ecs_assert(v != NULL, ECS_INTERNAL_ERROR, "missing enum constant value");
         return v;
+#else
+        // Fallback if we don't have the reflection addon
+        return static_cast<const T*>(ecs_get_id(world_, id_, r));
+#endif
     } else {
         // If there is no matching pair for (r, *), try just r
         return static_cast<const T*>(ecs_get_id(world_, id_, r));
@@ -28850,8 +29309,7 @@ inline flecs::entity world::entity(E value) const {
 
 template <typename T>
 inline flecs::entity world::entity(const char *name) const {
-    return flecs::entity(world_, 
-        _::type<T>::id_explicit(world_, name, true, 0, false) );
+    return flecs::entity(world_, _::type<T>::register_id(world_, name, true) );
 }
 
 template <typename... Args>
@@ -29263,7 +29721,7 @@ struct term_builder_i : term_ref_builder_i<Base> {
     /** Set read/write access of term. */
     Base& inout(flecs::inout_kind_t inout) {
         this->assert_term();
-        term_->inout = static_cast<ecs_inout_kind_t>(inout);
+        term_->inout = static_cast<int16_t>(inout);
         return *this;
     }
 
@@ -29277,7 +29735,7 @@ struct term_builder_i : term_ref_builder_i<Base> {
      */
     Base& inout_stage(flecs::inout_kind_t inout) {
         this->assert_term();
-        term_->inout = static_cast<ecs_inout_kind_t>(inout);
+        term_->inout = static_cast<int16_t>(inout);
         if (term_->oper != EcsNot) {
             this->src().entity(0);
         }
@@ -29328,7 +29786,7 @@ struct term_builder_i : term_ref_builder_i<Base> {
     /** Set operator of term. */
     Base& oper(flecs::oper_kind_t oper) {
         this->assert_term();
-        term_->oper = static_cast<ecs_oper_kind_t>(oper);
+        term_->oper = static_cast<int16_t>(oper);
         return *this;
     }
 
@@ -30213,6 +30671,20 @@ struct query_base {
 
     operator query<>() const;
 
+#   ifdef FLECS_JSON
+
+/** Serialize query to JSON.
+ * 
+ * @memberof flecs::query_base
+ * @ingroup cpp_addons_json
+ */
+flecs::string to_json(flecs::iter_to_json_desc_t *desc = nullptr) {
+    ecs_iter_t it = ecs_query_iter(ecs_get_world(query_), query_);
+    char *json = ecs_iter_to_json(&it, desc);
+    return flecs::string(json);
+}
+#   endif
+
 protected:
     query_t *query_ = nullptr;
 };
@@ -30330,7 +30802,7 @@ inline void world::each(Func&& func) const {
 
 template <typename T, typename Func>
 inline void world::each(Func&& func) const {
-    ecs_iter_t it = ecs_each_id(world_, _::type<T>::id());
+    ecs_iter_t it = ecs_each_id(world_, _::type<T>::id(world_));
 
     while (ecs_each_next(&it)) {
         _::each_delegate<Func, T>(func).invoke(&it);
@@ -30406,8 +30878,7 @@ public:
         auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(func));
         desc_.run = Delegate::run;
         desc_.run_ctx = ctx;
-        desc_.run_ctx_free = reinterpret_cast<
-            ecs_ctx_free_t>(_::free_obj<Delegate>);
+        desc_.run_ctx_free = _::free_obj<Delegate>;
         return T(world_, &desc_);
     }
 
@@ -30419,8 +30890,7 @@ public:
         auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(func));
         desc_.run = Delegate::run;
         desc_.run_ctx = ctx;
-        desc_.run_ctx_free = reinterpret_cast<
-            ecs_ctx_free_t>(_::free_obj<Delegate>);
+        desc_.run_ctx_free = _::free_obj<Delegate>;
         return each(FLECS_FWD(each_func));
     }
 
@@ -30431,8 +30901,7 @@ public:
         auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(func));
         desc_.callback = Delegate::run;
         desc_.callback_ctx = ctx;
-        desc_.callback_ctx_free = reinterpret_cast<
-            ecs_ctx_free_t>(_::free_obj<Delegate>);
+        desc_.callback_ctx_free = _::free_obj<Delegate>;
         return T(world_, &desc_);
     }
 
@@ -30649,8 +31118,7 @@ namespace _ {
         {
             using Delegate = _::entity_observer_delegate<Func>;
             auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(f));
-            entity_observer_create(world, _::type<Evt>::id(world), entity, Delegate::run, ctx, 
-                reinterpret_cast<ecs_ctx_free_t>(_::free_obj<Delegate>));
+            entity_observer_create(world, _::type<Evt>::id(world), entity, Delegate::run, ctx, _::free_obj<Delegate>);
         }
 
         template <typename Evt, if_not_t<is_empty<Evt>::value> = 0>
@@ -30661,8 +31129,7 @@ namespace _ {
         {
             using Delegate = _::entity_payload_observer_delegate<Func, Evt>;
             auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(f));
-            entity_observer_create(world, _::type<Evt>::id(world), entity, Delegate::run, ctx, 
-                reinterpret_cast<ecs_ctx_free_t>(_::free_obj<Delegate>));
+            entity_observer_create(world, _::type<Evt>::id(world), entity, Delegate::run, ctx, _::free_obj<Delegate>);
         }
     };
 }
@@ -30673,8 +31140,7 @@ inline const Self& entity_builder<Self>::observe(flecs::entity_t evt, Func&& f) 
     using Delegate = _::entity_observer_delegate<Func>;
     auto ctx = FLECS_NEW(Delegate)(FLECS_FWD(f));
 
-    _::entity_observer_create(world_, evt, id_, Delegate::run, ctx,
-        reinterpret_cast<ecs_ctx_free_t>(_::free_obj<Delegate>));
+    _::entity_observer_create(world_, evt, id_, Delegate::run, ctx, _::free_obj<Delegate>);
 
     return to_base();
 }
@@ -30714,9 +31180,17 @@ namespace flecs {
 
 template <typename E>
 inline E entity_view::to_constant() const {
-    const E* ptr = this->get<E>();
+#ifdef FLECS_META
+    using U = typename std::underlying_type<E>::type;
+    const E* ptr = static_cast<const E*>(ecs_get_id(world_, id_, 
+        ecs_pair(flecs::Constant, _::type<U>::id(world_))));
     ecs_assert(ptr != NULL, ECS_INVALID_PARAMETER, "entity is not a constant");
     return ptr[0];
+#else
+    ecs_assert(false, ECS_UNSUPPORTED,
+        "operation not supported without FLECS_META addon");
+    return E();
+#endif
 }
 
 template <typename E, if_t< is_enum<E>::value >>
@@ -30777,10 +31251,9 @@ flecs::entity import(world& world) {
     ecs_entity_t m = ecs_lookup_symbol(world, symbol, true, false);
 
     if (!_::type<T>::registered(world)) {
-
         /* Module is registered with world, initialize static data */
         if (m) {
-            _::type<T>::init(m, false);
+            _::type<T>::init_builtin(world, m, false);
 
         /* Module is not yet registered, register it now */
         } else {
@@ -30808,7 +31281,7 @@ flecs::entity import(world& world) {
 
 template <typename Module>
 inline flecs::entity world::module(const char *name) const {
-    flecs::entity result = this->entity(_::type<Module>::id(
+    flecs::entity result = this->entity(_::type<Module>::register_id(
         world_, nullptr, false));
 
     if (name) {
@@ -30824,6 +31297,11 @@ inline flecs::entity world::module(const char *name) const {
                 ecs_iter_t it = ecs_each_id(world_, ecs_pair(EcsChildOf, cur));
                 if (!ecs_iter_is_true(&it)) {
                     cur.destruct();
+
+                    // Prevent increasing the generation count of the temporary
+                    // parent. This allows entities created during 
+                    // initialization to keep non-recycled ids.
+                    this->set_version(cur);
                 }
 
                 cur = next;
@@ -31748,18 +32226,14 @@ inline void init(flecs::world& world) {
     // specific types.
 
     if (!flecs::is_same<i32_t, iptr_t>() && !flecs::is_same<i64_t, iptr_t>()) {
-        flecs::_::type<iptr_t>::init(flecs::Iptr, true);
-        ecs_assert(flecs::type_id<iptr_t>() == flecs::Iptr, 
-            ECS_INTERNAL_ERROR, NULL);
+        flecs::_::type<iptr_t>::init_builtin(world, flecs::Iptr, true);
         // Remove symbol to prevent validation errors, as it doesn't match with 
         // the typename
         ecs_remove_pair(world, flecs::Iptr, ecs_id(EcsIdentifier), EcsSymbol);
     }
 
     if (!flecs::is_same<u32_t, uptr_t>() && !flecs::is_same<u64_t, uptr_t>()) {
-        flecs::_::type<uptr_t>::init(flecs::Uptr, true);
-        ecs_assert(flecs::type_id<uptr_t>() == flecs::Uptr, 
-            ECS_INTERNAL_ERROR, NULL);
+        flecs::_::type<uptr_t>::init_builtin(world, flecs::Uptr, true);
         // Remove symbol to prevent validation errors, as it doesn't match with 
         // the typename
         ecs_remove_pair(world, flecs::Uptr, ecs_id(EcsIdentifier), EcsSymbol);
@@ -32623,8 +33097,9 @@ inline flecs::table_range iter::range() const {
 template <typename T, typename A,
     typename std::enable_if<std::is_const<T>::value, void>::type*>
 inline flecs::field<A> iter::field(int8_t index) const {
-    ecs_assert(!(iter_->flags & EcsIterCppEach), ECS_INVALID_OPERATION,
-        "cannot .field from .each, use .field_at<const %s>(%d, row) instead",
+    ecs_assert(!(iter_->flags & EcsIterCppEach) || 
+               ecs_field_src(iter_, index) != 0, ECS_INVALID_OPERATION,
+        "cannot .field from .each, use .field_at<%s>(%d, row) instead",
             _::type_name<T>(), index);
     return get_field<A>(index);
 }
@@ -32633,7 +33108,8 @@ template <typename T, typename A,
     typename std::enable_if<
         std::is_const<T>::value == false, void>::type*>
 inline flecs::field<A> iter::field(int8_t index) const {
-    ecs_assert(!(iter_->flags & EcsIterCppEach), ECS_INVALID_OPERATION,
+    ecs_assert(!(iter_->flags & EcsIterCppEach) || 
+               ecs_field_src(iter_, index) != 0, ECS_INVALID_OPERATION,
         "cannot .field from .each, use .field_at<%s>(%d, row) instead",
             _::type_name<T>(), index);
     ecs_assert(!ecs_field_is_readonly(iter_, index),
@@ -32954,14 +33430,16 @@ inline flecs::entity world::make_alive(flecs::entity_t e) const {
 
 template <typename E>
 inline flecs::entity enum_data<E>::entity() const {
-    return flecs::entity(world_, impl_.id);
+    return flecs::entity(world_, _::type<E>::id(world_));
 }
 
 template <typename E>
 inline flecs::entity enum_data<E>::entity(underlying_type_t<E> value) const {
     int index = index_by_value(value);
     if (index >= 0) {
-        return flecs::entity(world_, impl_.constants[index].id);
+        int32_t constant_i = impl_.constants[index].index;
+        flecs::entity_t entity = flecs_component_ids_get(world_, constant_i);
+        return flecs::entity(world_, entity);
     }
 #ifdef FLECS_META
     // Reflection data lookup failed. Try value lookup amongst flecs::Constant relationships

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -5,7 +5,7 @@ const builtin = @import("builtin");
 pub const flecs_version = std.SemanticVersion{
     .major = 4,
     .minor = 0,
-    .patch = 3,
+    .patch = 4,
 };
 
 // TODO: flecs_is_sanitize should come from flecs build flags.
@@ -162,7 +162,6 @@ pub const EcsTableRemoveEdgeFlags = EcsTableHasOnRemove | EcsTableHasSparse | Ec
 
 // Aperiodic action flags (used by ecs_run_aperiodic)
 
-pub const EcsAperiodicEmptyTables = 1 << 1;
 pub const EcsAperiodicComponentMonitors = 1 << 2;
 pub const EcsAperiodicEmptyQueries = 1 << 4;
 
@@ -170,26 +169,62 @@ pub const EcsAperiodicEmptyQueries = 1 << 4;
 extern const EcsQuery: entity_t;
 extern const EcsObserver: entity_t;
 extern const EcsSystem: entity_t;
+extern const EcsFlecs: entity_t;
+extern const EcsFlecsCore: entity_t;
+extern const EcsWorld: entity_t;
 extern const EcsWildcard: entity_t;
 extern const EcsAny: entity_t;
+extern const EcsThis: entity_t;
+extern const EcsVariable: entity_t;
 extern const EcsTransitive: entity_t;
 extern const EcsReflexive: entity_t;
 extern const EcsFinal: entity_t;
+extern const EcsOnInstantiate: entity_t;
+extern const EcsOverride: entity_t;
+extern const EcsInherit: entity_t;
 extern const EcsDontInherit: entity_t;
-extern const EcsAlwaysOverride: entity_t;
 extern const EcsSymmetric: entity_t;
 extern const EcsExclusive: entity_t;
 extern const EcsAcyclic: entity_t;
 extern const EcsTraversable: entity_t;
 extern const EcsWith: entity_t;
 extern const EcsOneOf: entity_t;
+extern const EcsCanToggle: entity_t;
+extern const EcsTrait: entity_t;
+extern const EcsRelationship: entity_t;
+extern const EcsTarget: entity_t;
 extern const EcsPairIsTag: entity_t;
-extern const EcsUnion: entity_t;
+extern const EcsName: entity_t;
+extern const EcsSymbol: entity_t;
 extern const EcsAlias: entity_t;
 extern const EcsChildOf: entity_t;
+extern const EcsIsA: entity_t;
+extern const EcsDependsOn: entity_t;
 extern const EcsSlotOf: entity_t;
+extern const EcsModule: entity_t;
+extern const EcsPrivate: entity_t;
 extern const EcsPrefab: entity_t;
 extern const EcsDisabled: entity_t;
+extern const EcsNotQueryable: entity_t;
+extern const EcsOnAdd: entity_t;
+extern const EcsOnRemove: entity_t;
+extern const EcsOnSet: entity_t;
+extern const EcsMonitor: entity_t;
+extern const EcsOnTableCreate: entity_t;
+extern const EcsOnTableDelete: entity_t;
+extern const EcsOnDelete: entity_t;
+extern const EcsOnDeleteTarget: entity_t;
+extern const EcsRemove: entity_t;
+extern const EcsDelete: entity_t;
+extern const EcsPanic: entity_t;
+extern const EcsSparse: entity_t;
+extern const EcsUnion: entity_t;
+extern const EcsPredEq: entity_t;
+extern const EcsPredMatch: entity_t;
+extern const EcsPredLookup: entity_t;
+extern const EcsScopeOpen: entity_t;
+extern const EcsScopeClose: entity_t;
+extern const EcsEmpty: entity_t;
 
 extern const EcsOnStart: entity_t;
 extern const EcsPreFrame: entity_t;
@@ -204,61 +239,69 @@ extern const EcsOnStore: entity_t;
 extern const EcsPostFrame: entity_t;
 extern const EcsPhase: entity_t;
 
-extern const EcsOnAdd: entity_t;
-extern const EcsOnRemove: entity_t;
-extern const EcsOnSet: entity_t;
-extern const EcsMonitor: entity_t;
-extern const EcsOnTableCreate: entity_t;
-extern const EcsOnTableDelete: entity_t;
-extern const EcsOnTableEmpty: entity_t;
-extern const EcsOnTableFill: entity_t;
-
-extern const EcsOnDelete: entity_t;
-extern const EcsOnDeleteTarget: entity_t;
-extern const EcsRemove: entity_t;
-extern const EcsDelete: entity_t;
-extern const EcsPanic: entity_t;
-
-extern const EcsFlatten: entity_t;
-
 pub const EcsDefaultChildComponent = extern struct {
     component: id_t,
 };
 
-extern const EcsPredEq: entity_t;
-extern const EcsPredMatch: entity_t;
-extern const EcsPredLookup: entity_t;
-
-extern const EcsIsA: entity_t;
-extern const EcsDependsOn: entity_t;
-
 pub var Query: entity_t = undefined;
 pub var Observer: entity_t = undefined;
 pub var System: entity_t = undefined;
+pub var Flecs: entity_t = undefined;
+pub var FlecsCore: entity_t = undefined;
+pub var World: entity_t = undefined;
 pub var Wildcard: entity_t = undefined;
 pub var Any: entity_t = undefined;
+pub var This: entity_t = undefined;
+pub var Variable: entity_t = undefined;
 pub var Transitive: entity_t = undefined;
 pub var Reflexive: entity_t = undefined;
 pub var Final: entity_t = undefined;
+pub var OnInstantiate: entity_t = undefined;
+pub var Override: entity_t = undefined;
+pub var Inherit: entity_t = undefined;
 pub var DontInherit: entity_t = undefined;
-pub var PairIsTag: entity_t = undefined;
-pub var Union: entity_t = undefined;
+pub var Symmetric: entity_t = undefined;
 pub var Exclusive: entity_t = undefined;
 pub var Acyclic: entity_t = undefined;
 pub var Traversable: entity_t = undefined;
-pub var Symmetric: entity_t = undefined;
 pub var With: entity_t = undefined;
 pub var OneOf: entity_t = undefined;
-
-pub var IsA: entity_t = undefined;
+pub var CanToggle: entity_t = undefined;
+pub var Trait: entity_t = undefined;
+pub var Relationship: entity_t = undefined;
+pub var Target: entity_t = undefined;
+pub var PairIsTag: entity_t = undefined;
+pub var Name: entity_t = undefined;
+pub var Symbol: entity_t = undefined;
+pub var Alias: entity_t = undefined;
 pub var ChildOf: entity_t = undefined;
+pub var IsA: entity_t = undefined;
 pub var DependsOn: entity_t = undefined;
 pub var SlotOf: entity_t = undefined;
-
-pub var AlwaysOverride: entity_t = undefined;
-pub var Alias: entity_t = undefined;
+pub var Module: entity_t = undefined;
+pub var Private: entity_t = undefined;
 pub var Prefab: entity_t = undefined;
 pub var Disabled: entity_t = undefined;
+pub var NotQueryable: entity_t = undefined;
+pub var OnAdd: entity_t = undefined;
+pub var OnRemove: entity_t = undefined;
+pub var OnSet: entity_t = undefined;
+pub var Monitor: entity_t = undefined;
+pub var OnTableCreate: entity_t = undefined;
+pub var OnTableDelete: entity_t = undefined;
+pub var OnDelete: entity_t = undefined;
+pub var OnDeleteTarget: entity_t = undefined;
+pub var Remove: entity_t = undefined;
+pub var Delete: entity_t = undefined;
+pub var Panic: entity_t = undefined;
+pub var Sparse: entity_t = undefined;
+pub var Union: entity_t = undefined;
+pub var PredEq: entity_t = undefined;
+pub var PredMatch: entity_t = undefined;
+pub var PredLookup: entity_t = undefined;
+pub var ScopeOpen: entity_t = undefined;
+pub var ScopeClose: entity_t = undefined;
+pub var Empty: entity_t = undefined;
 
 pub var OnStart: entity_t = undefined;
 pub var PreFrame: entity_t = undefined;
@@ -273,27 +316,68 @@ pub var OnStore: entity_t = undefined;
 pub var PostFrame: entity_t = undefined;
 pub var Phase: entity_t = undefined;
 
-pub var OnAdd: entity_t = undefined;
-pub var OnRemove: entity_t = undefined;
-pub var OnSet: entity_t = undefined;
-pub var UnSet: entity_t = undefined;
-pub var Monitor: entity_t = undefined;
-pub var OnTableCreate: entity_t = undefined;
-pub var OnTableDelete: entity_t = undefined;
-pub var OnTableEmpty: entity_t = undefined;
-pub var OnTableFill: entity_t = undefined;
+// pub var Query: entity_t = undefined;
+// pub var Observer: entity_t = undefined;
+// pub var System: entity_t = undefined;
+// pub var Wildcard: entity_t = undefined;
+// pub var Any: entity_t = undefined;
+// pub var Transitive: entity_t = undefined;
+// pub var Reflexive: entity_t = undefined;
+// pub var Final: entity_t = undefined;
+// pub var DontInherit: entity_t = undefined;
+// pub var PairIsTag: entity_t = undefined;
+// pub var Union: entity_t = undefined;
+// pub var Exclusive: entity_t = undefined;
+// pub var Acyclic: entity_t = undefined;
+// pub var Traversable: entity_t = undefined;
+// pub var Symmetric: entity_t = undefined;
+// pub var With: entity_t = undefined;
+// pub var OneOf: entity_t = undefined;
 
-pub var OnDelete: entity_t = undefined;
-pub var OnDeleteTarget: entity_t = undefined;
-pub var Remove: entity_t = undefined;
-pub var Delete: entity_t = undefined;
-pub var Panic: entity_t = undefined;
+// pub var IsA: entity_t = undefined;
+// pub var ChildOf: entity_t = undefined;
+// pub var DependsOn: entity_t = undefined;
+// pub var SlotOf: entity_t = undefined;
 
-pub var DefaultChildComponent: EcsDefaultChildComponent = undefined;
+// pub var AlwaysOverride: entity_t = undefined;
+// pub var Alias: entity_t = undefined;
+// pub var Prefab: entity_t = undefined;
+// pub var Disabled: entity_t = undefined;
 
-pub var PredEq: entity_t = undefined;
-pub var PredMatch: entity_t = undefined;
-pub var PredLookup: entity_t = undefined;
+// pub var OnStart: entity_t = undefined;
+// pub var PreFrame: entity_t = undefined;
+// pub var OnLoad: entity_t = undefined;
+// pub var PostLoad: entity_t = undefined;
+// pub var PreUpdate: entity_t = undefined;
+// pub var OnUpdate: entity_t = undefined;
+// pub var OnValidate: entity_t = undefined;
+// pub var PostUpdate: entity_t = undefined;
+// pub var PreStore: entity_t = undefined;
+// pub var OnStore: entity_t = undefined;
+// pub var PostFrame: entity_t = undefined;
+// pub var Phase: entity_t = undefined;
+
+// pub var OnAdd: entity_t = undefined;
+// pub var OnRemove: entity_t = undefined;
+// pub var OnSet: entity_t = undefined;
+// pub var UnSet: entity_t = undefined;
+// pub var Monitor: entity_t = undefined;
+// pub var OnTableCreate: entity_t = undefined;
+// pub var OnTableDelete: entity_t = undefined;
+// pub var OnTableEmpty: entity_t = undefined;
+// pub var OnTableFill: entity_t = undefined;
+
+// pub var OnDelete: entity_t = undefined;
+// pub var OnDeleteTarget: entity_t = undefined;
+// pub var Remove: entity_t = undefined;
+// pub var Delete: entity_t = undefined;
+// pub var Panic: entity_t = undefined;
+
+// pub var DefaultChildComponent: EcsDefaultChildComponent = undefined;
+
+// pub var PredEq: entity_t = undefined;
+// pub var PredMatch: entity_t = undefined;
+// pub var PredLookup: entity_t = undefined;
 
 //--------------------------------------------------------------------------------------------------
 //
@@ -340,7 +424,6 @@ pub const table_cache_hdr_t = extern struct {
     cache: *table_cache_t,
     table: *table_t,
     prev: *table_cache_hdr_t,
-    empty: bool,
 };
 
 pub const table_record_t = extern struct {
@@ -614,15 +697,40 @@ pub const observer_t = extern struct {
     entity: entity_t = 0,
 };
 //--------------------------------------------------------------------------------------------------
+
+pub const ECS_TYPE_HOOK_CTOR = (1 << 0);
+pub const ECS_TYPE_HOOK_DTOR = (1 << 1);
+pub const ECS_TYPE_HOOK_COPY = (1 << 2);
+pub const ECS_TYPE_HOOK_MOVE = (1 << 3);
+pub const ECS_TYPE_HOOK_COPY_CTOR = (1 << 4);
+pub const ECS_TYPE_HOOK_MOVE_CTOR = (1 << 5);
+pub const ECS_TYPE_HOOK_CTOR_MOVE_DTOR = (1 << 6);
+pub const ECS_TYPE_HOOK_MOVE_DTOR = (1 << 7);
+
+pub const ECS_TYPE_HOOK_CTOR_ILLEGAL = (1 << 8);
+pub const ECS_TYPE_HOOK_DTOR_ILLEGAL = (1 << 9);
+pub const ECS_TYPE_HOOK_COPY_ILLEGAL = (1 << 10);
+pub const ECS_TYPE_HOOK_MOVE_ILLEGAL = (1 << 11);
+pub const ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL = (1 << 12);
+pub const ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL = (1 << 13);
+pub const ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL = (1 << 14);
+pub const ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL = (1 << 15);
+
+pub const ECS_TYPE_HOOKS = (ECS_TYPE_HOOK_CTOR | ECS_TYPE_HOOK_DTOR | ECS_TYPE_HOOK_COPY | ECS_TYPE_HOOK_MOVE | ECS_TYPE_HOOK_COPY_CTOR | ECS_TYPE_HOOK_MOVE_CTOR | ECS_TYPE_HOOK_CTOR_MOVE_DTOR | ECS_TYPE_HOOK_MOVE_DTOR);
+pub const ECS_TYPE_HOOKS_ILLEGAL = (ECS_TYPE_HOOK_CTOR_ILLEGAL | ECS_TYPE_HOOK_DTOR_ILLEGAL | ECS_TYPE_HOOK_COPY_ILLEGAL | ECS_TYPE_HOOK_MOVE_ILLEGAL | ECS_TYPE_HOOK_COPY_CTOR_ILLEGAL | ECS_TYPE_HOOK_MOVE_CTOR_ILLEGAL | ECS_TYPE_HOOK_CTOR_MOVE_DTOR_ILLEGAL | ECS_TYPE_HOOK_MOVE_DTOR_ILLEGAL);
+
 pub const type_hooks_t = extern struct {
     ctor: ?xtor_t = null,
     dtor: ?xtor_t = null,
     copy: ?copy_t = null,
     move: ?move_t = null,
+
     copy_ctor: ?copy_t = null,
     move_ctor: ?move_t = null,
     ctor_move_dtor: ?move_t = null,
     move_dtor: ?move_t = null,
+
+    flags: flags32_t = 0,
     on_add: ?iter_action_t = null,
     on_set: ?iter_action_t = null,
     on_remove: ?iter_action_t = null,
@@ -660,6 +768,7 @@ pub const observable_t = extern struct {
     on_set: event_record_t,
     on_wildcard: event_record_t,
     events: sparse_t,
+    last_observer_id: u64,
 };
 
 pub const table_range_t = extern struct {
@@ -681,8 +790,8 @@ pub const ref_t = extern struct {
     record: *record_t,
 };
 
-pub const stack_page_t = opaque {};
-pub const stack_t = opaque {};
+pub const stack_page_t = opaque {}; // TODO: Complete binding
+pub const stack_t = opaque {}; // TODO: Complete binding
 
 pub const stack_cursor_t = extern struct {
     prev: ?*stack_cursor_t,
@@ -706,7 +815,8 @@ pub const worker_iter_t = extern struct {
 pub const table_cache_iter_t = extern struct {
     cur: ?*table_cache_hdr_t,
     next: ?*table_cache_hdr_t,
-    next_list: ?*table_cache_hdr_t,
+    iter_fill: bool,
+    iter_empty: bool,
 };
 
 pub const each_iter_t = extern struct {
@@ -771,6 +881,7 @@ pub const vec_t = extern struct {
     count: i32,
     size: i32,
     elem_size: if (flecs_is_sanitize) size_t else void,
+    type_name: if (flecs_is_sanitize) [:*0]const u8 else void,
 };
 
 pub const sparse_t = extern struct {
@@ -800,7 +911,8 @@ pub const block_allocator_t = extern struct {
     data_size: i32,
     chunks_per_block: i32,
     block_size: i32,
-    alloc_count: i32,
+    alloc_count: if (flecs_is_sanitize) i32 else void,
+    outstanding: if (flecs_is_sanitize) *map_t else void,
 };
 
 pub const allocator_t = extern struct {
@@ -1080,7 +1192,6 @@ pub const world_info_t = extern struct {
     pair_id_count: i32,
 
     table_count: i32,
-    empty_table_count: i32,
 
     cmd: extern struct {
         add_count: i64,
@@ -1224,41 +1335,62 @@ pub fn init() *world_t {
     Query = EcsQuery;
     Observer = EcsObserver;
     System = EcsSystem;
+    Flecs = EcsFlecs;
+    FlecsCore = EcsFlecsCore;
+    World = EcsWorld;
     Wildcard = EcsWildcard;
     Any = EcsAny;
+    This = EcsThis;
+    Variable = EcsVariable;
     Transitive = EcsTransitive;
     Reflexive = EcsReflexive;
     Final = EcsFinal;
+    OnInstantiate = EcsOnInstantiate;
+    Override = EcsOverride;
+    Inherit = EcsInherit;
     DontInherit = EcsDontInherit;
+    Symmetric = EcsSymmetric;
     Exclusive = EcsExclusive;
     Acyclic = EcsAcyclic;
     Traversable = EcsTraversable;
-    Symmetric = EcsSymmetric;
     With = EcsWith;
     OneOf = EcsOneOf;
-
-    IsA = EcsIsA;
+    CanToggle = EcsCanToggle;
+    Trait = EcsTrait;
+    Relationship = EcsRelationship;
+    Target = EcsTarget;
+    PairIsTag = EcsPairIsTag;
+    Name = EcsName;
+    Symbol = EcsSymbol;
+    Alias = EcsAlias;
     ChildOf = EcsChildOf;
+    IsA = EcsIsA;
     DependsOn = EcsDependsOn;
     SlotOf = EcsSlotOf;
-
+    Module = EcsModule;
+    Private = EcsPrivate;
+    Prefab = EcsPrefab;
+    Disabled = EcsDisabled;
+    NotQueryable = EcsNotQueryable;
+    OnAdd = EcsOnAdd;
+    OnRemove = EcsOnRemove;
+    OnSet = EcsOnSet;
+    Monitor = EcsMonitor;
+    OnTableCreate = EcsOnTableCreate;
+    OnTableDelete = EcsOnTableDelete;
     OnDelete = EcsOnDelete;
     OnDeleteTarget = EcsOnDeleteTarget;
     Remove = EcsRemove;
     Delete = EcsDelete;
     Panic = EcsPanic;
-
-    // TODO DefaultChildComponent = EcsDefaultChildComponent;
-
+    Sparse = EcsSparse;
+    Union = EcsUnion;
     PredEq = EcsPredEq;
     PredMatch = EcsPredMatch;
     PredLookup = EcsPredLookup;
-
-    PairIsTag = EcsPairIsTag;
-    Union = EcsUnion;
-    Alias = EcsAlias;
-    Prefab = EcsPrefab;
-    Disabled = EcsDisabled;
+    ScopeOpen = EcsScopeOpen;
+    ScopeClose = EcsScopeClose;
+    Empty = EcsEmpty;
     OnStart = EcsOnStart;
     PreFrame = EcsPreFrame;
     OnLoad = EcsOnLoad;
@@ -1271,14 +1403,8 @@ pub fn init() *world_t {
     OnStore = EcsOnStore;
     PostFrame = EcsPostFrame;
     Phase = EcsPhase;
-    OnAdd = EcsOnAdd;
-    OnRemove = EcsOnRemove;
-    OnSet = EcsOnSet;
-    Monitor = EcsMonitor;
-    OnTableCreate = EcsOnTableCreate;
-    OnTableDelete = EcsOnTableDelete;
-    OnTableEmpty = EcsOnTableEmpty;
-    OnTableFill = EcsOnTableFill;
+
+    // TODO DefaultChildComponent = EcsDefaultChildComponent;
 
     return world;
 }
@@ -1463,25 +1589,17 @@ extern fn ecs_get_max_id(world: *const world_t) entity_t;
 pub const run_aperiodic = ecs_run_aperiodic;
 extern fn ecs_run_aperiodic(world: *world_t, flags: flags32_t) void;
 
-/// ```
-/// pub fn delete_empty_tables(
-///     world: *world_t,
-///     id: id_t,
-///     clear_generation: u16,
-///     delete_generation: u16,
-///     min_id_count: i32,
-///     time_budget_seconds: f64,
-/// ) i32;
-/// ```
-pub const delete_empty_tables = ecs_delete_empty_tables;
-extern fn ecs_delete_empty_tables(
-    world: *world_t,
+pub const delete_empty_tables_desc_t = struct {
     id: id_t,
     clear_generation: u16,
     delete_generation: u16,
     min_id_count: i32,
     time_budget_seconds: f64,
-) i32;
+};
+
+/// `pub fn delete_empty_tables(world: *world_t, desc: *delete_empty_tables_desc_t) i32`
+pub const delete_empty_tables = ecs_delete_empty_tables;
+extern fn ecs_delete_empty_tables(world: *world_t, desc: *delete_empty_tables_desc_t) i32;
 
 /// `pub fn make_pair(first: entity_t, second: entity_t) id_t`
 pub const make_pair = ecs_make_pair;
@@ -2051,6 +2169,10 @@ extern fn ecs_query_populate(iter: *iter_t, when_changed: bool) c_int;
 /// `pub fn query_changed(query: *query_t) bool`
 pub const query_changed = ecs_query_changed;
 extern fn ecs_query_changed(query: *query_t) bool;
+
+/// `pub fn query_get(world: *world_t, query: entity_t) *const query_t;`
+pub const query_get = ecs_query_get;
+extern fn ecs_query_get(world: *world_t, query: entity_t) *const query_t;
 
 /// `pub fn iter_skip(iter: *iter_t) void`
 pub const iter_skip = ecs_iter_skip;

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -316,68 +316,7 @@ pub var OnStore: entity_t = undefined;
 pub var PostFrame: entity_t = undefined;
 pub var Phase: entity_t = undefined;
 
-// pub var Query: entity_t = undefined;
-// pub var Observer: entity_t = undefined;
-// pub var System: entity_t = undefined;
-// pub var Wildcard: entity_t = undefined;
-// pub var Any: entity_t = undefined;
-// pub var Transitive: entity_t = undefined;
-// pub var Reflexive: entity_t = undefined;
-// pub var Final: entity_t = undefined;
-// pub var DontInherit: entity_t = undefined;
-// pub var PairIsTag: entity_t = undefined;
-// pub var Union: entity_t = undefined;
-// pub var Exclusive: entity_t = undefined;
-// pub var Acyclic: entity_t = undefined;
-// pub var Traversable: entity_t = undefined;
-// pub var Symmetric: entity_t = undefined;
-// pub var With: entity_t = undefined;
-// pub var OneOf: entity_t = undefined;
-
-// pub var IsA: entity_t = undefined;
-// pub var ChildOf: entity_t = undefined;
-// pub var DependsOn: entity_t = undefined;
-// pub var SlotOf: entity_t = undefined;
-
-// pub var AlwaysOverride: entity_t = undefined;
-// pub var Alias: entity_t = undefined;
-// pub var Prefab: entity_t = undefined;
-// pub var Disabled: entity_t = undefined;
-
-// pub var OnStart: entity_t = undefined;
-// pub var PreFrame: entity_t = undefined;
-// pub var OnLoad: entity_t = undefined;
-// pub var PostLoad: entity_t = undefined;
-// pub var PreUpdate: entity_t = undefined;
-// pub var OnUpdate: entity_t = undefined;
-// pub var OnValidate: entity_t = undefined;
-// pub var PostUpdate: entity_t = undefined;
-// pub var PreStore: entity_t = undefined;
-// pub var OnStore: entity_t = undefined;
-// pub var PostFrame: entity_t = undefined;
-// pub var Phase: entity_t = undefined;
-
-// pub var OnAdd: entity_t = undefined;
-// pub var OnRemove: entity_t = undefined;
-// pub var OnSet: entity_t = undefined;
-// pub var UnSet: entity_t = undefined;
-// pub var Monitor: entity_t = undefined;
-// pub var OnTableCreate: entity_t = undefined;
-// pub var OnTableDelete: entity_t = undefined;
-// pub var OnTableEmpty: entity_t = undefined;
-// pub var OnTableFill: entity_t = undefined;
-
-// pub var OnDelete: entity_t = undefined;
-// pub var OnDeleteTarget: entity_t = undefined;
-// pub var Remove: entity_t = undefined;
-// pub var Delete: entity_t = undefined;
-// pub var Panic: entity_t = undefined;
-
 // pub var DefaultChildComponent: EcsDefaultChildComponent = undefined;
-
-// pub var PredEq: entity_t = undefined;
-// pub var PredMatch: entity_t = undefined;
-// pub var PredLookup: entity_t = undefined;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -972,7 +972,7 @@ pub const query_desc_t = extern struct {
     terms: [FLECS_TERM_COUNT_MAX]term_t = [_]term_t{.{}} ** FLECS_TERM_COUNT_MAX,
     expr: ?[*:0]const u8 = null,
 
-    cache_kind: query_cache_kind_t = .QueryCacheNone,
+    cache_kind: query_cache_kind_t = .QueryCacheDefault,
 
     flags: flags32_t = 0,
 


### PR DESCRIPTION
Updated from 4.0.1.
One commit per version bump. 
Completed the bindings a bit and fixed some buggy docstrings etc.
Reordered some stuff to be more in line with the header.

IMPORTANT: The wrong default was used for query caches, so even system queries were not cached. Oops!

Tests run and Tides of Revival now uses these bindings :) 