### PR TITLE
Fix Zig 0.16 compatibility by replacing deprecated

### DIFF
--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1249,7 +1249,8 @@ const EcsAllocator = struct {
 
     const Alignment = 16;
 
-    var gpa: ?std.heap.GeneralPurposeAllocator(.{}) = null;
+    //var gpa: ?std.heap.GeneralPurposeAllocator(.{}) = null;
+    var gpa: ?std.heap.DebugAllocator(.{}) = null;
     var allocator: ?std.mem.Allocator = null;
 
     fn alloc(size: i32) callconv(.c) ?*anyopaque {


### PR DESCRIPTION
## Summary

Fix Zig 0.16 compatibility by replacing deprecated `std.heap.GeneralPurposeAllocator` with `std.heap.DebugAllocator`.
url: https://ziglang.org/documentation/0.16.0/#toc-Choosing-an-Allocator

## Changes

Updated allocator declarations in `zflecs.zig`:

```zig
std.heap.GeneralPurposeAllocator(.{})
```

→

```zig
std.heap.DebugAllocator(.{})
```

## Why

`GeneralPurposeAllocator` is no longer available in Zig 0.16 stdlib.

`DebugAllocator` is the supported replacement and provides equivalent allocator behavior for this use case.

No functional ECS behavior was changed.

## Notes

`deinit()` logic was left unchanged since the current implementation compiles and behaves correctly with `DebugAllocator`.
