### PR TITLE
Update to work with newer zig"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        zig: [0.15.2, master]
+        zig: [0.15.1, master]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        zig: [0.15.2, master]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Zig
         uses: mlugg/setup-zig@v2
+        with:
+          version: ${{matrix.zig}}
       - name: Check format
         continue-on-error: true
         run: zig fmt --check .

--- a/build.zig
+++ b/build.zig
@@ -666,11 +666,23 @@ pub fn build(b: *std.Build) void {
     }
     const test_step = b.step("test", "Run zflecs tests");
 
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("libs/flecs/flecs.h"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    translate_c.defineCMacro("FLECS_SANITIZE", if (builtin.mode == .Debug) "1" else {});
+    translate_c.defineCMacro("FLECS_USE_OS_ALLOC", "1");
+    translate_c.defineCMacro("FLECS_NO_CPP", "1");
     const tests_module = b.createModule(.{
         .root_source_file = b.path("src/tests.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .imports = &.{
+            .{ .name = "flecs_c", .module = translate_c.createModule() },
+        },
     });
     tests_module.addOptions("build-options", options);
     tests_module.addIncludePath(b.path("libs/flecs"));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zflecs,
     .fingerprint = 0xb539547bca77f3d4,
     .version = "0.2.0-dev",
-    .minimum_zig_version = "0.16.0-dev.2623+27eec9bd6",
+    .minimum_zig_version = "0.15.1",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zflecs,
     .fingerprint = 0xb539547bca77f3d4,
     .version = "0.2.0-dev",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0-dev.2623+27eec9bd6",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -13,7 +13,7 @@ const Walking = struct {};
 const Direction = enum { north, south, east, west };
 
 test {
-    std.testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDecls(@This());
 }
 
 test "extern struct ABI compatibility" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -18,12 +18,7 @@ test {
 
 test "extern struct ABI compatibility" {
     @setEvalBranchQuota(50_000);
-    const flecs_c = @cImport({
-        @cDefine("FLECS_SANITIZE", if (builtin.mode == .Debug) "1" else {});
-        @cDefine("FLECS_USE_OS_ALLOC", "1");
-        @cDefine("FLECS_NO_CPP", "1");
-        @cInclude("flecs.h");
-    });
+    const flecs_c = @import("flecs_c");
     inline for (comptime std.meta.declarations(@This())) |decl| {
         const ZigType = @field(@This(), decl.name);
         if (@TypeOf(ZigType) != type) {
@@ -473,11 +468,12 @@ test "zflecs.pairs.delete-children" {
 }
 
 test "zflecs.struct-dtor-hook" {
+    const a = std.testing.allocator;
     const world = ecs.init();
     defer _ = ecs.fini(world);
 
     const Chat = struct {
-        messages: std.ArrayList([]const u8) = .{},
+        messages: std.ArrayList([]const u8),
         pub fn dtor(self: *@This()) void {
             self.messages.deinit(std.testing.allocator);
         }
@@ -498,8 +494,9 @@ test "zflecs.struct-dtor-hook" {
         _ = ecs.SYSTEM(world, "Chat system", ecs.OnUpdate, &system_desc);
     }
 
+    const chat = Chat{ .messages = try .initCapacity(a, 200) };
     const chat_entity = ecs.new_entity(world, "Chat entity");
-    _ = ecs.set(world, chat_entity, Chat, Chat{});
+    _ = ecs.set(world, chat_entity, Chat, chat);
 
     _ = ecs.progress(world, 0);
 

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1319,9 +1319,14 @@ const EcsAllocator = struct {
 };
 
 fn flecs_abort() callconv(.c) noreturn {
-    std.debug.dumpCurrentStackTrace(@returnAddress());
+    std.debug.dumpCurrentStackTrace(.{
+        .first_address = @returnAddress(),
+        // TODO: Not sure about that
+        // .allow_unsafe_unwind = false,
+        // .context = null,
+    });
     @breakpoint();
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1319,12 +1319,16 @@ const EcsAllocator = struct {
 };
 
 fn flecs_abort() callconv(.c) noreturn {
-    std.debug.dumpCurrentStackTrace(.{
-        .first_address = @returnAddress(),
-        // TODO: Not sure about that
-        // .allow_unsafe_unwind = false,
-        // .context = null,
-    });
+    if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15) {
+        std.debug.dumpCurrentStackTrace(@returnAddress());
+    } else {
+        std.debug.dumpCurrentStackTrace(.{
+            .first_address = @returnAddress(),
+            // TODO: Not sure about that
+            // .allow_unsafe_unwind = false,
+            // .context = null,
+        });
+    }
     @breakpoint();
     std.process.exit(1);
 }

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -31,7 +31,7 @@ pub const flags32_t = u32;
 pub const flags64_t = u64;
 
 pub fn flagsn_t(comptime bits: u16) type {
-    return std.meta.Int(.unsigned, bits);
+    return @Int(.unsigned, bits);
 }
 pub const termset_t = flagsn_t(FLECS_TERM_COUNT_MAX);
 
@@ -686,7 +686,7 @@ pub const query_t = extern struct {
 };
 
 pub fn array(comptime T: type, comptime len: comptime_int) [len]T {
-    return [_]T{.{}} ** len;
+    return @splat(.{});
 }
 
 pub const observer_t = extern struct {
@@ -1105,7 +1105,7 @@ pub const iter_t = extern struct {
 pub const query_desc_t = extern struct {
     _canary: i32 = 0,
 
-    terms: [FLECS_TERM_COUNT_MAX]term_t = [_]term_t{.{}} ** FLECS_TERM_COUNT_MAX,
+    terms: [FLECS_TERM_COUNT_MAX]term_t = @splat(.{}),
     expr: ?[*:0]const u8 = null,
 
     cache_kind: query_cache_kind_t = .QueryCacheDefault,
@@ -1136,7 +1136,7 @@ pub const observer_desc_t = extern struct {
 
     query: query_desc_t = .{},
 
-    events: [FLECS_EVENT_DESC_MAX]entity_t = [_]entity_t{0} ** FLECS_EVENT_DESC_MAX,
+    events: [FLECS_EVENT_DESC_MAX]entity_t = @splat(0),
 
     yield_existing: bool = false,
     callback: ?iter_action_t,
@@ -1242,7 +1242,7 @@ const EcsAllocator = struct {
 
     const Alignment = 16;
 
-    var gpa: ?std.heap.GeneralPurposeAllocator(.{}) = null;
+    var gpa: ?std.heap.DebugAllocator(.{}) = null;
     var allocator: ?std.mem.Allocator = null;
 
     fn alloc(size: i32) callconv(.c) ?*anyopaque {
@@ -3055,7 +3055,7 @@ pub fn new_entity(world: *world_t, name: [*:0]const u8) entity_t {
 pub fn new_prefab(world: *world_t, name: [*:0]const u8) entity_t {
     return entity_init(world, &.{
         .name = name,
-        .add = @ptrCast(&[_]id_t{EcsPrefab} ++ [_]id_t{0} ** (FLECS_ID_DESC_MAX - 1)),
+        .add = @ptrCast(&[_]id_t{EcsPrefab} ++ @as([FLECS_ID_DESC_MAX - 1]id_t, @splat(0))),
     });
 }
 


### PR DESCRIPTION
- **Upgrade to zig 0.16.0-dev**
- **Make 0.16.0 changes backwards compatible**
- **Add zig version to matrix strategy in github action. For now only 0.15.2 and master (0.16.0-dev nightly)**
- **Revert minimum zig version to 0.15.1**
- **Change zig version in matrix to 0.15.1 to follow min version**
- **Update to work with zig 0.17.0-dev.284+cd23f7a81**
