### PR TITLE
Upgrade zflecs to 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [zflecs](https://github.com/zig-gamedev/zflecs)
 
 Zig build package and bindings for [flecs](https://github.com/SanderMertens/flecs) ECS v4.1.5
+
 Minimum Zig Version: [0.16.0](https://ziglang.org/download/)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [zflecs](https://github.com/zig-gamedev/zflecs)
 
 Zig build package and bindings for [flecs](https://github.com/SanderMertens/flecs) ECS v4.1.5
-Minimum Zig Version: 0.16.0
+Minimum Zig Version: [0.16.0](https://ziglang.org/download/)
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # [zflecs](https://github.com/zig-gamedev/zflecs)
 
 Zig build package and bindings for [flecs](https://github.com/SanderMertens/flecs) ECS v4.1.5
+Minimum Zig Version: 0.16.0
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 
     const zflecs = b.dependency("zflecs", .{});
     exe.root_module.addImport("zflecs", zflecs.module("root"));
-    exe.linkLibrary(zflecs.artifact("flecs"));
+    exe.root_module.linkLibrary(zflecs.artifact("flecs"));
 }
 ```
 
@@ -49,7 +49,8 @@ fn move_system_with_it(it: *ecs.iter_t, positions: []Position, velocities: []con
     }
 }
 
-pub fn main() !void {
+pub fn main(init : std.process.Init.Minimal) !void {
+    _ = init;
     const world = ecs.init();
     defer _ = ecs.fini(world);
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -477,7 +477,7 @@ test "zflecs.struct-dtor-hook" {
     defer _ = ecs.fini(world);
 
     const Chat = struct {
-        messages: std.ArrayList([]const u8) = .{},
+        messages: std.ArrayList([]const u8) = .empty,
         pub fn dtor(self: *@This()) void {
             self.messages.deinit(std.testing.allocator);
         }

--- a/src/zflecs.zig
+++ b/src/zflecs.zig
@@ -1249,7 +1249,7 @@ const EcsAllocator = struct {
 
     const Alignment = 16;
 
-    var gpa: ?std.heap.GeneralPurposeAllocator(.{}) = null;
+    var gpa: ?std.heap.DebugAllocator(.{}) = null;
     var allocator: ?std.mem.Allocator = null;
 
     fn alloc(size: i32) callconv(.c) ?*anyopaque {


### PR DESCRIPTION
Upgraded zflecs to 0.16.0 with small changes
- Replaced empty `std.ArrayList` initialisation using` .{}` with the new `.empty`
- Replaced std.heap.GeneralPurposeAllocator with std.heap.DebugAllocator
No change in ECS behaviour.

QoL Changes:
- Updated example code to be 0.16.0 compliant with "juicy main" `std.process.Init`
- Added a minimum version notice and a link to Zig download