### PR TITLE
Fixed binding of ecs_each and usage in test.

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -74,10 +74,10 @@ test "zflecs.entities.basics" {
     const ptr = ecs.get(world, bob, Position).?;
     print("({d}, {d})\n", .{ ptr.x, ptr.y });
 
-    _ = ecs.set(world, bob, Position, .{ .x = 20, .y = 30 });
+    _ = ecs.set(world, bob, Position, .{ .x = 10, .y = 30 });
 
     const alice = ecs.set_name(world, 0, "Alice");
-    _ = ecs.set(world, alice, Position, .{ .x = 10, .y = 20 });
+    _ = ecs.set(world, alice, Position, .{ .x = 10, .y = 50 });
     ecs.add(world, alice, Walking);
 
     const str = ecs.type_str(world, ecs.get_type(world, alice)).?;
@@ -87,11 +87,11 @@ test "zflecs.entities.basics" {
     ecs.remove(world, alice, Walking);
 
     {
-        var term = ecs.term_t{ .id = ecs.id(Position) };
-        var it = ecs.each(world, &term);
+        var it = ecs.each(world, Position);
         while (ecs.each_next(&it)) {
             if (ecs.field(&it, Position, 0)) |positions| {
                 for (positions, it.entities()) |p, e| {
+                    try std.testing.expectEqual(p.x, 10);
                     print(
                         "Term loop: {s}: ({d}, {d})\n",
                         .{ ecs.get_name(world, e).?, p.x, p.y },

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -2087,9 +2087,14 @@ extern fn ecs_id_from_str(world: *const world_t, expr: [*:0]const u8) id_t;
 // Functions for working with `term_t` and `query_t`.
 //
 //--------------------------------------------------------------------------------------------------
-/// `pub fn term_iter(world: *const world_t, term: *term_t) iter_t`
-pub const each = ecs_each_id;
-extern fn ecs_each_id(world: *const world_t, term: *term_t) iter_t;
+
+pub fn each(world: *const world_t, comptime T: type) iter_t {
+    return each_id(world, id(T));
+}
+
+/// `pub fn ecs_each_id(world: *const world_t, id: id_t) iter_t`
+pub const each_id = ecs_each_id;
+extern fn ecs_each_id(world: *const world_t, id: id_t) iter_t;
 
 /// `pub fn term_chain_iter(world: *const world_t, term: *term_t) iter_t`
 pub const term_chain_iter = ecs_term_chain_iter;


### PR DESCRIPTION
Tested in Tides and with the unit test.