### PR TITLE
Support for zig 0.16.0-dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        zig: [0.15.2, master]
+        zig: [0.15.1, master]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        zig: [0.15.2, master]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Zig
         uses: mlugg/setup-zig@v2
+        with:
+          version: ${{matrix.zig}}
       - name: Check format
         continue-on-error: true
         run: zig fmt --check .

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zflecs,
     .fingerprint = 0xb539547bca77f3d4,
     .version = "0.2.0-dev",
-    .minimum_zig_version = "0.16.0-dev.2623+27eec9bd6",
+    .minimum_zig_version = "0.15.1",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zflecs,
     .fingerprint = 0xb539547bca77f3d4,
     .version = "0.2.0-dev",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0-dev.2623+27eec9bd6",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -13,7 +13,7 @@ const Walking = struct {};
 const Direction = enum { north, south, east, west };
 
 test {
-    std.testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDecls(@This());
 }
 
 test "extern struct ABI compatibility" {

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1319,9 +1319,14 @@ const EcsAllocator = struct {
 };
 
 fn flecs_abort() callconv(.c) noreturn {
-    std.debug.dumpCurrentStackTrace(@returnAddress());
+    std.debug.dumpCurrentStackTrace(.{
+        .first_address = @returnAddress(),
+        // TODO: Not sure about that
+        // .allow_unsafe_unwind = false,
+        // .context = null,
+    });
     @breakpoint();
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1319,12 +1319,16 @@ const EcsAllocator = struct {
 };
 
 fn flecs_abort() callconv(.c) noreturn {
-    std.debug.dumpCurrentStackTrace(.{
-        .first_address = @returnAddress(),
-        // TODO: Not sure about that
-        // .allow_unsafe_unwind = false,
-        // .context = null,
-    });
+    if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15) {
+        std.debug.dumpCurrentStackTrace(@returnAddress());
+    } else {
+        std.debug.dumpCurrentStackTrace(.{
+            .first_address = @returnAddress(),
+            // TODO: Not sure about that
+            // .allow_unsafe_unwind = false,
+            // .context = null,
+        });
+    }
     @breakpoint();
     std.process.exit(1);
 }


### PR DESCRIPTION
Hello guys,
I made some changes in order to support zig 0.16.0-dev in my demo project and wanted to contribute that back to you.

I guess most changes are straight forward. Replaced removed function calls with their newer alternative.

The point I'm not sure about is the `flecs_abort` function.
```zig
 if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15) {
    std.debug.dumpCurrentStackTrace(@returnAddress());
} else {
    std.debug.dumpCurrentStackTrace(.{
        .first_address = @returnAddress(),
        // TODO: Not sure about that
        // .allow_unsafe_unwind = false,
        // .context = null,
    });
}
``` 
I assumed a version check is adequate because it's a callback, not in any hot path.
Regarding `allow_unsafe_unwind` and `context`:
I left them as default values since I couldn't find a reason not to do so. 
But honestly, especially for `allow_unsafe_unwind` I don't know what implications `true` would exactly have.

```zig
/// If not `null`, we will unwind from this `cpu_context.Native` instead of the current top of
/// the stack. The main use case here is printing stack traces from signal handlers, where the
/// kernel provides a `*const cpu_context.Native` of the state before the signal.
context: ?CpuContextPtr = null,
/// If `true`, stack unwinding strategies which may cause crashes are used as a last resort.
/// If `false`, only known-safe mechanisms will be attempted.
allow_unsafe_unwind: bool = false,
``` 

In order to check backwards compatibility I added zig version 0.15.1 and master to matrix strategy in the github action.

I'm new to the zig community and this is my first PR in any open source project. Please forgive me in case I missed something.
Greetings ☕ Sören